### PR TITLE
Use `json-rpc` package for communication between RE Manager and Watchdog

### DIFF
--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -1,0 +1,102 @@
+import threading
+import pprint
+import json
+from jsonrpc import JSONRPCResponseManager
+from jsonrpc.dispatcher import Dispatcher
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class PipeJsonRpcReceive:
+    """
+    The class contains functions for receiving and processing JSON RPC messages received on
+    communication pipe.
+
+    Parameters
+    ----------
+    conn: multiprocessing.Connection
+        Reference to bidirectional end of a pipe (multiprocessing.Pipe)
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        conn1, conn2 = multiprocessing.Pipe()
+        pc = PipeJsonRPC(conn=conn1)
+
+        def func():
+            print("Testing")
+
+        pc.add_handler(func, "some_method")
+        pc.start()   # Wait and process commands
+        # The function 'func' is called when the message with method=="some_method" is received
+        pc.stop()  # Stop before exit to stop the thread.
+    """
+    def __init__(self, conn):
+        self._conn = conn
+        self._dispatcher = Dispatcher()  # json-rpc dispatcher
+        self._stop_thread = False  # Set True to exit the thead
+
+    def start(self):
+        """
+        Start processing of the pipe messages
+        """
+        self._start_conn_thread()
+
+    def stop(self):
+        """
+        Stop processing of the pipe messages (and exit the tread)
+        """
+        self._stop_thread = True
+
+    def __del__(self):
+        self.stop()
+
+    def add_method(self, handler, name=None):
+        """
+        Add method to json-rpc dispatcher.
+
+        Parameters
+        ----------
+        handler: callable
+            Reference to a handler handler
+        name: str, optional
+            Name to register (default is the handler name)
+        """
+        # Add method to json-rpc dispatcher
+        self._dispatcher.add_method(handler, name)
+
+    def _start_conn_thread(self):
+        self._thread_conn = threading.Thread(target=self._receive_conn_thread,
+                                             name="RE Watchdog Comm",
+                                             daemon=True)
+        self._thread_conn.start()
+
+    def _receive_conn_thread(self):
+        while True:
+            if self._conn.poll(0.1):
+                try:
+                    msg = self._conn.recv()
+                    # Messages should be handled in the event loop
+                    self._conn_received(msg)
+                except Exception as ex:
+                    logger.exception("Exception occurred while waiting for "
+                                     "RE Manager-> Watchdog message: %s", str(ex))
+                    break
+                if self._stop_thread:  # Exit thread
+                    break
+
+    def _conn_received(self, msg):
+
+        if logger.level < 11:  # Print output only if logging level is DEBUG (10) or less
+            msg_json = json.loads(msg)
+            # We don't want to print 'heartbeat' messages
+            if not isinstance(msg_json, dict) or (msg_json["method"] != "heartbeat"):
+                logger.debug("Command received RE Manager->Watchdog: %s", pprint.pformat(msg_json))
+
+        response = JSONRPCResponseManager.handle(msg, self._dispatcher)
+        if response:
+            response = response.json
+            self._conn.send(response)

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -61,7 +61,7 @@ class PipeJsonRpcReceive:
         Parameters
         ----------
         handler: callable
-            Reference to a handler handler
+            Reference to a handler
         name: str, optional
             Name to register (default is the handler name)
         """

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -37,7 +37,7 @@ class PipeJsonRpcReceive:
     def __init__(self, conn):
         self._conn = conn
         self._dispatcher = Dispatcher()  # json-rpc dispatcher
-        self._stop_thread = False  # Set True to exit the thead
+        self._stop_thread = False  # Set True to exit the thread
 
     def start(self):
         """

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -690,7 +690,7 @@ class RunEngineManager(Process):
 
     async def _watchdog_response(self, response):
         """
-        Set the fututure with the results
+        Set the future with the results
         """
         if self._event_watchdog_comm.is_set():
             self._event_watchdog_comm.clear()  # Clear once the message received

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -107,7 +107,7 @@ class CliClient:
 
         try:
             await self._zmq_open_connection(self._zmq_server_address)
