### PR TITLE
Simple CLI tool for communicating with RE Manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,20 +20,35 @@ Server for queueing plans
 Features
 --------
 
-This is demo version of the server that supports creation and closing of Run Engine execution environment, adding
+This is demo version of the QueueServer that supports creation and closing of Run Engine execution environment, adding
 and removing items from the queue, checking the queue status and execution of the queue, pausing (immediate and
-deferred), resuming, aborting, stopping and halting plans, collection of data to 'temp' database.
+deferred), resuming, aborting, stopping and halting plans, collection of data to 'temp' Databroker.
 
-The demo has limited data handling implemented. While it is relatively stable while testing the example
-commands, the shell may still freeze (e.g. if Ctrl-C is pressed while the RE environment is not closed).
-In this case the best way is to close the shell and start a new one (simply killing the process will not
-help).
+Implementation of error handling is very limited. The modules are relatively stable when running the commands
+presented below, the shell may still freeze if the sequence of operations is violated (e.g. if the Manager
+application is closed using Ctrl-C is pressed before the RE environment is not closed). In this case
+some sockets will remain open and prevent the Manager from restarting. To close the sockets (we are interested
+sockets on ports 5555 and 8080), find PIDs of the processes::
 
-The server can be started from a shell as follows::
+  $ sudo netstat -ltnp
+
+and then kill the processes::
+
+  $ kill -9 <pid>
+
+The RE Manager and Web Server are running as two separate applications. To run the demo you will need to open
+three shells: the first for RE Manager, the second for Web Server and the third to send HTTP requests to
+the server.
+
+In the first shell start RE Manager::
+
+  python -m bluesky_queueserver.manager
+
+The Web Server should be started from the second shell as follows::
 
   python -m aiohttp.web -H 0.0.0.0 -P 8080 bluesky_queueserver.server:init_func
 
-The server is controlled from a different shell. Add plans to the queue::
+Use the third shell to send REST API requests to the server. Add plans to the queue::
 
   http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
   http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
@@ -111,7 +126,7 @@ the databased can be printed on the screen by sending the command::
 
   http POST 0.0.0.0:8080/print_db_uids
 
-The table will be printed in the QueueServer terminal::
+The table will be printed in the RE Manager terminal::
 
     ===================================================================
                  The contents of 'temp' database.

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,12 @@ and then kill the processes::
 
   $ kill -9 <pid>
 
+Installation of QueueServer from source::
+
+  pip install -e .
+
+This also sets up an entry point for the 'qserver' CLI tool.
+
 The RE Manager and Web Server are running as two separate applications. To run the demo you will need to open
 three shells: the first for RE Manager, the second for Web Server and the third to send HTTP requests to
 the server.
@@ -138,3 +144,56 @@ The table will be printed in the RE Manager terminal::
       Total of 3 runs were found in 'temp' database.
     ===================================================================
 
