### PR TITLE
Proof-of-Principle Prototype of the QueueServer that Manages and Executes the Queue via REST API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,4 @@ script:
     fi
 
 after_success:
-  - if [ $SUBMIT_CODECOV == 'true' ]; then codecov; fi;
+  # - if [ $SUBMIT_CODECOV == 'true' ]; then codecov; fi;

--- a/README.rst
+++ b/README.rst
@@ -20,36 +20,54 @@ Server for queueing plans
 Features
 --------
 
-A minimal example.
+This is demo version of the server that supports creation and closing of Run Engine execution environment, adding
+and removing items from the queue, checking the queue status and execution of the queue. There is no error
+handling implemented yet, so the server process will probably freeze if an error occurs. In this case the shell
+running the server may need to be closed and a new shell opened.
 
-From a shell::
+The server can be started from a shell as follows::
 
   python -m aiohttp.web -H 0.0.0.0 -P 8080 bluesky_queueserver.server:init_func
 
+The server is controlled from a different shell. Add plans to the queue::
 
-From Python ::
+  http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
 
-  from ophyd.sim import motor, det
-  from bluesky.plans import count, scan
-  from bluesky_queueserver.plan import configure_plan
-  from bluesky import RunEngine
+The names of the plans and devices are strings. The strings are converted to references to plans and
+devices in the worker process. In this demo the server can recognize only 'det1', 'det2', 'motor' devices
+and 'count' and 'scan' plans.
 
+The last item can be removed from the back of the queue::
 
-  devices = {d.name: d for d in [motor, det]}
-  plans = {'count': count, 'scan': scan}
-  url = 'http://0.0.0.0:8080'
+  http POST 0.0.0.0:8080/pop_from_queue
 
-  plan = configure_plan(devices, plans, url)
+The number of entries in the queue may be checked as follows::
 
-  RE = RunEngine()
-  # be _very_ verbose
-  RE.msg_hook = print
-  RE.subscribe(print)
+  http GET 0.0.0.0:8080
 
-  RE(plan())
+The contents of the queue can be retrieved as follows::
 
+  http GET 0.0.0.0:8080/queue_view
 
-From a different shell::
+Before the queue can be executed, the worker environment must be created and initialized. This operation
+creates a new execution environment for Bluesky Run Engine and used to execute plans until it explicitly
+closed::
 
-   http POST 0.0.0.0:8080/add_to_queue plan:='{"plan":"count", "args":[["det"]]}'
-   http POST 0.0.0.0:8080/add_to_queue plan:='{"plan":"scan", "args":[["det"], "motor", -1, 1, 10]}'
+  http POST 0.0.0.0:8080/create_environment
+
+Execution of the plans in the queue is started as follows::
+
+  http POST 0.0.0.0:8080/process_queue
+
+Environment may be closed as follows::
+
+  http POST 0.0.0.0:8080/close_environment
+
+There is minimal user protection: the environment can not be created twice, the queue processing can not be
+started before the the environment is created and the environment can not be closed twice or closed before
+it is created (those mistakes are very easy to make). Also, processing an empty queue is a valid operation that
+does nothing, additional items can be added at any time. If items are added to the running queue and they
+are executed as part of the queue. If execution of the queue is finished before an item is added, then
+execution has to be started again (execution is stopped once an attempt is made to fetch an element
+from an empty queue).

--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,13 @@ Features
 --------
 
 This is demo version of the server that supports creation and closing of Run Engine execution environment, adding
-and removing items from the queue, checking the queue status and execution of the queue. There is no error
-handling implemented yet, so the server process will probably freeze if an error occurs. In this case the shell
-running the server may need to be closed and a new shell opened.
+and removing items from the queue, checking the queue status and execution of the queue, pausing (immediate and
+deferred), resuming, aborting, stopping and halting plans, collection of data to 'temp' database.
+
+The demo has limited data handling implemented. While it is relatively stable while testing the example
+commands, the shell may still freeze (e.g. if Ctrl-C is pressed while the RE environment is not closed).
+In this case the best way is to close the shell and start a new one (simply killing the process will not
+help).
 
 The server can be started from a shell as follows::
 
@@ -94,4 +98,24 @@ Resuming, aborting, stopping or halting of currently executed plan::
 There is minimal user protection features implemented that will prevent execution of
 the commands that are not supported in current state of the server. Error messages are printed
 in the terminal that is running the server along with output of Run Engine.
+
+There is demo of data collection capability. The instance of the QueueServer is keeping a reference
+to an instance of 'temp' Databroker, which is passed to the RE Worker at the time of creation and
+used to collect documents from Run Engine. Data from all plans executed during QueueServer session
+are accumulated in the 'temp' database. The table that contains Run IDs and UIDs of the runs in
+the databased can be printed on the screen by sending the command::
+
+  http POST 0.0.0.0:8080/print_db_uids
+
+The table will be printed in the QueueServer terminal::
+
+    ===================================================================
+                 The contents of 'temp' database.
+    -------------------------------------------------------------------
+    Run ID: 1   UID: bd621328-ffcf-409f-a668-0c303c0d287f
+    Run ID: 2   UID: e85f2f40-44e9-4097-be50-c27f42c4e201
+    Run ID: 3   UID: 1dec536d-3397-43c1-91a3-2af323452bfe
+    -------------------------------------------------------------------
+      Total of 3 runs were found in 'temp' database.
+    ===================================================================
 

