### PR TITLE
ENH: pause plan using 'RE.request_pause()' instead of SIGINT

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,10 @@ The server is controlled from a different shell. Add plans to the queue::
   http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
   http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
 
+The following plan runs for 10 seconds. It is convenient for testing pausing/resuming/stopping the plan::
+
+  http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
+
 The names of the plans and devices are strings. The strings are converted to references to plans and
 devices in the worker process. In this demo the server can recognize only 'det1', 'det2', 'motor' devices
 and 'count' and 'scan' plans. If items are added to the running queue and they

--- a/bluesky_queueserver/worker.py
+++ b/bluesky_queueserver/worker.py
@@ -266,7 +266,7 @@ class RunEngineWorker(Process):
                         raise RuntimeError(f"Option '{option}' is not supported. "
                                            f"Available options: {pausing_options}")
 
-                    defer = (option == "deferred")
+                    defer = {'deferred': True, 'immediate': False}[option]
                     self._RE.request_pause(defer=defer)
                     msg_ack["value"]["status"] = "accepted"
                 except Exception as ex:

--- a/bluesky_queueserver/worker.py
+++ b/bluesky_queueserver/worker.py
@@ -2,8 +2,6 @@ from multiprocessing import Process
 import threading
 import queue
 import time as ttime
-import os
-import signal
 from collections.abc import Iterable
 
 from bluesky import RunEngine
@@ -53,9 +51,6 @@ class RunEngineWorker(Process):
 
         # The thread that receives packets from the pipe 'self._conn'
         self._thread_conn = None
-
-        # Thread used for to send the second sigint after short timeout
-        self._thread_sigint = None
 
         self._db = db
 
@@ -262,35 +257,17 @@ class RunEngineWorker(Process):
             # Stop the loop in main thread
             logger.info("Pausing Run Engine")
             pausing_options = ("deferred", "immediate")
+            # TODO: the question is whether it is possible or should be allowed to pause a plan in
+            #       any other state than 'running'???
             if self._RE._state == 'running':
                 try:
                     option = msg["option"]
                     if option not in pausing_options:
                         raise RuntimeError(f"Option '{option}' is not supported. "
                                            f"Available options: {pausing_options}")
-                    pid = os.getpid()
 
-                    def send_sigint():
-                        try:
-                            os.kill(pid, signal.SIGINT)
-                        except Exception:
-                            pass
-
-                    def send_second_sigint():
-                        ttime.sleep(0.05)
-                        send_sigint()
-
-                    send_sigint()  # 1st SIGINT
-                    # TODO: I am not sure that this is a good way to initiate immediate pause.
-                    #       It seems to work in this prototype, but it needs to be well understood
-                    #       before it can be used in production.
-                    if option == "immediate":
-                        # Run it in a separate thread. So that the function could return immediately.
-                        self._thread_sigint = threading.Thread(target=send_second_sigint,
-                                                               name="RE Worker 2nd SIGINT",
-                                                               daemon=True)
-                        self._thread_sigint.start()
-
+                    defer = (option == "deferred")
+                    self._RE.request_pause(defer=defer)
                     msg_ack["value"]["status"] = "accepted"
                 except Exception as ex:
                     msg_ack["value"]["status"] = "error"


### PR DESCRIPTION
Small improvement in the code: pausing a plan using `RE.request_pause()` instead of generating `SIGINT`. To test the operation the following code may be changes:

Start the server:
```
python -m aiohttp.web -H 0.0.0.0 -P 8080 bluesky_queueserver.server:init_func
```
In a different terminal load a plan (runs for 10 seconds):
```
http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}' 
```
Create the environment and start the queue execution (the queue contains one plan):
```
http POST 0.0.0.0:8080/create_environment
http POST 0.0.0.0:8080/process_queue
```
Pause the plan while it is running:
```
http POST 0.0.0.0:8080/re_pause option="immediate"
```
Resume the plan:
```
http POST 0.0.0.0:8080/re_continue option="resume"
```
Check that the last measurement was repeated after the scan is restarted. Now load the plan again (queue can be filled with as many plans as desired). Start the queue execution. Request the deferred pause:
```
http POST 0.0.0.0:8080/re_pause option="deferred"
```
Resume the plan and check that the last measurement in the plan was not repeated after the plan is resumed.
```
http POST 0.0.0.0:8080/close_environment
```