+The 'qserver' CLI tool can be started from a separate shell. Display help options::
+
+  qserver -h
+
+Run 'ping' command (get status from RE Manager)::
+
+  qserver -c ping
+
+Run 'qserver' in the monitoring mode (send 'ping' request to RE Manager every second)::
+
+  qserver -c monitor
+
+Add a new plan to the queue::
+
+  qserver -c add_to_queue -v '{"name":"count", "args":[["det1", "det2"]]}'
+  qserver -c add_to_queue -v '{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+  qserver -c add_to_queue -v '{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
+
+View the contents of the queue::
+
+  qserver -c queue_view
+
+Pop the last element from queue::
+
+  qserver -c pop_from_queue
+
+Create new RE environment::
+
+  qserver -c create_environment
+
+Execute the plan queue::
+
+  qserver -c process_queue
+
+Close and destroy RE environment::
+
+  qserver -c close_environment
+
+Pause the Run Engine (and the queue)::
+
+  qserver -c re_pause -v immediate
+  qserver -c re_pause -v deferred
+
+Countinue paused plan::
+
+  qserver -c re_continue -v resume
+  qserver -c re_continue -v abort
+  qserver -c re_continue -v stop
+  qserver -c re_continue -v halt
+
+Print UIDs in 'temp' Databroker::
+
+  qserver -c print_db_uids

--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,11 @@ Run 'ping' command (get status from RE Manager)::
 
   qserver -c ping
 
+Current default address of RE Manager is set to tcp://localhost:5555, but different
+address may be passed as a parameter::
+
+  qserver -c ping -a "tcp://localhost:5555"
+
 Run 'qserver' in the monitoring mode (send 'ping' request to RE Manager every second)::
 
   qserver -c monitor

--- a/bluesky_queueserver/manager.py
+++ b/bluesky_queueserver/manager.py
@@ -222,7 +222,7 @@ class RunEngineManager:
             self._queue_plans.append(plan)
         else:
             plan = {}
-        return {}
+        return plan
 
     async def _pop_from_queue_handler(self, request):
         """

--- a/bluesky_queueserver/manager.py
+++ b/bluesky_queueserver/manager.py
@@ -1,0 +1,384 @@
+import asyncio
+import zmq
+import zmq.asyncio
+from multiprocessing import Pipe
+import threading
+
+from .worker import RunEngineWorker
+
+from databroker import Broker
+
+import logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+db_logger = logging.getLogger("databroker")
+db_logger.setLevel(logging.INFO)
+
+
+"""
+#  The following plans that can be used to test the syste
+
+http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
+
+# This is the slowly running plan (convenient to test pausing)
+http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]],
+"kwargs":{"num":10, "delay":1}}'
+
+http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+"""
+
+
+class RunEngineManager:
+
+    def __init__(self):
+        self._re_worker = None
+        self._manager_conn = None
+        self._worker_conn = None
+
+        self._environment_exists = False
+
+        self._thread_conn = None
+
+        self._queue_plans = []
+
+        self._loop = None
+
+        self._start_conn_pipes()
+        self._start_conn_thread()
+
+        # Communication with the server using ZMQ
+        self._ctx = zmq.asyncio.Context()
+        self._zmq_socket = None
+        self._ip_zmq_server = "tcp://*:5555"
+
+        # Create Databroker instance. This reference is passed to RE Worker process.
+        # The experimental data can later be retrieved from the database.
+        # This subscription mechanism is strictly for the demo, since using reference
+        # to the databroker in several processes may not be a good idea. Here it is assumed
+        # that only one process access Databroker at a time.
+        self._db = Broker.named('temp')
+
+    def _start_conn_pipes(self):
+        self._manager_conn, self._worker_conn = Pipe()
+
+    def _start_conn_thread(self):
+        self._thread_conn = threading.Thread(target=self._receive_packet_thread,
+                                             name="RE Server Comm",
+                                             daemon=True)
+        self._thread_conn.start()
+
+    # ======================================================================
+    #   Functions that implement functionality of the server
+
+    def _start_re_worker(self):
+        """
+        Creates worker process.
+        """
+        # Passing reference to Databroker to a different process may be not a great idea.
+        # This is here strictly for the demo.
+        self._re_worker = RunEngineWorker(conn=self._worker_conn, db=self._db)
+        self._re_worker.start()
+
+    def _stop_re_worker(self):
+        """
+        Closes Run Engine execution environment (destroys the worker process). Running plan needs
+        to be stopped before the environment can be closed. Separate function could be added that could
+        kill unresponsive process that can not be closed gracefully.
+        """
+        msg = {"type": "command", "value": "quit"}
+        self._manager_conn.send(msg)
+        self._re_worker.join()
+
+    def _run_task(self):
+        """
+        Upload the plan to the worker process for execution.
+        Plan in the queue is represented as a dictionary with the keys "name" (plan name),
+        "args" (list of args), "kwargs" (list of kwargs). Only the plan name is mandatory.
+        Names of plans and devices are strings.
+        """
+        if self._queue_plans:
+            logger.info(f"Starting new plan: {len(self._queue_plans)} plans are left in the queue")
+            new_plan = self._queue_plans[0]
+
+            plan_name = new_plan["name"]
+            args = new_plan["args"] if "args" in new_plan else []
+            kwargs = new_plan["kwargs"] if "kwargs" in new_plan else {}
+
+            msg = {"type": "plan",
+                   "value": {"name": plan_name,
+                             "args": args,
+                             "kwargs": kwargs
+                             }
+                   }
+
+            self._manager_conn.send(msg)
+            return True
+        else:
+            logger.info("Queue is empty")
+            return False
+
+    def _pause_run_engine(self, option):
+        """
+        Pause execution of a running plan. Run Engine must be in 'running' state in order for
+        the request to pause to be accepted by RE Worker.
+        """
+        msg = {"type": "command", "value": "pause", "option": option}
+        self._manager_conn.send(msg)
+
+    def _continue_run_engine(self, option):
+        """
+        Continue handling of a paused plan.
+        """
+        msg = {"type": "command", "value": "continue", "option": option}
+        self._manager_conn.send(msg)
+
+    def _print_db_uids(self):
+        """
+        Prints the UIDs of the scans in 'temp' database. Just for the demo.
+        Not part of future API.
+        """
+        print("\n===================================================================")
+        print("             The contents of 'temp' database.")
+        print("-------------------------------------------------------------------")
+        n_runs = 0
+        for run_id in range(1, 100000):
+            try:
+                hdr = self._db[run_id]
+                uid = hdr.start["uid"]
+                n_runs += 1
+                print(f"Run ID: {run_id}   UID: {uid}")
+            except Exception:
+                break
+        print("-------------------------------------------------------------------")
+        print(f"  Total of {n_runs} runs were found in 'temp' database.")
+        print("===================================================================\n")
+
+    # =======================================================================
+    #   Functions for communication with the worker process
+
+    def _receive_packet_thread(self):
+        while True:
+            if self._manager_conn.poll(0.1):
+                try:
+                    msg = self._manager_conn.recv()
+                    logger.debug(f"Message received from RE Worker: {msg}")
+                    # Messages should be handled in the event loop
+                    self._loop.call_soon_threadsafe(self._conn_received, msg)
+                except Exception as ex:
+                    logger.error(f"Exception occurred while waiting for packet: {ex}")
+                    break
+
+    def _conn_received(self, msg):
+        type, value = msg["type"], msg["value"]
+
+        if type == "report":
+            completed = value["completed"]
+            success = value["success"]
+            result = value["result"]
+            logger.info(f"Report received from RE Worker:\nsuccess={success}\n{result}\n)")
+            if completed and success:
+                # Executed plan is removed from the queue only after it is successfully completed.
+                # If a plan was not completed or not successful (exception was raised), then
+                # execution of the queue is stopped. It can be restarted later (failed or
+                # interrupted plan will still be in the queue.
+                self._queue_plans.pop(0)
+                self._run_task()
+
+        if type == "acknowledge":
+            status = value["status"]
+            result = value["result"]
+            msg_original = value["msg"]
+            logger.info("Acknownegement received from RE Worker:\n"
+                        f"Status: '{status}'\nResult: '{result}'\nMessage: {msg_original}")
+
+    # =========================================================================
+    #    REST API handlers
+
+    async def _hello_handler(self, request):
+        """
+        May be called to get response from the Manager. Returns the number of plans in the queue.
+        """
+        logger.info("Processing 'Hello' request.")
+        msg = {"msg": f"Hello, world! There are {len(self._queue_plans)} plans enqueed."}
+        return msg
+
+    async def _queue_view_handler(self, request):
+        """
+         Returns the contents of the current queue.
+         """
+        logger.info("Returning current queue.")
+        return {"queue": self._queue_plans}
+
+    async def _add_to_queue_handler(self, request):
+        """
+        Adds new plan to the end of the queue
+        """
+        # TODO: validate inputs!
+        logger.info(f"Adding new plan to the queue: {request}")
+        if "plan" in request:
+            plan = request["plan"]
+            self._queue_plans.append(plan)
+        else:
+            plan = {}
+        return {}
+
+    async def _pop_from_queue_handler(self, request):
+        """
+        Pop the last item from back of the queue
+        """
+        logger.info("Popping the last item from the queue.")
+        if self._queue_plans:
+            plan = self._queue_plans.pop()  # Pops from the back of the queue
+            return plan
+        else:
+            return {}  # No items
+
+    async def _create_environment_handler(self, request):
+        """
+        Creates RE environment: creates RE Worker process, starts and configures Run Engine.
+        """
+        logger.info("Creating the new RE environment.")
+        if not self._environment_exists:
+            self._start_re_worker()
+            self._environment_exists = True
+            success, msg = True, ""
+        else:
+            success, msg = False, "Environment already exists."
+        return {"success": success, "msg": msg}
+
+    async def _close_environment_handler(self, request):
+        """
+        Deletes RE environment. In the current 'demo' prototype the environment will be deleted
+        only after RE completes the current scan.
+        """
+        logger.info("Closing current RE environment.")
+        if self._environment_exists:
+            self._stop_re_worker()
+            self._environment_exists = False
+            success, msg = True, ""
+        else:
+            success, msg = False, "Environment does not exist."
+        return {"success": success, "msg": msg}
+
+    async def _process_queue_handler(self, request):
+        """
+        Start execution of the loaded queue. Additional runs can be added to the queue while
+        it is executed. If the queue is empty, then nothing will happen.
+        """
+        logger.info("Starting queue processing.")
+        if self._environment_exists:
+            self._run_task()
+            success, msg = True, ""
+        else:
+            success, msg = False, "Environment does not exist. Can not start the task."
+        return {"success": success, "msg": msg}
+
+    async def _re_pause_handler(self, request):
+        """
+        Pause Run Engine
+        """
+        logger.info("Pausing the queue (currently running plan).")
+        option = request["option"] if "option" in request else None
+        available_options = ("deferred", "immediate")
+        if option in available_options:
+            if self._environment_exists:
+                self._pause_run_engine(option)
+                success, msg = True, ""
+            else:
+                success, msg = False, "Environment does not exist. Can not pause Run Engine."
+        else:
+            success, msg = False, f"Option '{option}' is not supported. " \
+                                  f"Available options: {available_options}"
+        return {"success": success, "msg": msg}
+
+    async def _re_continue_handler(self, request):
+        """
+        Control Run Engine in the paused state
+        """
+        logger.info("Continue paused queue (plan).")
+        option = request["option"] if "option" in request else None
+        available_options = ("resume", "abort", "stop", "halt")
+        if option in available_options:
+            if self._environment_exists:
+                self._continue_run_engine(option)
+                success, msg = True, ""
+            else:
+                success, msg = False, "Environment does not exist. Can not pause Run Engine."
+        else:
+            success, msg = False, f"Option '{option}' is not supported. " \
+                                  f"Available options: {available_options}"
+        return {"success": success, "msg": msg}
+
+    async def _print_db_uids_handler(self, request):
+        """
+        Prints the UIDs of the scans in 'temp' database. Just for the demo.
+        Not part of future API.
+        """
+        logger.info("Print UIDs of collected run ('temp' Databroker).")
+        self._print_db_uids()
+        return {"success": True, "msg": ""}
+
+    async def _zmq_execute(self, msg):
+        command = msg["command"]
+        value = msg["value"]
+        handler_dict = {
+            "": "_hello_handler",
+            "queue_view": "_queue_view_handler",
+            "add_to_queue": "_add_to_queue_handler",
+            "pop_from_queue": "_pop_from_queue_handler",
+            "create_environment": "_create_environment_handler",
+            "close_environment": "_close_environment_handler",
+            "process_queue": "_process_queue_handler",
+            "re_pause": "_re_pause_handler",
+            "re_continue": "_re_continue_handler",
+            "print_db_uids": "_print_db_uids_handler",
+        }
+
+        try:
+            handler_name = handler_dict[command]
+            handler = getattr(self, handler_name)
+            result = await handler(value)
+        except KeyError:
+            result = {"success": False, "msg": f"Unknown command '{command}'"}
+        except AttributeError:
+            result = {"success": False, "msg": f"Handler for the command '{command}' is not implemented"}
+        return result
+
+    async def _zmq_receive(self):
+        msg_in = await self._zmq_socket.recv_json()
+        return msg_in
+
+    async def _zmq_send(self, msg):
+        await self._zmq_socket.send_json(msg)
+
+    async def zmq_server_comm(self):
+        """
+        This function is supposed to be executed by asyncio.run() to start the manager.
+        """
+        self._loop = asyncio.get_running_loop()
+
+        logger.info("Starting ZeroMQ server")
+        self._zmq_socket = self._ctx.socket(zmq.REP)
+        self._zmq_socket.bind(self._ip_zmq_server)
+        logger.info(f"ZeroMQ server is waiting on {self._ip_zmq_server}")
+
+        while True:
+            #  Wait for next request from client
+            msg_in = await self._zmq_receive()
+            logger.info(f"ZeroMQ server received request: {msg_in}")
+
+            msg_out = await self._zmq_execute(msg_in)
+
+            #  Send reply back to client
+            logger.info(f"ZeroMQ server sending response: {msg_out}")
+            await self._zmq_send(msg_out)
+
+
+if __name__ == "__main__":
+    re_manager = RunEngineManager()
+    try:
+        asyncio.run(re_manager.zmq_server_comm())
+    except KeyboardInterrupt:
+        logger.info("The application was stopped")

--- a/bluesky_queueserver/qserver_cli.py
+++ b/bluesky_queueserver/qserver_cli.py
@@ -1,0 +1,203 @@
+import asyncio
+import ast
+import time as ttime
+from datetime import datetime
+import pprint
+import re
+
+import zmq
+import zmq.asyncio
+import argparse
+
+import bluesky_queueserver
+
+import logging
+# logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.CRITICAL)
+
+qserver_version = bluesky_queueserver.__version__
+
+"""
+#  The following plans that can be used to test the server
+
+http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
+
+# This is the slowly running plan (convenient to test pausing)
+http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]],
+"kwargs":{"num":10, "delay":1}}'
+
+http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+"""
+
+
+class CliClient:
+
+    def __init__(self):
+        # ZeroMQ communication
+        self._ctx = zmq.asyncio.Context()
+        self._zmq_socket = None
+        self._zmq_server_address = "tcp://localhost:5555"
+
+        # The attributes for storing output command and received input
+        self._msg_command_out = ""
+        self._msg_value_out = {}
+        self._msg_in = {}
+        self._msg_err_in = ""
+
+    @staticmethod
+    def get_supported_commands():
+        """
+        Get the dictionary that maps command names supported by the cli tool to
+        the command names in RE Manager API.
+
+        Returns
+        -------
+        dict(str, str)
+            Dictionary that maps supported commands to commands from RE Manager API.
+        """
+        command_dict = {
+            "ping": "",
+            "queue_view": "queue_view",
+            "add_to_queue": "add_to_queue",
+            "pop_from_queue": "pop_from_queue",
+            "create_environment": "create_environment",
+            "close_environment": "close_environment",
+            "process_queue": "process_queue",
+            "re_pause": "re_pause",
+            "re_continue": "re_continue",
+            "print_db_uids": "print_db_uids",
+        }
+        return command_dict
+
+    # ==========================================================================
+    #    Functions that support ZeroMQ communications with RE Manager
+
+    async def _zmq_send(self, msg):
+        await self._zmq_socket.send_json(msg)
+
+    async def _zmq_receive(self):
+        return await self._zmq_socket.recv_json()
+
+    async def _zmq_communicate(self, msg_out):
+        try:
+            await self._zmq_send(msg_out)
+            msg_in = await self._zmq_receive()
+            return msg_in
+        except Exception as ex:
+            raise RuntimeError(f"ZeroMQ communication failed: {str(ex)}")
+
+    async def _zmq_open_connection(self, address):
+        if self._zmq_socket.connect(address):
+            msg_err = f"Failed to connect to the server '{address}'"
+            raise RuntimeError(msg_err)
+
+    async def zmq_single_request(self):
+        self._zmq_socket = self._ctx.socket(zmq.REQ)
+        self._zmq_socket.RCVTIMEO = 2000  # Timeout for 'recv' operation
+        self._zmq_socket.SNDTIMEO = 500  # Timeout for 'send' operation
+        # Clear the buffer quickly after the socket is closed
+        self._zmq_socket.setsockopt(zmq.LINGER, 100)
+
+        try:
+            await self._zmq_open_connection(self._zmq_server_address)
+            logger.info(f"Connected to ZeroMQ server '{self._zmq_server_address}'")
+            self._msg_in = await self._send_command(command=self._msg_command_out,
+                                                    value=self._msg_value_out)
+            self._msg_err_in = ""
+        except Exception as ex:
+            self._msg_in = None
+            self._msg_err_in = str(ex)
+            # Close the socket to clear the buffer quickly in case of an error.
+            self._zmq_socket.close()
+
+        if self._msg_err_in:
+            logger.warning(f"Communication with RE Manager failed: {self._msg_err_in}")
+
+    async def _send_command(self, *, command, value=None):
+        msg_out = self._create_msg(command=command, value=value)
+        msg_in = await self._zmq_communicate(msg_out)
+        return msg_in
+
+    def _create_msg(self, command, value=None):
+        # This function may transform human-friendly command names to API names
+        command_dict = self.get_supported_commands()
+        try:
+            command = command_dict[command]
+            # Present value in the proper format. This will change as the format is changed.
+            if command == "add_to_queue":
+                value = {"plan": value}  # Value is dict
+            else:
+                value = {"option": value}  # Value is str
+            return {"command": command, "value": value}
+        except KeyError:
+            raise ValueError(f"Command '{command}' is not supported.")
+
+    def set_msg_out(self, command, value):
+        self._msg_command_out = command
+        self._msg_value_out = value
+
+    def get_msg_in(self):
+        return self._msg_in, self._msg_err_in
+
+
+def qserver():
+    supported_commands = list(CliClient.get_supported_commands().keys())
+    # Add the command 'monitor' to the list. This command is not sent to RE Manager.
+    supported_commands = ["monitor"] + supported_commands
+
+    parser = argparse.ArgumentParser(description='Command-line tool for communicating with RE Monitor.',
+                                     epilog=f'Bluesky-QServer version {qserver_version}.')
+    parser.add_argument('--command', '-c', dest="command", action='store', required=True,
+                        help=f"Command sent to the server. Supported commands: {supported_commands}.")
+    parser.add_argument('--value', '-v', dest="value", action='store', default=None,
+                        help="Arguments that are sent with the command. Currently the arguments "
+                             "must be represented as a string that contains a python dictionary.")
+    parser.add_argument('--address', '-a', action='store',
+                        help="Address of the server (e.g. 'tcp://localhost:5555', quoted string)")
+
+    args = parser.parse_args()
+
+    command, value = args.command, args.value
+
+    if command not in supported_commands:
+        print(f"Command '{command}' is not supported. Please enter a valid command.\n"
+              f"Call 'qserver' with the option '-h' to see full list of supported commands.")
+        return
+
+    # Value is a string representing a python dictionary. We need to convert it into a dictionary.
+    #   Also don't evaluate the expression that is a non-quoted string with alphanumeric characters.
+    if (value is not None) and not re.search(r"^\w+$", value):
+        try:
+            value = ast.literal_eval(value)
+        except Exception as ex:
+            print(f"Failed to parse value {value}: {str(ex)}. "
+                  f"The value must be a valid Python dictionary")
+            return
+
+    # 'ping' command will be sent to RE Manager periodically if 'monitor' command is entered
+    monitor_on = (command == "monitor")
+    if monitor_on:
+        command = "ping"
+        print("Running QSever monitor. Press Ctrl-C to exit ...")
+
+    re_server = CliClient()
+    try:
+        while True:
+            re_server.set_msg_out(command, value)
+            asyncio.run(re_server.zmq_single_request())
+            msg, msg_err = re_server.get_msg_in()
+
+            now = datetime.now()
+            current_time = now.strftime("%H:%M:%S")
+
+            if not msg_err:
+                print(f"{current_time} - MESSAGE: {pprint.pformat(msg)}")
+            else:
+                print(f"{current_time} - ERROR: {msg_err}")
+
+            if not monitor_on:
+                break
+            ttime.sleep(1)
+    except KeyboardInterrupt:
+        print("\nThe program was manually stopped.")

--- a/bluesky_queueserver/qserver_cli.py
+++ b/bluesky_queueserver/qserver_cli.py
@@ -33,11 +33,15 @@ http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det
 
 class CliClient:
 
-    def __init__(self):
+    def __init__(self, *, address=None):
         # ZeroMQ communication
         self._ctx = zmq.asyncio.Context()
         self._zmq_socket = None
-        self._zmq_server_address = "tcp://localhost:5555"
+
+        if address is None:
+            self._zmq_server_address = "tcp://localhost:5555"
+        else:
+            self._zmq_server_address = address
 
         # The attributes for storing output command and received input
         self._msg_command_out = ""
@@ -153,7 +157,7 @@ def qserver():
     parser.add_argument('--value', '-v', dest="value", action='store', default=None,
                         help="Arguments that are sent with the command. Currently the arguments "
                              "must be represented as a string that contains a python dictionary.")
-    parser.add_argument('--address', '-a', action='store',
+    parser.add_argument('--address', '-a', dest="address", action='store', default=None,
                         help="Address of the server (e.g. 'tcp://localhost:5555', quoted string)")
 
     args = parser.parse_args()
@@ -181,7 +185,7 @@ def qserver():
         command = "ping"
         print("Running QSever monitor. Press Ctrl-C to exit ...")
 
-    re_server = CliClient()
+    re_server = CliClient(address=args.address)
     try:
         while True:
             re_server.set_msg_out(command, value)

--- a/bluesky_queueserver/server.py
+++ b/bluesky_queueserver/server.py
@@ -1,14 +1,13 @@
 from aiohttp import web
-from multiprocessing import Pipe
-import threading
 import asyncio
+import zmq
+import zmq.asyncio
 
-from .worker import RunEngineWorker
-
-from databroker import Broker
 
 import logging
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 db_logger = logging.getLogger("databroker")
 db_logger.setLevel("INFO")
@@ -27,30 +26,24 @@ http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det
 """
 
 
