### PR TITLE
Testing for Watchdog module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ install:
   - pip install .
   # Install extra requirements for running tests and building docs.
   - pip install -r requirements-dev.txt
+  - pip install scikit-image
 
 script:
   - coverage run -m pytest  # Run the tests and check for test coverage.

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -14,7 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 class WatchdogProcess:
-    def __init__(self, *, re_env_config=None):
+    def __init__(self, *, re_env_config=None,
+                 cls_run_engine_worker=RunEngineWorker,
+                 cls_run_engine_manager=RunEngineManager):
+
+        self._cls_run_engine_worker = cls_run_engine_worker
+        self._cls_run_engine_manager = cls_run_engine_manager
+
         self._re_manager = None
         self._re_worker = None
 
@@ -32,6 +38,7 @@ class WatchdogProcess:
         self._watchdog_state_lock = threading.Lock()
 
         self._manager_is_stopping = False  # Set True to stop the server
+        self._heartbeat_timeout = 5  # Time to wait before restarting RE Manager
 
         # Configuration of the RE environment (passed to RE Worker)
         self._re_env_config = re_env_config
@@ -52,7 +59,7 @@ class WatchdogProcess:
         """
         logger.info("Starting RE Worker ...")
         try:
-            self._re_worker = RunEngineWorker(
+            self._re_worker = self._cls_run_engine_worker(
                 conn=self._manager_conn, name="RE Worker Process", env_config=self._re_env_config,
             )
             self._re_worker.start()
@@ -112,9 +119,9 @@ class WatchdogProcess:
 
     def _start_re_manager(self):
         self._init_watchdog_state()
-        self._re_manager = RunEngineManager(conn_watchdog=self._manager_to_watchdog_conn,
-                                            conn_worker=self._worker_conn,
-                                            name="RE Manager Process")
+        self._re_manager = self._cls_run_engine_manager(conn_watchdog=self._manager_to_watchdog_conn,
+                                                        conn_worker=self._worker_conn,
+                                                        name="RE Manager Process")
         self._re_manager.start()
 
     def run(self):
@@ -123,9 +130,9 @@ class WatchdogProcess:
         self._comm_to_manager.add_method(self._start_re_worker_handler, "start_re_worker")
         self._comm_to_manager.add_method(self._join_re_worker_handler, "join_re_worker")
         self._comm_to_manager.add_method(self._kill_re_worker_handler, "kill_re_worker")
-        self._comm_to_manager.add_method(self._manager_stopping_handler, "manager_stopping")
-        # Notifications
         self._comm_to_manager.add_method(self._is_worker_alive_handler, "is_worker_alive")
+        # Notifications
+        self._comm_to_manager.add_method(self._manager_stopping_handler, "manager_stopping")
         self._comm_to_manager.add_method(self._register_heartbeat_handler, "heartbeat")
 
         self._comm_to_manager.start()
@@ -144,7 +151,8 @@ class WatchdogProcess:
             # Interval is used to protect the system from restarting in case of clock issues.
             # It may be a better idea to implement a ticker in a separate thread to act as
             #   a clock to be completely independent from system clock.
-            if (time_passed > 5.0) and (time_passed < 15.0) and not self._manager_is_stopping:
+            t_min, t_max = self._heartbeat_timeout, self._heartbeat_timeout + 10.0
+            if (time_passed >= t_min) and (time_passed <= t_max) and not self._manager_is_stopping:
                 logger.error("Timeout detected by Watchdog. RE Manager malfunctioned and must be restarted.")
                 self._re_manager.kill()
                 self._start_re_manager()
@@ -171,6 +179,7 @@ def start_manager():
         config['kafka'] = {}
         config['kafka']['topic'] = args.kafka_topic
         config['kafka']['bootstrap'] = args.kafka_server
+
     wp = WatchdogProcess(re_env_config=config)
     try:
         wp.run()

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -87,6 +87,7 @@ class WatchdogProcess:
         # TODO: kill() or terminate()???
         logger.info("Killing RE Worker ...")
         self._re_worker.kill()
+        self._re_worker.join()  # Not really necessary, but helps with unit testing.
         return {"success": True}
 
     def _is_worker_alive_handler(self):

--- a/bluesky_queueserver/manager/tests/test_comms.py
+++ b/bluesky_queueserver/manager/tests/test_comms.py
@@ -4,6 +4,7 @@ import time as ttime
 import json
 import multiprocessing
 from bluesky_queueserver.manager.comms import PipeJsonRpcReceive
+from bluesky_queueserver.tests.common import format_jsonrpc_msg
 
 
 def test_PipeJsonRpcReceive_1():
@@ -66,23 +67,16 @@ def test_PipeJsonRpcReceive_2(method, params, result, notification):
     pc.add_method(some_class.method_handler4, "method4")
     pc.start()
 
-    request = {"method": method, "jsonrpc": "2.0"}
-    if params:
-        request["params"] = params
-
     for n in range(3):
         value_nonlocal = None
 
-        if not notification:
-            msg_id = random.randint(0, 1000)  # Generate some message ID
-            request["id"] = msg_id
-
+        request = format_jsonrpc_msg(method, params, notification=notification)
         conn1.send(json.dumps(request))
         if conn1.poll(timeout=0.5):  # Set timeout large enough
             if not notification:
                 response = conn1.recv()
                 response = json.loads(response)
-                assert response["id"] == msg_id, "Response ID does not match message ID."
+                assert response["id"] == request["id"], "Response ID does not match message ID."
                 assert "result" in response, \
                     f"Key 'result' is not contained in response: {response}"
                 assert response["result"] == result, \
@@ -120,17 +114,17 @@ def test_PipeJsonRpcReceive_3():
     pc.start()
 
     # Non-existing method ('Method not found' error)
-    request = [{"id": 2, "jsonrpc": "2.0", "method": "method3", "params": {"value": 7}},
-               {"jsonrpc": "2.0", "method": "method4", "params": {"value": 3}},  # Notification
-               {"id": 3, "jsonrpc": "2.0", "method": "method4", "params": {"value": 9}}]
+    request = [format_jsonrpc_msg("method3", {"value": 7}),
+               format_jsonrpc_msg("method4", {"value": 3}, notification=True),
+               format_jsonrpc_msg("method4", {"value": 9})]
     conn1.send(json.dumps(request))
 
     if conn1.poll(timeout=0.5):  # Set timeout large enough
         response = conn1.recv()
         response = json.loads(response)
         assert len(response) == 2, "Unexpected number of response messages"
-        assert response[0]["id"] == 2, "Response ID does not match message ID."
-        assert response[1]["id"] == 3, "Response ID does not match message ID."
+        assert response[0]["id"] == request[0]["id"], "Response ID does not match message ID."
+        assert response[1]["id"] == request[2]["id"], "Response ID does not match message ID."
         assert response[0]["result"] == 22, "Response ID does not match message ID."
         assert response[1]["result"] == 16, "Response ID does not match message ID."
     else:
@@ -153,7 +147,7 @@ def test_PipeJsonRpcReceive_4_failing():
 
     # ------- Incorrect argument (arg list instead of required kwargs) -------
     #   Returns 'Server Error' (-32000)
-    request = {"id": 0, "jsonrpc": "2.0", "method": "method3", "params": [5]}
+    request = format_jsonrpc_msg("method3", [5])
     conn1.send(json.dumps(request))
 
     if conn1.poll(timeout=0.5):  # Set timeout large enough
@@ -165,7 +159,9 @@ def test_PipeJsonRpcReceive_4_failing():
         assert False, "Timeout occurred while waiting for response."
 
     # ------- Incorrect argument (incorrect argument type) -------
-    request = {"id": 1, "jsonrpc": "2.0", "method": "method3", "params": {"value": "abc"}}
+    # 'json-prc' doesn't check parameter types. Instead the handler will crash if the argument
+    #   type is not suitable.
+    request = format_jsonrpc_msg("method3", {"value": "abc"})
     conn1.send(json.dumps(request))
 
     if conn1.poll(timeout=0.5):
@@ -177,7 +173,7 @@ def test_PipeJsonRpcReceive_4_failing():
         assert False, "Timeout occurred while waiting for response."
 
     # ------- Incorrect argument (extra argument) -------
-    request = {"id": 1, "jsonrpc": "2.0", "method": "method3", "params": {"value": 5, "unknown": 10}}
+    request = format_jsonrpc_msg("method3", {"value": 5, "unknown": 10})
     conn1.send(json.dumps(request))
 
     if conn1.poll(timeout=0.5):
@@ -188,7 +184,7 @@ def test_PipeJsonRpcReceive_4_failing():
         assert False, "Timeout occurred while waiting for response."
 
     # ------- Non-existing method ('Method not found' error) -------
-    request = {"id": 1, "jsonrpc": "2.0", "method": "method_handler3", "params": {"value": 5}}
+    request = format_jsonrpc_msg("method_handler3", {"value": 5})
     conn1.send(json.dumps(request))
 
     if conn1.poll(timeout=0.5):
@@ -208,6 +204,8 @@ def test_PipeJsonRpcReceive_5_failing():
     built-in exception processing should be used to process exceptions within handlers.
     It may be better to catch and process all exceptions produced by the custom code and
     leave built-in processing for exceptions that happen while calling the function.
+
+    EXCEPTIONS SHOULD BE PROCESSED INSIDE THE HANDLER!!!
     """
     def method_handler5():
         raise RuntimeError("Function crashed ...")