--- a/bluesky_queueserver/server.py
+++ b/bluesky_queueserver/server.py
@@ -1,4 +1,15 @@
 from aiohttp import web
+from multiprocessing import Process, Pipe
+import threading
+
+from ophyd.sim import det1, det2
+from bluesky.plans import count
+
+from .worker import RunEngineWorker
+
+re_worker, server_conn, worker_conn = None, None, None
+environment_exists = False
+
 
 
 async def hello(request):
@@ -31,6 +42,70 @@ async def pop_from_queue_handler(request):
         return web.json_response({"plan": "sleep", "args": [10]})
 
 
+def start_re_worker():
+    global re_worker
+    re_worker = RunEngineWorker(conn=worker_conn)
+    re_worker.start()
+
+
+def stop_re_worker():
+    global re_worker
+    msg = {"type": "command", "value": "quit"}
+    server_conn.send(msg)
+    re_worker.join()
+
+
+def run_task():
+    plan_name = "count"
+    args = [["det1", "det2"]]
+    kwargs = {"num": 5, "delay": [1, 2, 3, 4]}
+
+    msg = {"type": "plan",
+           "value": {"name": plan_name,
+                     "args": args,
+                     "kwargs": kwargs
+                    }
+          }
+
+    print(f"Sending emssage 'run_task' ...")
+    server_conn.send(msg)
+
+
+async def start_environment(request):
+    global environment_exists
+    queue = request.app["queue"]
+    if not environment_exists:
+        start_re_worker()
+        environment_exists = True
+        success, msg = True, ""
+    else:
+        success, msg = False, "Environment already exists."
+    return web.json_response({"success": success, "msg": msg})
+
+
+async def close_environment(request):
+    global environment_exists
+    queue = request.app["queue"]
+    if environment_exists:
+        stop_re_worker()
+        environment_exists = False
+        success, msg = True, ""
+    else:
+        success, msg = False, "Environment does not exist."
+    return web.json_response({"success": success, "msg": msg})
+
+
+async def process_queue(request):
+    global environment_exists
+    queue = request.app["queue"]
+    if environment_exists:
+        run_task()
+        success, msg = True, ""
+    else:
+        success, msg = False, "Environment does not exist. Can not start the task."
+    return web.json_response({"success": success, "msg": msg})
+
+
 def setup_routes(app):
     app.add_routes(
         [
@@ -38,11 +113,17 @@ def setup_routes(app):
             web.get("/queue_view", queue_view_handler),
             web.post("/add_to_queue", addto_queue_handler),
             web.post("/pop_from_queue", pop_from_queue_handler),
+            web.post("/start_environment", start_environment),
+            web.post("/close_environment", close_environment),
+            web.post("/process_queue", process_queue),
         ]
     )
 
 
 def init_func(argv):
+    global server_conn, worker_conn
+    server_conn, worker_conn = Pipe()
+
     app = web.Application()
     app["queue"] = []
     setup_routes(app)

--- a/bluesky_queueserver/server.py
+++ b/bluesky_queueserver/server.py
@@ -1,7 +1,6 @@
 from aiohttp import web
 from multiprocessing import Pipe
 import threading
-import time as ttime
 import asyncio
 
 from .worker import RunEngineWorker
@@ -101,8 +100,7 @@ class RunEngineServer:
 
     def _receive_packet_thread(self):
         while True:
-            ttime.sleep(0.1)
-            if self._server_conn.poll():
+            if self._server_conn.poll(0.1):
                 try:
                     msg = self._server_conn.recv()
                     self._loop.call_soon_threadsafe(self._conn_received, msg)

--- a/bluesky_queueserver/server.py
+++ b/bluesky_queueserver/server.py
@@ -3,161 +3,155 @@ from multiprocessing import Process, Pipe
 import threading
 import time as ttime
 
-from ophyd.sim import det1, det2
-from bluesky.plans import count
+#from ophyd.sim import det1, det2
+#from bluesky.plans import count
 
 from .worker import RunEngineWorker
 
 import logging
 logger = logging.getLogger(__name__)
 
-re_worker, server_conn, worker_conn = None, None, None
-environment_exists = False
-
-thread_conn = None
-
-queue_plans = []
+#  Plans that can be used to test the server
+#  http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
+#  http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
 
 
-#   http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
-#   http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+class RunEngineServer:
 
+    def __init__(self):
+        self._re_worker = None
+        self._server_conn = None
+        self._worker_conn = None
 
-async def hello(request):
-    return web.Response(text=f"Hello, world.  There are {len(queue_plans)} plans enqueed")
+        self._environment_exists = False
 
+        self._thread_conn = None
 
-async def queue_view_handler(request):
-    out = {"queue": queue_plans}
-    return web.json_response(out)
+        self._queue_plans = []
 