-class RunEngineServer:
+class WebServer:
 
     def __init__(self):
-        self._re_worker = None
-        self._server_conn = None
-        self._worker_conn = None
-
-        self._environment_exists = False
-
-        self._thread_conn = None
-
-        self._queue_plans = []
-
         self._loop = asyncio.get_event_loop()
 
-        self._start_conn_pipes()
-        self._start_conn_thread()
+        # ZeroMQ communication
+        self._ctx = zmq.asyncio.Context()
+        self._zmq_socket = None
+        self._zmq_server_address = "tcp://localhost:5555"
 
-        # Create Databroker instance. This reference is passed to RE Worker process.
-        # The experimental data can later be retrieved from the database.
-        # This subscription mechanism is strictly for the demo, since using reference
-        # to the databroker in several processes may not be a good idea. Here it is assumed
-        # that only one process access Databroker at a time.
-        self._db = Broker.named('temp')
+        # Start communication task
+        self._event_zmq_stop = None
+        self._task_zmq_client_conn = asyncio.ensure_future(self._zmq_start_client_conn())
+
+    def __del__(self):
+        # Cancel the communication task
+        if not self._task_zmq_client_conn.done():
+            self._task_zmq_client_conn.cancel()
 
     def get_loop(self):
         """
@@ -58,154 +51,65 @@ class RunEngineServer:
         """
         return self._loop
 