@@ -217,8 +215,7 @@ def test_PipeJsonRpcReceive_5_failing():
     pc.add_method(method_handler5, "method5")
     pc.start()
 
-    # Non-existing method ('Method not found' error)
-    request = {"id": 2, "jsonrpc": "2.0", "method": "method5"}
+    request = format_jsonrpc_msg("method5")
     conn1.send(json.dumps(request))
 
     if conn1.poll(timeout=0.5):  # Set timeout large enough
@@ -239,7 +236,7 @@ def test_PipeJsonRpcReceive_6_failing():
     Care must be taken to write handles that execute quickly. Timeouts must be handled
     explicitly within the handlers.
 
-    ONLY QUICKLY EXECUTED HANDLERS MAY BE USED!!!
+    ONLY INSTANTLY EXECUTED HANDLERS MAY BE USED!!!
     """
     def method_handler6():
         ttime.sleep(3)  # Longer than 'poll' timeout
@@ -250,7 +247,8 @@ def test_PipeJsonRpcReceive_6_failing():
     pc.start()
 
     # Non-existing method ('Method not found' error)
-    request = {"id": 2, "jsonrpc": "2.0", "method": "method6"}
+    request = format_jsonrpc_msg("method6")
+
     conn1.send(json.dumps(request))
 
     if conn1.poll(timeout=0.5):  # Set timeout large enough

--- a/bluesky_queueserver/manager/tests/test_comms.py
+++ b/bluesky_queueserver/manager/tests/test_comms.py
@@ -1,5 +1,4 @@
 import pytest
-import random
 import time as ttime
 import json
 import multiprocessing

--- a/bluesky_queueserver/manager/tests/test_start_manager.py
+++ b/bluesky_queueserver/manager/tests/test_start_manager.py
@@ -1,0 +1,148 @@
+import threading
+import uuid
+import time as ttime
+import json
+
+from bluesky_queueserver.manager.start_manager import WatchdogProcess
+
+
+def format_jsonrpc_msg(method, params=None, *, notification=False):
+    """Returns dictionary that contains JSON RPC message"""
+    msg = {"method": method, "jsonrpc": "2.0"}
+    if params is not None:
+        msg["params"] = params
+    if not notification:
+        msg["id"] = uuid.uuid4()
+    return msg
+
+
+class ReManagerEmulation(threading.Thread):
+    """
+    Emulation of RE Manager, which is using Thread instead of Process.
+    The functionality of the emulator is to test if Watchdog can start
+    and restart RE Manager properly. The emulator also generates periodic
+    'heartbeat' messages to inform RE Manager that it is running.
+    """
+
+    def __init__(self, *args, conn_watchdog, conn_worker, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._conn_watchdog = conn_watchdog
+        self._n_loops = 0
+        self._exit = False
+        self._restart = False
+        self._send_heartbeat = True
+
+    def _heartbeat(self):
+        hb_period, dt = 0.5, 0.01
+        n_wait = round(hb_period / dt)
+        msg = format_jsonrpc_msg("heartbeat", {"value": "alive"}, notification=True)
+        msg_json = json.dumps(msg)
+        while True:
+            # Since we are emulating 'kill' method, we want the function to
+            #   react to 'exit' quickly.
+            for n in range(n_wait):
+                ttime.sleep(0.005)
+                if self._exit:
+                    return
+            if self._send_heartbeat:
+                self._conn_watchdog.send(msg_json)
+
+    def exit(self, *, restart=False):
+        """
+        Stop the emulated RE Manager (exit the 'run' method). Set 'restart=True'
+        to skip informing Watchdog that the exit is intentional: Watchdog is expected
+        to restart the process.
+        """
+        self._restart = restart
+        self._exit = True
+
+    def kill(self):
+        """
+        This is emulation of 'kill' method of mp.Process. The method just normally
+        exists the current process.
+        """
+        self.exit(restart=True)
+
+    def stop_heartbeat(self):
+        """
+        Heatbeat generator may be stopped to emulate 'freezing' of the event loop of RE Manager.
+        """
+        self._send_heartbeat = False
+
+    def run(self):
+        th_hb = threading.Thread(target=self._heartbeat)
+        th_hb.start()
+
+        while not self._exit:
+            ttime.sleep(0.01)
+            self._n_loops += 1
+
+        if not self._restart:
+            msg = format_jsonrpc_msg("manager_stopping", notification=True)
+            self._conn_watchdog.send(json.dumps(msg))
+
+        th_hb.join()
+
+
+def test_WatchdogProcess_1():
+    """Test starting and orderly existing the RE Manager"""
+    wp = WatchdogProcess(cls_run_engine_manager=ReManagerEmulation)
+    wp_th = threading.Thread(target=wp.run)
+    wp_th.start()
+    ttime.sleep(1)  # Let RE Manager run 1 second
+    assert wp._re_manager._n_loops > 0, "RE is not running"
+    wp._re_manager.exit(restart=False)
+    ttime.sleep(0.05)
+    assert wp._manager_is_stopping is True, "'Manager Stopping' flag is not set"
+    wp_th.join(0.1)
+
+
+def test_WatchdogProcess_2():
+    """Test starting RE Manager, stopping heartbeat generator
+    and waiting for restart of RE Manager"""
+    wp = WatchdogProcess(cls_run_engine_manager=ReManagerEmulation)
+    wp_th = threading.Thread(target=wp.run)
+    wp_th.start()
+    ttime.sleep(1)  # Let RE Manager run 1 second
+    assert wp._re_manager._n_loops > 0, "RE is not running"
+    n_loops = wp._re_manager._n_loops
+
+    wp._re_manager.stop_heartbeat()
+    hb_timeout = wp._heartbeat_timeout
+    ttime.sleep(hb_timeout + 0.5)
+    # At this point RE Manager is expected to run for 0.5 second, so
+    #   the new number of loops must be about 'n_loops/2'.
+    #   Here we check if RE Manager was really restarted and the number of
+    #   loops reset.
+    assert wp._re_manager._n_loops < n_loops, "Unexpected number of loops"
+
+    wp._re_manager.exit(restart=False)
+    ttime.sleep(0.05)
+    assert wp._manager_is_stopping is True, "'Manager Stopping' flag is not set"
+    wp_th.join(0.1)
+
+
+def test_WatchdogProcess_3():
+    """Test starting RE Manager, exiting without sending notification and
+    and waiting for the restart of RE Manager"""
+    wp = WatchdogProcess(cls_run_engine_manager=ReManagerEmulation)
+    wp_th = threading.Thread(target=wp.run)
+    wp_th.start()
+    ttime.sleep(1)  # Let RE Manager run 1 second
+    assert wp._re_manager._n_loops > 0, "RE is not running"
+    n_loops = wp._re_manager._n_loops
+
+    # Stop RE Manager without notifying the Watchdog (emulates crashing of RE Manager)
+    wp._re_manager.exit(restart=True)
+    hb_timeout = wp._heartbeat_timeout
+    ttime.sleep(hb_timeout + 0.5)
+    # At this point RE Manager is expected to run for 0.5 second, so
+    #   the new number of loops must be about 'n_loops/2'.
+    #   Here we check if RE Manager was really restarted and the number of
+    #   loops reset.
+    assert wp._re_manager._n_loops < n_loops, "Unexpected number of loops"
+
+    wp._re_manager.exit(restart=False)
+    ttime.sleep(0.05)
+    assert wp._manager_is_stopping is True, "'Manager Stopping' flag is not set"
+    wp_th.join(0.1)

--- a/bluesky_queueserver/manager/tests/test_start_manager.py
+++ b/bluesky_queueserver/manager/tests/test_start_manager.py
@@ -1,5 +1,4 @@
 import threading
-import uuid
 import time as ttime
 import json
 

--- a/bluesky_queueserver/manager/tests/test_start_manager.py
+++ b/bluesky_queueserver/manager/tests/test_start_manager.py
@@ -4,16 +4,7 @@ import time as ttime
 import json
 
 from bluesky_queueserver.manager.start_manager import WatchdogProcess
-
-
-def format_jsonrpc_msg(method, params=None, *, notification=False):
-    """Returns dictionary that contains JSON RPC message"""
-    msg = {"method": method, "jsonrpc": "2.0"}
-    if params is not None:
-        msg["params"] = params
-    if not notification:
-        msg["id"] = uuid.uuid4()
-    return msg
+from bluesky_queueserver.tests.common import format_jsonrpc_msg
 
 
 class ReManagerEmulation(threading.Thread):
@@ -27,10 +18,11 @@ class ReManagerEmulation(threading.Thread):
     def __init__(self, *args, conn_watchdog, conn_worker, **kwargs):
         super().__init__(*args, **kwargs)
         self._conn_watchdog = conn_watchdog
-        self._n_loops = 0
+        self.n_loops = 0
         self._exit = False
         self._restart = False
         self._send_heartbeat = True
+        self._lock = threading.Lock()
 
     def _heartbeat(self):
         hb_period, dt = 0.5, 0.01
@@ -45,7 +37,8 @@ class ReManagerEmulation(threading.Thread):
                 if self._exit:
                     return
             if self._send_heartbeat:
-                self._conn_watchdog.send(msg_json)
+                with self._lock:
+                    self._conn_watchdog.send(msg_json)
 
     def exit(self, *, restart=False):
         """