+        self._start_conn_pipes()
+        self._start_conn_thread()
 
-async def addto_queue_handler(request):
-    data = await request.json()
-    # TODO validate inputs!
-    plan = data["plan"]
-    location = data.get("location", len(queue_plans))
-    queue_plans.insert(location, plan)
-    return web.json_response(data)
+    async def hello(self, request):
+        return web.Response(text=f"Hello, world. "
+                                 f"There are {len(self._queue_plans)} plans enqueed")
 
+    async def queue_view_handler(self, request):
+        out = {"queue": self._queue_plans}
+        return web.json_response(out)
 
-async def pop_from_queue_handler(request):
-    if len(queue_plans):
-        plan = queue_plans.pop()  # Pops from the back of the queue
-        return web.json_response(plan)
-    else:
-        return web.json_response({"plan": "sleep", "args": [10]})
+    async def addto_queue_handler(self, request):
+        data = await request.json()
+        # TODO validate inputs!
+        plan = data["plan"]
+        location = data.get("location", len(self._queue_plans))
+        self._queue_plans.insert(location, plan)
+        return web.json_response(data)
 
+    async def pop_from_queue_handler(self, request):
+        if len(self._queue_plans):
+            plan = self._queue_plans.pop()  # Pops from the back of the queue
+            return web.json_response(plan)
+        else:
+            return web.json_response({"plan": "sleep", "args": [10]})
 
-def start_re_worker():
-    global re_worker
-    re_worker = RunEngineWorker(conn=worker_conn)
-    re_worker.start()
+    def _start_conn_pipes(self):
+        self._server_conn, self._worker_conn = Pipe()
 
+    def _start_conn_thread(self):
+        self._thread_conn = threading.Thread(target=self.receive_packet_thread,
+                                             name="RE Server Comm",
+                                             daemon=True)
+        self._thread_conn.start()
 
-def stop_re_worker():
-    global re_worker
-    msg = {"type": "command", "value": "quit"}
-    server_conn.send(msg)
-    re_worker.join()
+    def start_re_worker(self):
+        self._re_worker = RunEngineWorker(conn=self._worker_conn)
+        self._re_worker.start()
 
+    def stop_re_worker(self):
+        msg = {"type": "command", "value": "quit"}
+        self._server_conn.send(msg)
+        self._re_worker.join()
 
-def run_task():
-    if queue_plans:
-        print(f"Starting new plan: {len(queue_plans)} plans are left in the queue")
-        new_plan = queue_plans.pop(0)
+    def run_task(self):
+        if self._queue_plans:
+            print(f"Starting new plan: {len(self._queue_plans)} plans are left in the queue")
+            new_plan = self._queue_plans.pop(0)
 
-        plan_name = new_plan["name"]
-        args = new_plan["args"] if "args" in new_plan else []
-        kwargs = new_plan["kwargs"] if "kwargs" in new_plan else {}
+            plan_name = new_plan["name"]
+            args = new_plan["args"] if "args" in new_plan else []
+            kwargs = new_plan["kwargs"] if "kwargs" in new_plan else {}
 
-        msg = {"type": "plan",
-               "value": {"name": plan_name,
-                         "args": args,
-                         "kwargs": kwargs
-                        }
-              }
+            msg = {"type": "plan",
+                   "value": {"name": plan_name,
+                             "args": args,
+                             "kwargs": kwargs
+                            }
+                  }
 
-        print(f"Sending message 'run_task' ...")
-        server_conn.send(msg)
-        return True
-    else:
-        print(f"Queue is empty")
-        return False
+            print(f"Sending message 'run_task' ...")
+            self._server_conn.send(msg)
+            return True
+        else:
+            print(f"Queue is empty")
+            return False
 
+    def receive_packet_thread(self):
+        while True:
+            ttime.sleep(0.1)
+            if self._server_conn.poll():
+                try:
+                    msg = self._server_conn.recv()
+                    self.run_task()
+                except Exception as ex:
+                    logger.error(f"Server: Exception occurred while waiting for packet: {ex}")
+                    break
 
-async def start_environment(request):
-    global environment_exists
-    if not environment_exists:
-        start_re_worker()
-        environment_exists = True
-        success, msg = True, ""
-    else:
-        success, msg = False, "Environment already exists."
-    return web.json_response({"success": success, "msg": msg})
+    async def start_environment(self, request):
+        if not self._environment_exists:
+            self.start_re_worker()
+            self._environment_exists = True
+            success, msg = True, ""
+        else:
+            success, msg = False, "Environment already exists."
+        return web.json_response({"success": success, "msg": msg})
 
+    async def close_environment(self, request):
+        if self._environment_exists:
+            self.stop_re_worker()
+            self._environment_exists = False
+            success, msg = True, ""
+        else:
+            success, msg = False, "Environment does not exist."
+        return web.json_response({"success": success, "msg": msg})
 