-    def _start_conn_pipes(self):
-        self._server_conn, self._worker_conn = Pipe()
+    # ==========================================================================
+    #    Functions that support ZeroMQ communications with RE Manager
 
-    def _start_conn_thread(self):
-        self._thread_conn = threading.Thread(target=self._receive_packet_thread,
-                                             name="RE Server Comm",
-                                             daemon=True)
-        self._thread_conn.start()
+    async def _zmq_send(self, msg):
+        await self._zmq_socket.send_json(msg)
 
-    # ======================================================================
-    #   Functions that implement functionality of the server
+    async def _zmq_receive(self):
+        try:
+            msg = await self._zmq_socket.recv_json()
+        except Exception as ex:
+            # TODO: proper error handling for cases when connection is interrupted.
+            # This is primitive error handling to make sure the server doesn't get stuck
+            #   if there is no reply after timeout. The server still needs to be restarted
+            #   if it was disconnected, since there is not mechanism to reestablish
+            #   connection.
+            logger.error(f"ZeroMQ communication failed: {str(ex)}")
+            msg = {}
+        return msg
 
-    def _start_re_worker(self):
-        """
-        Creates worker process.
-        """
-        # Passing reference to Databroker to a different process may be a terrible idea.
-        # This is here strictly for the demo.
-        self._re_worker = RunEngineWorker(conn=self._worker_conn, db=self._db)
-        self._re_worker.start()
+    async def _zmq_communicate(self, msg_out):
+        await self._zmq_send(msg_out)
+        msg_in = await self._zmq_receive()
+        return msg_in
 