@@ -63,6 +56,22 @@ class ReManagerEmulation(threading.Thread):
         """
         self.exit(restart=True)
 
+    def send_msg_to_watchdog(self, method, params=None, *, notification=False, timeout=0.5):
+        # The function may block all communication for the period of 'timeout', but
+        #   this is acceptable for testing. Timeout would typically indicate an error.
+        msg = format_jsonrpc_msg(method, params, notification=notification)
+        with self._lock:
+            self._conn_watchdog.send(json.dumps(msg))
+            if notification:
+                return
+            if self._conn_watchdog.poll(timeout):
+                response_json = self._conn_watchdog.recv()
+                response = json.loads(response_json)
+                result = response["result"]
+            else:
+                result = None
+        return result
+
     def stop_heartbeat(self):
         """
         Heatbeat generator may be stopped to emulate 'freezing' of the event loop of RE Manager.
@@ -75,13 +84,33 @@ class ReManagerEmulation(threading.Thread):
 
         while not self._exit:
             ttime.sleep(0.01)
-            self._n_loops += 1
+            self.n_loops += 1
 
         if not self._restart:
             msg = format_jsonrpc_msg("manager_stopping", notification=True)
-            self._conn_watchdog.send(json.dumps(msg))
+            with self._lock:
+                self._conn_watchdog.send(json.dumps(msg))
 
         th_hb.join()