-async def close_environment(request):
-    global environment_exists
-    if environment_exists:
-        stop_re_worker()
-        environment_exists = False
-        success, msg = True, ""
-    else:
-        success, msg = False, "Environment does not exist."
-    return web.json_response({"success": success, "msg": msg})
+    async def process_queue(self, request):
+        if self._environment_exists:
+            self.run_task()
+            success, msg = True, ""
+        else:
+            success, msg = False, "Environment does not exist. Can not start the task."
+        return web.json_response({"success": success, "msg": msg})
 
+    def setup_routes(self, app):
+        app.add_routes(
+            [
+                web.get("/", self.hello),
+                web.get("/queue_view", self.queue_view_handler),
+                web.post("/add_to_queue", self.addto_queue_handler),
+                web.post("/pop_from_queue", self.pop_from_queue_handler),
+                web.post("/start_environment", self.start_environment),
+                web.post("/close_environment", self.close_environment),
+                web.post("/process_queue", self.process_queue),
+            ]
+        )
 
-async def process_queue(request):
-    global environment_exists
-    if environment_exists:
-        run_task()
-        success, msg = True, ""
-    else:
-        success, msg = False, "Environment does not exist. Can not start the task."
-    return web.json_response({"success": success, "msg": msg})
-
-
-def setup_routes(app):
-    app.add_routes(
-        [
-            web.get("/", hello),
-            web.get("/queue_view", queue_view_handler),
-            web.post("/add_to_queue", addto_queue_handler),
-            web.post("/pop_from_queue", pop_from_queue_handler),
-            web.post("/start_environment", start_environment),
-            web.post("/close_environment", close_environment),
-            web.post("/process_queue", process_queue),
-        ]
-    )
-
-
-def receive_packet_thread():
-    while True:
-        ttime.sleep(0.1)
-        if server_conn.poll():
-            try:
-                print(f"Waiting for message")
-                msg = server_conn.recv()
-                run_task()
-                #self._loop.call_soon_threadsafe(self._conn_received, msg)
-                print(f"Server: message received {msg}")
-            except Exception as ex:
-                logger.error(f"Server: Exception occurred while waiting for packet: {ex}")
-                break
 
 
 def init_func(argv):
-    global server_conn, worker_conn, thread_conn
-    server_conn, worker_conn = Pipe()
-
-    # Start the thread as 'daemon', because there is no place to join it in the current configuration
-    thread_conn = threading.Thread(target=receive_packet_thread,
-                                   name="RE Server Comm",
-                                   daemon=True)
-    thread_conn.start()
+    re_server = RunEngineServer()
 
     app = web.Application()
-    app["queue"] = []
-    setup_routes(app)
+    re_server.setup_routes(app)
+    app["re_server"] = re_server  # To keep it alive
     return app

--- a/bluesky_queueserver/server.py
+++ b/bluesky_queueserver/server.py
@@ -2,9 +2,7 @@ from aiohttp import web
 from multiprocessing import Process, Pipe
 import threading
 import time as ttime
-
-#from ophyd.sim import det1, det2
-#from bluesky.plans import count
+import asyncio
 
 from .worker import RunEngineWorker
 
@@ -29,53 +27,60 @@ class RunEngineServer:
 
         self._queue_plans = []
 
+        self._loop = asyncio.get_event_loop()
+
         self._start_conn_pipes()
         self._start_conn_thread()
 
-    async def hello(self, request):
+    def get_loop(self):
+        return self._loop
+
+    async def _hello(self, request):
         return web.Response(text=f"Hello, world. "
                                  f"There are {len(self._queue_plans)} plans enqueed")
 
-    async def queue_view_handler(self, request):
+    async def _queue_view_handler(self, request):
+        print(f"Queue_view called")
         out = {"queue": self._queue_plans}
         return web.json_response(out)
 
-    async def addto_queue_handler(self, request):
+    async def _add_to_queue_handler(self, request):
         data = await request.json()
-        # TODO validate inputs!
+        # TODO: validate inputs!
         plan = data["plan"]
         location = data.get("location", len(self._queue_plans))
         self._queue_plans.insert(location, plan)
         return web.json_response(data)
 
-    async def pop_from_queue_handler(self, request):
-        if len(self._queue_plans):
+    async def _pop_from_queue_handler(self, request):
+        """Pop the last item from the queue"""
+        if self._queue_plans:
             plan = self._queue_plans.pop()  # Pops from the back of the queue
             return web.json_response(plan)
         else:
-            return web.json_response({"plan": "sleep", "args": [10]})
+            return web.json_response({})  # No items
 
     def _start_conn_pipes(self):
         self._server_conn, self._worker_conn = Pipe()
 
     def _start_conn_thread(self):