-    def _stop_re_worker(self):
-        """
-        Closes Run Engine execution environment (destroys the worker process). Running plan needs
-        to be stopped before the environment can be closed. Separate function could be added that could
-        kill unresponsive process that can not be closed gracefully.
-        """
-        msg = {"type": "command", "value": "quit"}
-        self._server_conn.send(msg)
-        self._re_worker.join()
+    async def _zmq_start_client_conn(self):
+        self._event_zmq_stop = asyncio.Event()
+        self._zmq_socket = self._ctx.socket(zmq.REQ)
+        self._zmq_socket.RCVTIMEO = 2000  # Timeout for 'recv' operation
 
-    def _run_task(self):
-        """
-        Upload the plan to the worker process for execution.
-        Plan in the queue is represented as a dictionary with the keys "name" (plan name),
-        "args" (list of args), "kwargs" (list of kwargs). Only the plan name is mandatory.
-        Names of plans and devices are strings.
-        """
-        if self._queue_plans:
-            logger.info(f"Starting new plan: {len(self._queue_plans)} plans are left in the queue")
-            new_plan = self._queue_plans[0]
+        self._zmq_socket.connect(self._zmq_server_address)
+        logger.info(f"Connected to ZeroMQ server '{self._zmq_server_address}'")
 
-            plan_name = new_plan["name"]
-            args = new_plan["args"] if "args" in new_plan else []
-            kwargs = new_plan["kwargs"] if "kwargs" in new_plan else {}
-
-            msg = {"type": "plan",
-                   "value": {"name": plan_name,
-                             "args": args,
-                             "kwargs": kwargs
-                             }
-                   }
-
-            self._server_conn.send(msg)
-            return True
-        else:
-            logger.info("Queue is empty")
-            return False
-
-    def _pause_run_engine(self, option):
-        """
-        Pause execution of a running plan. Run Engine must be in 'running' state in order for
-        the request to pause to be accepted by RE Worker.
-        """
-        msg = {"type": "command", "value": "pause", "option": option}
-        self._server_conn.send(msg)
-
-    def _continue_run_engine(self, option):
-        """
-        Continue handling of a paused plan.
-        """
-        msg = {"type": "command", "value": "continue", "option": option}
-        self._server_conn.send(msg)
-
-    def _print_db_uids(self):
-        """
-        Prints the UIDs of the scans in 'temp' database. Just for the demo.
-        Not part of future API.
-        """
-        print("\n===================================================================")
-        print("             The contents of 'temp' database.")
-        print("-------------------------------------------------------------------")
-        n_runs = 0
-        for run_id in range(1, 100000):
-            try:
-                hdr = self._db[run_id]
-                uid = hdr.start["uid"]
-                n_runs += 1
-                print(f"Run ID: {run_id}   UID: {uid}")
-            except Exception:
-                break
-        print("-------------------------------------------------------------------")
-        print(f"  Total of {n_runs} runs were found in 'temp' database.")
-        print("===================================================================\n")
-
-    # =======================================================================
-    #   Functions for communication with the worker process
-
-    def _receive_packet_thread(self):
-        while True:
-            if self._server_conn.poll(0.1):
-                try:
-                    msg = self._server_conn.recv()
-                    # Messages should be handled in the event loop
-                    self._loop.call_soon_threadsafe(self._conn_received, msg)
-                except Exception as ex:
-                    logger.error(f"Server: Exception occurred while waiting for packet: {ex}")
-                    break
-
-    def _conn_received(self, msg):
-        type, value = msg["type"], msg["value"]
-
-        if type == "report":
-            completed = value["completed"]
-            success = value["success"]
-            result = value["result"]
-            logger.info(f"Report received from RE Worker:\nsuccess={success}\n{result}\n)")
-            if completed and success:
-                # Executed plan is removed from the queue only after it is successfully completed.
-                # If a plan was not completed or not successful (exception was raised), then
-                # execution of the queue is stopped. It can be restarted later (failed or
-                # interrupted plan will still be in the queue.
-                self._queue_plans.pop(0)
-                self._run_task()
-
-        if type == "acknowledge":
-            status = value["status"]
-            result = value["result"]
-            msg_original = value["msg"]
-            logger.info("Acknownegement received from RE Worker:\n"
-                        f"Status: '{status}'\nResult: '{result}'\nMessage: {msg_original}")
+        # The event must be set somewhere else
+        await self._event_zmq_stop.wait()
 
     # =========================================================================
     #    REST API handlers