+
+
+class ReWorkerEmulation(threading.Thread):
+    def __init__(self, *args, conn, env_config=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._env_config = env_config or {}
+        self._exit = False
+        self.n_loops = 0
+
+    def exit(self):
+        self._exit = True
+
+    def kill(self):
+        self.exit()
+
+    def run(self):
+        while not self._exit:
+            ttime.sleep(0.005)
+            self.n_loops += 1
 
 
 def test_WatchdogProcess_1():
@@ -90,7 +119,7 @@ def test_WatchdogProcess_1():
     wp_th = threading.Thread(target=wp.run)
     wp_th.start()
     ttime.sleep(1)  # Let RE Manager run 1 second
-    assert wp._re_manager._n_loops > 0, "RE is not running"
+    assert wp._re_manager.n_loops > 0, "RE is not running"
     wp._re_manager.exit(restart=False)
     ttime.sleep(0.05)
     assert wp._manager_is_stopping is True, "'Manager Stopping' flag is not set"
@@ -104,8 +133,8 @@ def test_WatchdogProcess_2():
     wp_th = threading.Thread(target=wp.run)
     wp_th.start()
     ttime.sleep(1)  # Let RE Manager run 1 second
-    assert wp._re_manager._n_loops > 0, "RE is not running"
-    n_loops = wp._re_manager._n_loops
+    assert wp._re_manager.n_loops > 0, "RE is not running"
+    n_loops = wp._re_manager.n_loops
 
     wp._re_manager.stop_heartbeat()
     hb_timeout = wp._heartbeat_timeout
@@ -114,7 +143,7 @@ def test_WatchdogProcess_2():
     #   the new number of loops must be about 'n_loops/2'.
     #   Here we check if RE Manager was really restarted and the number of
     #   loops reset.
-    assert wp._re_manager._n_loops < n_loops, "Unexpected number of loops"
+    assert wp._re_manager.n_loops < n_loops, "Unexpected number of loops"
 
     wp._re_manager.exit(restart=False)
     ttime.sleep(0.05)
@@ -129,8 +158,8 @@ def test_WatchdogProcess_3():
     wp_th = threading.Thread(target=wp.run)
     wp_th.start()
     ttime.sleep(1)  # Let RE Manager run 1 second
-    assert wp._re_manager._n_loops > 0, "RE is not running"
-    n_loops = wp._re_manager._n_loops
+    assert wp._re_manager.n_loops > 0, "RE is not running"
+    n_loops = wp._re_manager.n_loops
 
     # Stop RE Manager without notifying the Watchdog (emulates crashing of RE Manager)
     wp._re_manager.exit(restart=True)
@@ -140,9 +169,114 @@ def test_WatchdogProcess_3():
     #   the new number of loops must be about 'n_loops/2'.
     #   Here we check if RE Manager was really restarted and the number of
     #   loops reset.
-    assert wp._re_manager._n_loops < n_loops, "Unexpected number of loops"
+    assert wp._re_manager.n_loops < n_loops, "Unexpected number of loops"
 
     wp._re_manager.exit(restart=False)
     ttime.sleep(0.05)
     assert wp._manager_is_stopping is True, "'Manager Stopping' flag is not set"
+    wp_th.join(0.1)
+
+
+def test_WatchdogProcess_4():
+    """
+    Test if Watchdog correctly executing commands that control starting
+    and stopping RE Worker.
+    """
+    wp = WatchdogProcess(cls_run_engine_manager=ReManagerEmulation,
+                         cls_run_engine_worker=ReWorkerEmulation)
+    wp_th = threading.Thread(target=wp.run)
+    wp_th.start()
+    ttime.sleep(0.01)
+
+    response = wp._re_manager.send_msg_to_watchdog("start_re_worker")
+    assert response["success"] is True, "Unexpected response from RE Manager"
+
+    # Worker is expected to be alive
+    response = wp._re_manager.send_msg_to_watchdog("is_worker_alive")
+    assert response["worker_alive"] is True, "Unexpected response from RE Manager"
+
+    # Join running process (thread). Expected to timeout.
+    # Note: here timeout should be set to be smaller than timeout for the message
+    #   in 'send_msg_to_watchdog method.
+    response = wp._re_manager.send_msg_to_watchdog("join_re_worker", {"timeout": 0.1})
+    assert response["success"] is False, "Unexpected response from RE Manager"
+
+    # Worker is expected to be alive
+    response = wp._re_manager.send_msg_to_watchdog("is_worker_alive")
+    assert response["worker_alive"] is True, "Unexpected response from RE Manager"
+
+    # Exit the process (thread).
+    wp._re_worker.exit()
+    ttime.sleep(0.01)
+
+    # Worker is expected to be stopped
+    response = wp._re_manager.send_msg_to_watchdog("is_worker_alive")
+    assert response["worker_alive"] is False, "Unexpected response from RE Manager"
+
+    response = wp._re_manager.send_msg_to_watchdog("join_re_worker", {"timeout": 0.5})
+    assert response["success"] is True, "Unexpected response from RE Manager"
+
+    wp._re_manager.exit(restart=False)
+    wp_th.join(0.1)
+
+
+def test_WatchdogProcess_5():
+    """
+    Test 'kill_re_worker' command RE Worker.
+    """
+    wp = WatchdogProcess(cls_run_engine_manager=ReManagerEmulation,
+                         cls_run_engine_worker=ReWorkerEmulation)
+    wp_th = threading.Thread(target=wp.run)
+    wp_th.start()
+    ttime.sleep(0.01)
+
+    response = wp._re_manager.send_msg_to_watchdog("start_re_worker")
+    assert response["success"] is True, "Unexpected response from RE Manager"
+
+    # Worker is expected to be alive
+    response = wp._re_manager.send_msg_to_watchdog("is_worker_alive")
+    assert response["worker_alive"] is True, "Unexpected response from RE Manager"
+
+    # Kill RE Worker process (emulated, since RE Worker is a thread)
+    response = wp._re_manager.send_msg_to_watchdog("kill_re_worker")
+    assert response["success"] is True, "Unexpected response from RE Manager"
+
+    # Worker is expected to be stopped
+    response = wp._re_manager.send_msg_to_watchdog("is_worker_alive")
+    assert response["worker_alive"] is False, "Unexpected response from RE Manager"
+
+    response = wp._re_manager.send_msg_to_watchdog("join_re_worker", {"timeout": 0.5})
+    assert response["success"] is True, "Unexpected response from RE Manager"
+
+    wp._re_manager.exit(restart=False)
+    wp_th.join(0.1)
+
+
+def test_WatchdogProcess_6():
+    """
+    Test if RE configuration is passed to RE Worker
+    """
+    config = {"some_parameter": "some_value"}
+
+    wp = WatchdogProcess(re_env_config=config,
+                         cls_run_engine_manager=ReManagerEmulation,
+                         cls_run_engine_worker=ReWorkerEmulation)
+    wp_th = threading.Thread(target=wp.run)
+    wp_th.start()
+    ttime.sleep(0.01)
+
+    response = wp._re_manager.send_msg_to_watchdog("start_re_worker")
+    assert response["success"] is True, "Unexpected response from RE Manager"
+
+    # Check if configuration was set correctly in RE Worker
+    assert wp._re_worker._env_config == config, "Configuration was not passed correctly"
+
+    # Exit the process (thread).
+    wp._re_worker.exit()
+    ttime.sleep(0.01)
+
+    response = wp._re_manager.send_msg_to_watchdog("join_re_worker", {"timeout": 0.5})
+    assert response["success"] is True, "Unexpected response from RE Manager"
+
+    wp._re_manager.exit(restart=False)
     wp_th.join(0.1)

--- a/bluesky_queueserver/tests/common.py
+++ b/bluesky_queueserver/tests/common.py
@@ -1,0 +1,22 @@
+import uuid
+
+
+def format_jsonrpc_msg(method, params=None, *, notification=False):
+    """
+    Returns dictionary that contains JSON RPC message.
+
+    Parameters
+    ----------
+    method: str
+        Method name
+    params: dict or list, optional
+        List of args or dictionary of kwargs.
+    notification: boolean
+        If the message is notification, no response will be expected.
+    """
+    msg = {"method": method, "jsonrpc": "2.0"}
+    if params is not None:
+        msg["params"] = params
+    if not notification:
+        msg["id"] = str(uuid.uuid4())
+    return msg


### PR DESCRIPTION
Some more tests. Covered functionality of Watchdog module. Changed `WatchdogProcess.__init__ ()` so that it now accepts classes for RE Manager and RE Worker as parameters. It makes the design modular (any custom classes can be passed as parameters). This also makes testing much easier, since classes that emulate RE Manager and RE Worker APIs and run in threads may be used instead of the real ones that run as separate processes.  

The PR should be safe to merge.