-        self._thread_conn = threading.Thread(target=self.receive_packet_thread,
+        self._thread_conn = threading.Thread(target=self._receive_packet_thread,
                                              name="RE Server Comm",
                                              daemon=True)
         self._thread_conn.start()
 
-    def start_re_worker(self):
+    def _start_re_worker(self):
         self._re_worker = RunEngineWorker(conn=self._worker_conn)
         self._re_worker.start()
 
-    def stop_re_worker(self):
+    def _stop_re_worker(self):
         msg = {"type": "command", "value": "quit"}
         self._server_conn.send(msg)
         self._re_worker.join()
 
-    def run_task(self):
+    def _run_task(self):
         if self._queue_plans:
-            print(f"Starting new plan: {len(self._queue_plans)} plans are left in the queue")
+            logger.info(f"Starting new plan: {len(self._queue_plans)} plans are left in the queue")
             new_plan = self._queue_plans.pop(0)
 
             plan_name = new_plan["name"]
@@ -89,45 +94,51 @@ class RunEngineServer:
                             }
                   }
 
-            print(f"Sending message 'run_task' ...")
             self._server_conn.send(msg)
             return True
         else:
-            print(f"Queue is empty")
+            logger.info("Queue is empty")
             return False
 
-    def receive_packet_thread(self):
+    def _receive_packet_thread(self):
         while True:
             ttime.sleep(0.1)
             if self._server_conn.poll():
                 try:
                     msg = self._server_conn.recv()
-                    self.run_task()
+                    self._loop.call_soon_threadsafe(self._conn_received, msg)
                 except Exception as ex:
                     logger.error(f"Server: Exception occurred while waiting for packet: {ex}")
                     break
 
-    async def start_environment(self, request):
+    def _conn_received(self, msg):
+        type, value = msg["type"], msg["value"]
+        if type == "report":
+            uids = value["uids"]
+            logger.info(f"Successfully finished execution of the plan (run UIDs: {uids})")
+            self._run_task()
+
+    async def _start_environment(self, request):
         if not self._environment_exists:
-            self.start_re_worker()
+            self._start_re_worker()
             self._environment_exists = True
             success, msg = True, ""
         else:
             success, msg = False, "Environment already exists."
         return web.json_response({"success": success, "msg": msg})
 
-    async def close_environment(self, request):
+    async def _close_environment(self, request):
         if self._environment_exists:
-            self.stop_re_worker()
+            self._stop_re_worker()
             self._environment_exists = False
             success, msg = True, ""
         else:
             success, msg = False, "Environment does not exist."
         return web.json_response({"success": success, "msg": msg})
 
-    async def process_queue(self, request):
+    async def _process_queue(self, request):
         if self._environment_exists:
-            self.run_task()
+            self._run_task()
             success, msg = True, ""
         else:
             success, msg = False, "Environment does not exist. Can not start the task."
@@ -136,22 +147,21 @@ class RunEngineServer:
     def setup_routes(self, app):
         app.add_routes(
             [
-                web.get("/", self.hello),
-                web.get("/queue_view", self.queue_view_handler),
-                web.post("/add_to_queue", self.addto_queue_handler),
-                web.post("/pop_from_queue", self.pop_from_queue_handler),
-                web.post("/start_environment", self.start_environment),
-                web.post("/close_environment", self.close_environment),
-                web.post("/process_queue", self.process_queue),
+                web.get("/", self._hello),
+                web.get("/queue_view", self._queue_view_handler),
+                web.post("/add_to_queue", self._add_to_queue_handler),
+                web.post("/pop_from_queue", self._pop_from_queue_handler),
+                web.post("/start_environment", self._start_environment),
+                web.post("/close_environment", self._close_environment),
+                web.post("/process_queue", self._process_queue),
             ]
         )
-
 
 
 def init_func(argv):
     re_server = RunEngineServer()
 
-    app = web.Application()
+    app = web.Application(loop=re_server.get_loop())
     re_server.setup_routes(app)
     app["re_server"] = re_server  # To keep it alive
     return app

--- a/bluesky_queueserver/worker.py
+++ b/bluesky_queueserver/worker.py
@@ -3,7 +3,6 @@ import threading
 import asyncio
 import queue
 import time as ttime
-from functools import partial
 from collections.abc import Iterable
 
 from bluesky import RunEngine
@@ -17,8 +16,8 @@ from ophyd.log import config_ophyd_logging
 # from databroker import Broker
 
 # The following plans/devices must be imported (otherwise plan parsing wouldn't work)
-from ophyd.sim import det1, det2, motor
-from bluesky.plans import count, scan
+from ophyd.sim import det1, det2, motor  # noqa: F401
+from bluesky.plans import count, scan  # noqa: F401
 
 import logging
 logger = logging.getLogger(__name__)
@@ -33,101 +32,163 @@ mpl_logger.setLevel(logging.WARNING)
 class RunEngineWorker(Process):
     """
     The class implementing BlueskyWorker thread.
+
+    Parameters
+    ----------
+    conn
+        The end of bidirectional (input/output) pipe.
     """
     def __init__(self, *, conn):
 
         super().__init__(name="RE Worker")
 
+        # The end of bidirectional Pipe assigned to the worker (for communication with the server)
         self._conn = conn
-        print(f"conn={conn}")
 
         self._loop = None
-        self._th = None
-        self._exit_loop_event = None
+        self._th = None  # The thread in which the loop is running
+        self._exit_loop_event = None  # Reference to the asyncio.Event
 
         self._exit_event = threading.Event()