+
+    def _create_msg(self, *, command, value=None):
+        return {"command": command, "value": value}
+
+    async def _send_command(self, *, command, value=None):
+        msg_out = self._create_msg(command=command, value=value)
+        msg_in = await self._zmq_communicate(msg_out)
+        return msg_in
 
     async def _hello_handler(self, request):
         """
         May be called to get response from the server. Returns the number of plans in the queue.
         """
-        return web.Response(text=f"Hello, world. "
-                                 f"There are {len(self._queue_plans)} plans enqueed")
+        msg = await self._send_command(command="")
+        return web.json_response(msg)
 
     async def _queue_view_handler(self, request):
         """
         Returns the contents of the current queue.
         """
-        out = {"queue": self._queue_plans}
-        return web.json_response(out)
+        msg = await self._send_command(command="queue_view")
+        return web.json_response(msg)
 
     async def _add_to_queue_handler(self, request):
         """
@@ -213,101 +117,62 @@ class RunEngineServer:
         """
         data = await request.json()
         # TODO: validate inputs!
-        plan = data["plan"]
-        location = data.get("location", len(self._queue_plans))
-        self._queue_plans.insert(location, plan)
-        return web.json_response(data)
+        msg = await self._send_command(command="add_to_queue", value=data)
+        return web.json_response(msg)
 
     async def _pop_from_queue_handler(self, request):
         """
         Pop the last item from back of the queue
         """