-            logger.info("Connected to ZeroMQ server '%s'" % self._zmq_server_address)
+            logger.info("Connected to ZeroMQ server '%s'", self._zmq_server_address)
             self._msg_in = await self._send_command(command=self._msg_command_out,
                                                     value=self._msg_value_out)
             self._msg_err_in = ""
@@ -118,7 +118,7 @@ class CliClient:
             self._zmq_socket.close()
 
         if self._msg_err_in:
-            logger.warning("Communication with RE Manager failed: %s" % str(self._msg_err_in))
+            logger.warning("Communication with RE Manager failed: %s", str(self._msg_err_in))
 
     async def _send_command(self, *, command, value=None):
         msg_out = self._create_msg(command=command, value=value)

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -1,110 +1,13 @@
 from multiprocessing import Pipe
 import threading
 import time as ttime
-import pprint
-import json
-from jsonrpc import JSONRPCResponseManager
-from jsonrpc.dispatcher import Dispatcher
 
 from .worker import RunEngineWorker
 from .manager import RunEngineManager
+from .comms import PipeJsonRpcReceive
 
 import logging
 logger = logging.getLogger(__name__)
-
-
-class PipeJsonRpcReceive:
-    """
-    The class contains functions for receiving and processing JSON RPC messages received on
-    communication pipe.
-
-    Parameters
-    ----------
-    conn: multiprocessing.Connection
-        Reference to bidirectional end of a pipe (multiprocessing.Pipe)
-
-    Examples
-    --------
-
-    .. code-block:: python
-
-        conn1, conn2 = multiprocessing.Pipe()
-        pc = PipeJsonRPC(conn=conn1)
-
-        def func():
-            print("Testing")
-
-        pc.add_handler(func, "some_method")
-        pc.start()   # Wait and process commands
-        # The function 'func' is called when the message with method=="some_method" is received
-        pc.stop()  # Stop before exit to stop the thread.
-    """
-    def __init__(self, conn):
-        self._conn = conn
-        self._dispatcher = Dispatcher()  # json-rpc dispatcher
-        self._stop_thread = False  # Set True to exit the thead
-
-    def start(self):
-        """
-        Start processing of the pipe messages
-        """
-        self._start_conn_thread()
-
-    def stop(self):
-        """
-        Stop processing of the pipe messages (and exit the tread)
-        """
-        self._stop_thread = True
-
-    def __del__(self):
-        self.stop()
-
-    def add_method(self, handler, name=None):
-        """
-        Add method to json-rpc dispatcher.
-
-        Parameters
-        ----------
-        handler: callable
-            Reference to a handler handler
-        name: str, optional
-            Name to register (default is the handler name)
-        """
-        # Add method to json-rpc dispatcher
-        self._dispatcher.add_method(handler, name)
-
-    def _start_conn_thread(self):
-        self._thread_conn = threading.Thread(target=self._receive_conn_thread,
-                                             name="RE Watchdog Comm",
-                                             daemon=True)
-        self._thread_conn.start()
-
-    def _receive_conn_thread(self):
-        while True:
-            if self._conn.poll(0.1):
-                try:
-                    msg = self._conn.recv()
-                    # Messages should be handled in the event loop
-                    self._conn_received(msg)
-                except Exception as ex:
-                    logger.exception("Exception occurred while waiting for "
-                                     "RE Manager-> Watchdog message: %s", str(ex))
-                    break
-                if self._stop_thread:  # Exit thread
-                    break
-
-    def _conn_received(self, msg):
-
-        if logger.level < 11:  # Print output only if logging level is DEBUG (10) or less
-            msg_json = json.loads(msg)
-            # We don't want to print 'heartbeat' messages
-            if not isinstance(msg_json, dict) or (msg_json["method"] != "heartbeat"):
-                logger.debug("Command received RE Manager->Watchdog: %s", pprint.pformat(msg_json))
-
-        response = JSONRPCResponseManager.handle(msg, self._dispatcher)
-        if response:
-            response = response.json
-            self._conn.send(response)
 
 
 class WatchdogProcess:

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -55,10 +55,11 @@ class WatchdogProcess:
 
     def _conn_received(self, msg):
 