-        self._callback_queue = None
+        self._plan_execution_queue = None
 
+        # Reference to Bluesky Run Engine
         self._RE = None
 
         # The thread that receives packets from the pipe 'self._conn'
         self._thread_conn = None
 
     def _receive_packet_thread(self):
+        """
+        The function is running in a separate thread and monitoring the output
+        of the communication Pipe.
+        """
         while True:
             ttime.sleep(0.1)
             if self._exit_event.is_set():
                 break
             if self._conn.poll():
                 try:
-                    print(f"Waiting for message")
                     msg = self._conn.recv()
                     self._loop.call_soon_threadsafe(self._conn_received, msg)
-                    print(f"Message received")
                 except Exception as ex:
                     logger.error(f"Exception occurred while waiting for packet: {ex}")
                     break
 
-    def _execute_in_main_thread(self):
-        # This function blocks the main thread
-        while True:
-            ttime.sleep(1)
-            if self._exit_event.is_set():
-                break
-            try:
-                callback = self._callback_queue.get(False)
-                callback()
-            except queue.Empty:
-                pass
+    def _execute_plan(self, plan_func, plan_args, plan_kwargs):
+        """
+        Start Run Engine to execute a plan
+
+        Parameters
+        ----------
+        plan_func: function
+            Reference to a function that implements a Bluesky plan
+        plan_args: list
+            List of the plan arguments
+        plan_kwargs: dict
+            Dictionary of the plan kwargs.
+        """
+        logger.debug("Starting execution of a plan")
+
+        uids = self._RE(plan_func(*plan_args, **plan_kwargs))
+
+        # Very minimalistic report (for the demo).
+        msg = {"type": "report",
+               "value": {"uids": uids}}
+
+        self._conn.send(msg)
+        logger.debug("Finished execution of a plan")
+
+    def _load_new_plan(self, plan_name, plan_args, plan_kwargs):
+        """
+        Loads a new plan into `self._plan_execution_queue`. The plan is
+        later picked up by the function running in the main thread and
+        executed by the Run Engine.
+        """
+        logger.info(f"Starting a plan {plan_name}")
+
+        def ref_from_name(v):
+            if isinstance(v, str):
+                try:
+                    v = globals()[v]
+                except KeyError:
+                    pass
+            return v
+
+        # The following is some primitive parsing of the plan that replaces names
+        #   with references. No error handling is implemented, so it is better if
+        #   the submitted plans contain no errors.
+        plan_func = ref_from_name(plan_name)
+        plan_args_parsed = []
+        for arg in plan_args:
+            if isinstance(arg, Iterable) and not isinstance(arg, str):
+                arg_parsed = [ref_from_name(_) for _ in arg]
+            else:
+                arg_parsed = ref_from_name(arg)
+            plan_args_parsed.append(arg_parsed)
+
+        # We are not parsing 'kwargs' at this time
+        plan = (plan_func, plan_args_parsed, plan_kwargs)
+        self._plan_execution_queue.put(plan)
 
     def _conn_received(self, msg):
+        """
+        The function is processing the received message 'msg'.
+        """
         type, value = msg["type"], msg["value"]
 
         if type == "command" and value == "quit":
             # Stop the loop in main thread
-            logger.info(f"Closing RE Worker")
+            logger.info("Closing RE Worker")
             self._exit_event.set()
             self._exit_loop_event.set()
 
         if type == "plan":
             plan_name = value["name"]
-            args = value["args"]
-            kwargs = value["kwargs"]
+            plan_args = value["args"]
+            plan_kwargs = value["kwargs"]
+            self._load_new_plan(plan_name, plan_args, plan_kwargs)
 
-            logger.info(f"Starting a plan {plan_name}")
+    # ------------------------------------------------------------
 
-            def ref_from_name(v):
-                if isinstance(v, str):
-                    try:
-                        v = globals()[v]
-                    except KeyError:
-                        pass
-                return v
-
-            # Replace names with references
-            plan_name_parsed = ref_from_name(plan_name)
-            args_parsed = []
-            for arg in args:
-                if isinstance(arg, Iterable) and not isinstance(arg, str):
-                    arg_parsed = [ref_from_name(_) for _ in arg]
-                else:
-                    arg_parsed = ref_from_name(arg)
-                args_parsed.append(arg_parsed)
-
-            def plan():
-                yield from plan_name_parsed(*args_parsed, **kwargs)
-
-            func = partial(self._execute_plan, plan)
-            self._callback_queue.put(func)
+    def _execute_in_main_thread(self):
+        """
+        Run this function to block the main thread. The function is polling
+        `self._plan_execution_queue` and executes the plans that are in the queue.
+        If the queue is empty, then the thread remains idle.
+        """
+        # This function blocks the main thread
+        while True:
+            ttime.sleep(1)  # Polling once per second should be fine for now.
+            # Exit the thread if the Event is set (necessary to gracefully close the process)
+            if self._exit_event.is_set():
+                break
+            try:
+                plan_func, plan_args, plan_kwargs = self._plan_execution_queue.get(False)
+                self._execute_plan(plan_func, plan_args, plan_kwargs)
+            except queue.Empty:
+                pass
 
     async def _wait_for_exit(self):