-        if self._queue_plans:
-            plan = self._queue_plans.pop()  # Pops from the back of the queue
-            return web.json_response(plan)
-        else:
-            return web.json_response({})  # No items
+        msg = await self._send_command(command="pop_from_queue")
+        return web.json_response(msg)
 
     async def _create_environment_handler(self, request):
         """
         Creates RE environment: creates RE Worker process, starts and configures Run Engine.
         """
-        if not self._environment_exists:
-            self._start_re_worker()
-            self._environment_exists = True
-            success, msg = True, ""
-        else:
-            success, msg = False, "Environment already exists."
-        return web.json_response({"success": success, "msg": msg})
+        msg = await self._send_command(command="create_environment")
+        return web.json_response(msg)
 
     async def _close_environment_handler(self, request):
         """
         Deletes RE environment. In the current 'demo' prototype the environment will be deleted
         only after RE completes the current scan.
         """
-        if self._environment_exists:
-            self._stop_re_worker()
-            self._environment_exists = False
-            success, msg = True, ""
-        else:
-            success, msg = False, "Environment does not exist."
-        return web.json_response({"success": success, "msg": msg})
+        msg = await self._send_command(command="close_environment")
+        return web.json_response(msg)
 
     async def _process_queue_handler(self, request):
         """
         Start execution of the loaded queue. Additional runs can be added to the queue while
         it is executed. If the queue is empty, then nothing will happen.
         """