-        # We don't want to print 'heartbeat' messages
-        msg_json = json.loads(msg)
-        if not isinstance(msg_json, dict) or (msg_json["method"] != "heartbeat"):
-            logger.debug("Command received RE Manager->Watchdog: %s", pprint.pformat(msg_json))
+        if logger.level < 11:  # Print output only if logging level is DEBUG (10) or less
+            msg_json = json.loads(msg)
+            # We don't want to print 'heartbeat' messages
+            if not isinstance(msg_json, dict) or (msg_json["method"] != "heartbeat"):
+                logger.debug("Command received RE Manager->Watchdog: %s", pprint.pformat(msg_json))
 
         response = JSONRPCResponseManager.handle(msg, dispatcher)
         if response:

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -13,8 +13,32 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class PipeConnection:
+class PipeJsonRpcReceive:
+    """
+    The class contains functions for receiving and processing JSON RPC messages received on
+    communication pipe.
 
+    Parameters
+    ----------
+    conn: multiprocessing.Connection
+        Reference to bidirectional end of a pipe (multiprocessing.Pipe)
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        conn1, conn2 = multiprocessing.Pipe()
+        pc = PipeJsonRPC(conn=conn1)
+
+        def func():
+            print("Testing")
+
+        pc.add_handler(func, "some_method")
+        pc.start()   # Wait and process commands
+        # The function 'func' is called when the message with method=="some_method" is received
+        pc.stop()  # Stop before exit to stop the thread.
+    """
     def __init__(self, conn):
         self._conn = conn
         self._dispatcher = Dispatcher()  # json-rpc dispatcher
@@ -96,7 +120,7 @@ class WatchdogProcess:
         self._create_conn_pipes()
 
         # Class that supports communication over the pipe
-        self._comm_to_manager = PipeConnection(conn=self._watchdog_to_manager_conn)
+        self._comm_to_manager = PipeJsonRpcReceive(conn=self._watchdog_to_manager_conn)
 
         self._watchdog_state = 0  # State is currently just time since last notification
         self._watchdog_state_lock = threading.Lock()

--- a/bluesky_queueserver/manager/tests/test_general.py
+++ b/bluesky_queueserver/manager/tests/test_general.py
@@ -25,7 +25,7 @@ def re_manager():
         assert False, "RE Manager failed to stop"
 
 
-def tests_qserver_cli_and_manager(re_manager):
+def test_qserver_cli_and_manager(re_manager):
     # TODO: Redis pool should be cleaned before each test. Now it's only one tests,
     #   so it is not important, but cleaning should be implemented.
 

--- a/bluesky_queueserver/manager/tests/test_general.py
+++ b/bluesky_queueserver/manager/tests/test_general.py
@@ -35,18 +35,26 @@ def test_qserver_cli_and_manager(re_manager):
         re_server.set_msg_out(command, value)
         asyncio.run(re_server.zmq_single_request())
         msg, _ = re_server.get_msg_in()
+        if msg is None:
+            raise TimeoutError("Timeout occured while monitoring RE Manager state")
         n_plans, is_plan_running = msg["n_plans"], msg["is_plan_running"]
         return n_plans, is_plan_running
 
     def wait_for_processing_to_finish(time):
-        """Wait until queue is processed"""
-        dt = 1  # Period for checking the queue status
-        n_attempts = int(time/dt)  # Number of attempts
-        for n in range(n_attempts):
+        """
+        Wait until queue is processed. Note: processing of TimeoutError is needed for
+        monitoring RE Manager while it is restarted.
+        """
+        dt = 0.5  # Period for checking the queue status
+        time_stop = ttime.time() + time
+        while ttime.time() < time_stop:
             ttime.sleep(dt/2)
-            n_plans, is_plan_running = get_queue_status()
-            if (n_plans == 0) and not is_plan_running:
-                return True
+            try:
+                n_plans, is_plan_running = get_queue_status()
+                if (n_plans == 0) and not is_plan_running:
+                    return True
+            except TimeoutError:
+                pass
             ttime.sleep(dt/2)
         return False
 