+        """
+        The function waits for `self._exit_loop_event` to be set. Waiting for
+        the result of the returned futures ensures that all functions in the loop complete
+        before the process is destroyed.
+        """
+        # Create the event (must be created from the loop)
         self._exit_loop_event = asyncio.Event()
-        self._callback_queue = queue.Queue()
 
+        # Wait for the event to be set somewhere else (as a response to command from
+        #   the server)
         await self._exit_loop_event.wait()
 
-    def run(self):
+    # ------------------------------------------------------------
 
+    def run(self):
+        """
+        Overrides the `run()` function of the `multiprocessing.Process` class. Called
+        by the `start` method.
+        """
         self._exit_event.clear()
 
         if not self._loop:
@@ -144,6 +205,8 @@ class RunEngineWorker(Process):
 
         future = asyncio.run_coroutine_threadsafe(self._wait_for_exit(), self._loop)
 
+        self._plan_execution_queue = queue.Queue()
+
         self._thread_conn = threading.Thread(target=self._receive_packet_thread,
                                              name="RE Worker Receive")
         self._thread_conn.start()
@@ -157,11 +220,3 @@ class RunEngineWorker(Process):
         self._thread_conn.join()
 
         del self._RE
-
-    def _execute_plan(self, plan):
-        logger.info("Starting execution of a plan")
-        uids = self._RE(plan())
-        msg = {"type": "report",
-               "value": {"uids": uids}}
-        self._conn.send(msg)
-        logger.info("Finished execution of a plan")

--- a/bluesky_queueserver/worker.py
+++ b/bluesky_queueserver/worker.py
@@ -38,7 +38,7 @@ class RunEngineWorker(Process):
     conn
         The end of bidirectional (input/output) pipe.
     """
-    def __init__(self, *, conn):
+    def __init__(self, *, conn, db):
 
         super().__init__(name="RE Worker")
 
@@ -56,6 +56,8 @@ class RunEngineWorker(Process):
 
         # Thread used for to send the second sigint after short timeout
         self._thread_sigint = None
+
+        self._db = db
 
     def _receive_packet_thread(self):
         """
@@ -355,7 +357,7 @@ class RunEngineWorker(Process):
         self._RE.subscribe(bec)
 
         # db = Broker.named('temp')
-        # self._RE.subscribe(db.insert)
+        self._RE.subscribe(self._db.insert)
 
         self._execution_queue = queue.Queue()
 