-        if self._environment_exists:
-            self._run_task()
-            success, msg = True, ""
-        else:
-            success, msg = False, "Environment does not exist. Can not start the task."
-        return web.json_response({"success": success, "msg": msg})
+        msg = await self._send_command(command="process_queue")
+        return web.json_response(msg)
 
     async def _re_pause_handler(self, request):
         """
         Pause Run Engine
         """
         data = await request.json()
-        option = data["option"]
-        available_options = ("deferred", "immediate")
-        if option in available_options:
-            if self._environment_exists:
-                self._pause_run_engine(option)
-                success, msg = True, ""
-            else:
-                success, msg = False, "Environment does not exist. Can not pause Run Engine."
-        else:
-            success, msg = False, f"Option '{option}' is not supported. " \
-                                  f"Available options: {available_options}"
-        return web.json_response({"success": success, "msg": msg})
+        msg = await self._send_command(command="re_pause", value=data)
+        return web.json_response(msg)
 
     async def _re_continue_handler(self, request):
         """
         Control Run Engine in the paused state
         """
         data = await request.json()
-        option = data["option"]
-        available_options = ("resume", "abort", "stop", "halt")
-        if option in available_options:
-            if self._environment_exists:
-                self._continue_run_engine(option)
-                success, msg = True, ""
-            else:
-                success, msg = False, "Environment does not exist. Can not pause Run Engine."
-        else:
-            success, msg = False, f"Option '{option}' is not supported. " \
-                                  f"Available options: {available_options}"
-        return web.json_response({"success": success, "msg": msg})
+        msg = await self._send_command(command="re_continue", value=data)
+        return web.json_response(msg)
 
-    def _print_db_uids_handler(self, request):
+    async def _print_db_uids_handler(self, request):
         """
         Prints the UIDs of the scans in 'temp' database. Just for the demo.
         Not part of future API.
         """
-        self._print_db_uids()
-        return web.json_response({"success": True, "msg": ""})
+        msg = await self._send_command(command="print_db_uids")
+        return web.json_response(msg)
 
     def setup_routes(self, app):
         """
@@ -330,7 +195,7 @@ class RunEngineServer:
 
 
 def init_func(argv):
-    re_server = RunEngineServer()
+    re_server = WebServer()
 
     app = web.Application(loop=re_server.get_loop())
     re_server.setup_routes(app)

--- a/bluesky_queueserver/worker.py
+++ b/bluesky_queueserver/worker.py
@@ -19,6 +19,8 @@ from bluesky.plans import count, scan  # noqa: F401
 
 import logging
 logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 config_bluesky_logging(level='INFO')
 config_ophyd_logging(level='INFO')
@@ -40,7 +42,7 @@ class RunEngineWorker(Process):
 
         super().__init__(name="RE Worker")
 
-        # The end of bidirectional Pipe assigned to the worker (for communication with the server)
+        # The end of bidirectional Pipe assigned to the worker (for communication with Manager process)
         self._conn = conn
 
         self._exit_event = threading.Event()
@@ -111,7 +113,7 @@ class RunEngineWorker(Process):
         plan_kwargs: dict
             plan kwargs
         """
-        logger.info(f"Starting a plan {plan_name}")
+        logger.info(f"Starting a plan '{plan_name}'.")
 
         def ref_from_name(v):
             if isinstance(v, str):
@@ -222,7 +224,7 @@ class RunEngineWorker(Process):
 
         # Execute a plan
         if type == "plan":
-            logger.info("Starting a plan")
+            logger.info("Starting execution of a plan")
             # TODO: refine the criteria of acceptance of the new plan.
             invalid_state = 0
             if not self._execution_queue.empty():

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ with open(path.join(here, 'requirements.txt')) as requirements_file:
     requirements = [line for line in requirements_file.read().splitlines()
                     if not line.startswith('#')]
 
-
 setup(
     name='bluesky-queueserver',
     version=versioneer.get_version(),
@@ -46,7 +45,7 @@ setup(
     packages=find_packages(exclude=['docs', 'tests']),
     entry_points={
         'console_scripts': [
-            # 'command = some.module:some_function',
+            'qserver = bluesky_queueserver.qserver_cli:qserver'
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
Simple CLI tool for communicating with RE Manager. RE Manager can be fully controlled by the CLI tool without starting the Web Server. CLI tool may be used in the request-report mode or in monitoring mode. In monitoring mode a 'ping' request is sent to RE Manager periodically. Currently only the number of elements in the queue is returned in response to the 'ping' command. If RE Manager is stopped while monitor is running, the monitor will try to make periodic requests to the manager and report communication errors until the manager is started again.

The PR is based on the code from PR https://github.com/bluesky/bluesky-queueserver/pull/31.