@@ -103,7 +111,22 @@ def test_qserver_cli_and_manager(re_manager):
     assert n_plans == 2, "Incorrect number of plans in the queue"
 
     subprocess.call(["qserver", "-c", "process_queue"])
+    assert wait_for_processing_to_finish(60), "Timeout while waiting for process to finish"
 
+    # Test 'killing' the manager during running plan. Load long plan and two short ones.
+    #   The tests checks if execution of the queue is continued uninterrupted after
+    #   the manager restart
+    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+                     "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}"])
+    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+                     "{'name':'count', 'args':[['det1', 'det2']]}"])
+    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+                     "{'name':'count', 'args':[['det1', 'det2']]}"])
+    n_plans, is_plan_running = get_queue_status()
+    assert n_plans == 3, "Incorrect number of plans in the queue"
+    subprocess.call(["qserver", "-c", "process_queue"])
+    ttime.sleep(1)
+    subprocess.call(["qserver", "-c", "kill_manager"])
     assert wait_for_processing_to_finish(60), "Timeout while waiting for process to finish"
 
     subprocess.call(["qserver", "-c", "close_environment"])

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -70,7 +70,7 @@ class RunEngineWorker(Process):
                     msg = self._conn.recv()
                     self._conn_received(msg)
                 except Exception as ex:
-                    logger.exception("Exception occurred while waiting for packet: %s" % str(ex))
+                    logger.exception("Exception occurred while waiting for packet: %s", str(ex))
                     break
 
     def _execute_plan(self, plan, is_resuming):
@@ -148,7 +148,7 @@ class RunEngineWorker(Process):
         plan_args = plan["args"]
         plan_kwargs = plan["kwargs"]
 
-        logger.info(f"Starting a plan '{plan_name}'.")
+        logger.info("Starting a plan '%s'.", plan_name)
 
         def ref_from_name(v):
             if isinstance(v, str):
@@ -199,7 +199,7 @@ class RunEngineWorker(Process):
             Option on how to proceed with previously paused plan. The values are
             "resume", "abort", "stop", "halt".
         """
-        logger.info(f"Continue plan execution with the option '{option}'")
+        logger.info("Continue plan execution with the option '%s'", option)
 
         available_options = ("resume", "abort", "stop", "halt")
 
@@ -331,7 +331,7 @@ class RunEngineWorker(Process):
                 if self._RE.state == 'paused':
                     try:
                         option = msg["option"]
-                        logger.info(f"Run Engine: {option}")
+                        logger.info("Run Engine: %s", option)
                         self._continue_plan(option)
                         msg_ack["value"]["status"] = "accepted"
                     except Exception as ex:

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -32,10 +32,10 @@ class RunEngineWorker(Process):
     args, kwargs
         `args` and `kwargs` of the `multiprocessing.Process`
     """
-    def __init__(self, *args, conn=None, **kwargs):
+    def __init__(self, *args, conn, **kwargs):
 
-        if conn is None:
-            raise RuntimeError("Parameter 'conn' is not specified or None.")
+        if not conn:
+            raise RuntimeError("Invalid value of parameter 'conn': %S.", str(conn))
 
         super().__init__(*args, **kwargs)
 

--- a/bluesky_queueserver/tests/test_examples.py
+++ b/bluesky_queueserver/tests/test_examples.py
@@ -1,3 +1,0 @@
-def test_one_plus_one_is_two():
-    "Check that one and one are indeed two."
-    assert 1 + 1 == 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ databroker
 ophyd
 pyzmq
 requests
+json-rpc


### PR DESCRIPTION
Changes in this PR:

- Switched to `json-rpc` for communication between RE manager and Watchdog.

- Implemented communication timeout and simplistic handling of the timeout exception. 

- Added test case that involves restart of RE Manager while the plan is running.

- Implemented changes in code style based on requests for the previous PR (e.g. proper formatting of logging messages for better efficiency).