--- a/bluesky_queueserver/worker.py
+++ b/bluesky_queueserver/worker.py
@@ -64,10 +64,9 @@ class RunEngineWorker(Process):
         of the communication Pipe.
         """
         while True:
-            ttime.sleep(0.1)
             if self._exit_event.is_set():
                 break
-            if self._conn.poll():
+            if self._conn.poll(0.1):
                 try:
                     msg = self._conn.recv()
                     self._loop.call_soon_threadsafe(self._conn_received, msg)

--- a/bluesky_queueserver/worker.py
+++ b/bluesky_queueserver/worker.py
@@ -81,21 +81,20 @@ class RunEngineWorker(Process):
                 pass
 
     def _conn_received(self, msg):
-        print(f"Message is in the loop: {msg}")
-
         type, value = msg["type"], msg["value"]
 
         if type == "command" and value == "quit":
             # Stop the loop in main thread
-            print(f"Existing ...")
+            logger.info(f"Closing RE Worker")
             self._exit_event.set()
             self._exit_loop_event.set()
 
         if type == "plan":
-            logger.info("Starting a plan")
             plan_name = value["name"]
             args = value["args"]
             kwargs = value["kwargs"]
+
+            logger.info(f"Starting a plan {plan_name}")
 
             def ref_from_name(v):
                 if isinstance(v, str):
@@ -152,16 +151,12 @@ class RunEngineWorker(Process):
         # Now make the main thread busy
         self._execute_in_main_thread()
 
-        print("Exited main thread")
         # Wait for the coroutine to exit
         future.result()
-        print("Future completed")
 
         self._thread_conn.join()
-        print("Thread joined")
 
         del self._RE
-        print("Run engine deleted")
 
     def _execute_plan(self, plan):
         logger.info("Starting execution of a plan")

--- a/bluesky_queueserver/worker.py
+++ b/bluesky_queueserver/worker.py
@@ -1,0 +1,164 @@
+from multiprocessing import Process
+import threading
+import asyncio
+import queue
+import time as ttime
+from functools import partial
+
+from bluesky import RunEngine
+from bluesky.run_engine import get_bluesky_event_loop, _ensure_event_loop_running
+
+from bluesky.callbacks.best_effort import BestEffortCallback
+from bluesky.log import config_bluesky_logging
+
+from ophyd.log import config_ophyd_logging
+
+# from databroker import Broker
+
+from ophyd.sim import det1, det2
+from bluesky.plans import count
+
+import logging
+logger = logging.getLogger(__name__)
+
+config_bluesky_logging(level='INFO')
+config_ophyd_logging(level='INFO')
+
+mpl_logger = logging.getLogger("matplotlib")
+mpl_logger.setLevel(logging.WARNING)
+
+
+class RunEngineWorker(Process):
+    """
+    The class implementing BlueskyWorker thread.
+    """
+    def __init__(self, *, conn):
+
+        super().__init__(name="RE Worker")
+
+        self._conn = conn
+        print(f"conn={conn}")
+
+        self._loop = None
+        self._th = None
+        self._exit_loop_event = None
+
+        self._exit_event = threading.Event()
+        self._callback_queue = None
+
+        self._RE = None
+
+        # Start thread that receives packets from the pip 'conn
+        self._conn_recv_buffer = []
+
+        self._thread_conn = None
+
+    def _receive_packet_thread(self):
+        while True:
+            ttime.sleep(0.1)
+            if self._exit_event.is_set():
+                break
+            if self._conn.poll():
+                try:
+                    print(f"Waiting for message")
+                    msg = self._conn.recv()
+                    self._loop.call_soon_threadsafe(self._conn_received, msg)
+                    print(f"Message received")
+                except Exception as ex:
+                    logger.error(f"Exception occurred while waiting for packet: {ex}")
+                    break
+
+    def _execute_in_main_thread(self):
+        # This function blocks the main thread
+        while True:
+            ttime.sleep(1)
+            if self._exit_event.is_set():
+                break
+            try:
+                callback = self._callback_queue.get(False)
+                callback()
+            except queue.Empty:
+                pass
+
+    def _conn_received(self, msg):
+        print(f"Message is in the loop: {msg}")
+
+        type, value = msg["type"], msg["value"]
+
+        if type == "command" and value == "quit":
+            # Stop the loop in main thread
+            print(f"Existing ...")
+            self._exit_event.set()
+            self._exit_loop_event.set()
+
+        if type == "plan":
+            logger.info("Starting a plan")
+            plan_name = value["name"]
+            args = value["args"]
+            kwargs = value["kwargs"]
+
+            def ref_from_name(v):
+                if isinstance(v, str):
+                    try:
+                        v = globals()[v]
+                    except KeyError:
+                        pass
+                return v
+
+            # Replace names with references
+            plan_name = ref_from_name(plan_name)
+            args = [[ref_from_name(_) for _ in arg] for arg in args]
+            kwargs = {"num": 5, "delay": [1, 2, 3, 4]}
+
+            def plan():
+                yield from plan_name(*args, **kwargs)
+
+            func = partial(self._execute_plan, plan)
+            self._callback_queue.put(func)
+
+    async def _wait_for_exit(self):
+        self._exit_loop_event = asyncio.Event()
+        self._callback_queue = queue.Queue()
+
+        await self._exit_loop_event.wait()
+
+    def run(self):
+
+        self._exit_event.clear()
+
+        if not self._loop:
+            self._loop = get_bluesky_event_loop()
+            self._th = _ensure_event_loop_running(self._loop)
+
+        self._RE = RunEngine({})
+
+        bec = BestEffortCallback()
+        self._RE.subscribe(bec)
+
+        # db = Broker.named('temp')
+        # self._RE.subscribe(db.insert)
+
+        future = asyncio.run_coroutine_threadsafe(self._wait_for_exit(), self._loop)
+
+        self._thread_conn = threading.Thread(target=self._receive_packet_thread,
+                                             name="RE Worker Receive")
+        self._thread_conn.start()
+
+        # Now make the main thread busy
+        self._execute_in_main_thread()
+
+        print("Exited main thread")
+        # Wait for the coroutine to exit
+        future.result()
+        print("Future completed")
+
+        self._thread_conn.join()
+        print("Thread joined")
+
+        del self._RE
+        print("Run engine deleted")
+
+    def _execute_plan(self, plan):
+        logger.info("Starting execution of a plan")
+        self._RE(plan())
+        logger.info("Finished execution of a plan")


### PR DESCRIPTION
This is the proof-of-principle prototype of the QueueServer that implements the following functions:

- management of the queue (add element, remove (pop) last (not first) element, get queue info, read queue);

- creation and initialization, and closing (destruction) of the execution environment (worker process) for Bluesky Run Engine;

- execution of the queue; additional plans may be added while the queue is running executed,

- pausing (immediate and deferred) of running plan (and the queue), resuming, aborting, stopping and halting of the paused plan. If the plan is resumed, execution of the queue is resumed (next plan will be executed once the current plan is completed). If the plan is aborted, stopped or halted, execution of the queue is stopped and the current plan remains in the queue. Queue can be restarted at any time.

- some basic error handling is added; error messages are printed in the terminal in which the server is run.

- collection of data to 'temp' Databroker; REST API to list UIDs of collected runs (this is demo-only feature).

What is missing:

- comprehensive error handling and reporting (currently error messages are printed in the terminal running QueueServer;

- monitoring of Run Engine status while a plan is executed (in the demo the BEC table is printed on the terminal that runs the server, but if you have only REST API access you have to hope for the best).