### PR TITLE
Loading of simulated beamline profiles.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,10 @@ install:
   # Install extra requirements for running tests and building docs.
   - pip install -r requirements-dev.txt
   - pip install scikit-image
+  - pip list
 
 script:
-  - coverage run -m pytest  # Run the tests and check for test coverage.
+  - coverage run -m pytest -v  # Run the tests and check for test coverage.
   - coverage report -m  # Generate test coverage report.
   - set -e
   - if [ BUILD_DOCS == 'true' ]; then

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2,6 +2,7 @@ import os
 import glob
 import runpy
 from collections.abc import Iterable
+import pkg_resources
 
 import ophyd
 
@@ -11,11 +12,7 @@ def get_default_profile_collection_dir():
     Returns the path to the default profile collection that is distributed with the package.
     The function does not guarantee that the directory exists.
     """
-    pc_path = os.path.realpath(__file__)
-    pc_path = pc_path[:-1] if pc_path[-1] in "/\\" else pc_path  # Remove slash/backslash from the end
-    pc_path = os.path.split(pc_path)[0]  # Remove file name
-    pc_path = os.path.split(pc_path)[0]  # Remove bottom dir name
-    pc_path = os.path.join(pc_path, "profile_collection_sim")
+    pc_path = pkg_resources.resource_filename('bluesky_queueserver', 'profile_collection_sim/')
     return pc_path
 
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -1,0 +1,85 @@
+import os
+import glob
+import runpy
+
+import ophyd
+
+
+def load_profile_collection(path):
+    """
+    Load profile collection located at the specified path. The collection consists of
+    .py files started with 'DD-', where D is a digit (e.g. 05-file.py). The files
+    are alphabetically sorted before execution.
+
+    Parameters
+    ----------
+    path: str
+        path to profile collection
+
+    Returns
+    -------
+    nspace: dict
+        namespace in which the profile collection was executed
+    """
+
+    # Create the list of files to load
+    path = os.path.expanduser(path)
+    path = os.path.abspath(path)
+
+    if not os.path.exists(path):
+        raise IOError(f"Path '{path}' does not exist.")
+    if not os.path.isdir(path):
+        raise IOError(f"Failed to load the profile collection. Path '{path}' is not a directory.")
+
+    file_pattern = os.path.join(path, "[0-9][0-9]*.py")
+    file_list = glob.glob(file_pattern)
+    file_list.sort()  # Sort in alphabetical order
+
+    # Load the files into the namespace 'nspace'.
+    nspace = None
+    for file in file_list:
+        nspace = runpy.run_path(file, nspace)
+
+    return nspace
+
+
+def plans_from_nspace(nspace):
+    """
+    Extract plans from the namespace. Currently the function returns the dict of callable objects.
+
+    Parameters
+    ----------
+    nspace: dict
+        Namespace that may contain plans.
+
+    Returns
+    -------
+    dict(str: callable)
+        Dictionary of Bluesky plans
+    """
+    plans = {}
+    for item in nspace.items():
+        if callable(item[1]):
+            plans[item[0]] = item[1]
+    return plans
+
+
+def devices_from_nspace(nspace):
+    """
+    Extract devices from the namespace. Currently the function returns the dict of ophyd.Device objects.
+
+    Parameters
+    ----------
+    nspace: dict
+        Namespace that may contain plans.
+
+    Returns
+    -------
+    dict(str: callable)
+        Dictionary of devices.
+    """
+    devices = {}
+    for item in nspace.items():
+        if isinstance(item[1], ophyd.Device):
+            devices[item[0]] = item[1]
+    return devices

--- a/bluesky_queueserver/manager/tests/test_general.py
+++ b/bluesky_queueserver/manager/tests/test_general.py
@@ -11,7 +11,8 @@ def re_manager():
     """
     Start RE Manager as a subprocess. Tests will communicate with RE Manager via ZeroMQ.
     """
-    p = subprocess.Popen(["start-re-manager"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(["start-re-manager"], universal_newlines=True,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     yield  # Nothing to return
 

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -1,0 +1,88 @@
+import os
+import pytest
+
+import ophyd
+
+from bluesky_queueserver.manager.profile_ops import \
+    (get_default_profile_collection_dir, load_profile_collection, plans_from_nspace,
+     devices_from_nspace, parse_plan)
+
+
+def test_get_default_profile_collection_dir():
+    """
+    Function `get_default_profile_collection_dir`
+    """
+    pc_path = get_default_profile_collection_dir()
+    assert os.path.exists(pc_path), "Directory with default profile collection deos not exist."
+
+
+def test_load_profile_collection_1():
+    """
+    Loading default profile collection
+    """
+    pc_path = get_default_profile_collection_dir()
+    nspace = load_profile_collection(pc_path)
+    assert len(nspace) > 0, "Failed to load the profile collection"
+
+
+def test_load_profile_collection_2_fail(tmp_path):
+    """
+    Failing cases
+    """
+    # Non-existing path
+    pc_path = os.path.join(tmp_path, "abc")
+    with pytest.raises(IOError, match="Path .+ does not exist"):
+        load_profile_collection(pc_path)
+
+    pc_path = os.path.join(tmp_path, "test.txt")
+    # Create a file
+    with open(pc_path, "w"):
+        pass
+    with pytest.raises(IOError, match="Path .+ is not a directory"):
+        load_profile_collection(pc_path)
+
+
+def test_plans_from_nspace():
+    """
+    Function 'plans_from_nspace' is extracting a subset of callable items from the namespace
+    """
+    pc_path = get_default_profile_collection_dir()
+    nspace = load_profile_collection(pc_path)
+    plans = plans_from_nspace(nspace)
+    for name, plan in plans.items():
+        assert callable(plan), f"Plan '{name}' is not callable"
+
+
+def test_devices_from_nspace():
+    """
+    Function 'plans_from_nspace' is extracting a subset of callable items from the namespace
+    """
+    pc_path = get_default_profile_collection_dir()
+    nspace = load_profile_collection(pc_path)
+    devices = devices_from_nspace(nspace)
+    for name, device in devices.items():
+        assert isinstance(device, ophyd.Device), f"The object '{device}' is not an Ophyd device"
+
+
+@pytest.mark.parametrize("plan, success, err_msg", [
+    ({"name": "count", "args": [["det1", "det2"]]}, True, ""),
+    ({"name": "scan", "args": [["det1", "det2"], "motor", -1, 1, 10]}, True, ""),
+    ({"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 10, "delay": 1}}, True, ""),
+    ({"name": "countABC", "args": [["det1", "det2"]]}, False,
+     "Plan 'countABC' is not allowed or does not exist."),
+])
+def test_parse_plan(plan, success, err_msg):
+
+    pc_path = get_default_profile_collection_dir()
+    nspace = load_profile_collection(pc_path)
+    plans = plans_from_nspace(nspace)
+    devices = devices_from_nspace(nspace)
+
+    if success:
+        plan_parsed = parse_plan(plan, allowed_plans=plans, allowed_devices=devices)
+        expected_keys = ("name", "args", "kwargs")
+        for k in expected_keys:
+            assert k in plan_parsed, f"Key '{k}' does not exist: {plan_parsed.keys()}"
+    else:
+        with pytest.raises(RuntimeError, match=err_msg):
+            parse_plan(plan, allowed_plans=plans, allowed_devices=devices)

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 import asyncio
 from functools import partial
 import logging
+import os
 
 import msgpack
 import msgpack_numpy as mpn
@@ -16,11 +17,9 @@ from bluesky.run_engine import get_bluesky_event_loop
 from bluesky.callbacks.best_effort import BestEffortCallback
 from databroker import Broker
 
-# The following plans/devices must be imported (otherwise plan parsing wouldn't work)
-from ophyd.sim import det1, det2, motor  # noqa: F401
-from bluesky.plans import count, scan  # noqa: F401
 from bluesky_kafka import Publisher as kafkaPublisher
 
+from .profile_ops import load_profile_collection, plans_from_nspace, devices_from_nspace
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +62,8 @@ class RunEngineWorker(Process):
 
         self._db = DB[0]
         self._env_config = env_config or {}
+
+        self._re_namespace, self._allowed_plans, self._allowed_devices = {}, {}, {}
 
     def _receive_packet_thread(self):
         """
@@ -157,25 +158,30 @@ class RunEngineWorker(Process):
 
         logger.info("Starting a plan '%s'.", plan_name)
 
-        def ref_from_name(v):
+        def ref_from_name(v, allowed_items):
             if isinstance(v, str):
-                try:
-                    v = globals()[v]
-                except KeyError:
-                    pass
+                if v in allowed_items:
+                    v = allowed_items[v]
             return v
 
-        # The following is some primitive parsing of the plan that replaces names
-        #   with references. No error handling is implemented, so it is better if
-        #   the submitted plans contain no errors.
-        plan_func = ref_from_name(plan_name)
-        plan_args_parsed = []
-        for arg in plan_args:
-            if isinstance(arg, Iterable) and not isinstance(arg, str):
-                arg_parsed = [ref_from_name(_) for _ in arg]
-            else:
-                arg_parsed = ref_from_name(arg)
-            plan_args_parsed.append(arg_parsed)
+        def process_argument(v, allowed_items):
+            if isinstance(v, str):
+                v = ref_from_name(v, allowed_items)
+            elif isinstance(v, dict):
+                for key, value in v.copy().items():
+                    v[key] = process_argument(value, allowed_items)
+            elif isinstance(v, Iterable):
+                v_original = v
+                v = list()
+                for item in v_original:
+                    v.append(process_argument(item, allowed_items))
+            return v
+
+        # TODO: should we allow plan names as arguments
+        allowed_items = self._allowed_devices
+        plan_func = process_argument(plan_name, self._allowed_plans)
+        plan_args_parsed = process_argument(plan_args, allowed_items)
+        plan_kwargs_parsed = process_argument(plan_kwargs, allowed_items)
 
         # We are not parsing 'kwargs' at this time
         def get_plan(plan_func, plan_args, plan_kwargs):
@@ -191,7 +197,7 @@ class RunEngineWorker(Process):
                 return result
             return plan
 
-        plan = get_plan(plan_func, plan_args_parsed, plan_kwargs)
+        plan = get_plan(plan_func, plan_args_parsed, plan_kwargs_parsed)
         # 'is_resuming' is true (we start a new plan that is supposedly runs to completion
         #   as opposed to aborting/stopping/halting a plan)
         self._execution_queue.put((plan, True))
@@ -388,6 +394,19 @@ class RunEngineWorker(Process):
         # Setting the default event loop is needed to make the code work with Python 3.8.
         loop = get_bluesky_event_loop()
         asyncio.set_event_loop(loop)
+
+        # Load profile collection
+        # TODO: error processing while reading the profile collection
+        #   - failed to load the profile collection
+        path = os.path.realpath(__file__)
+        path = path[:-1] if path[-1] in "/\\" else path  # Remove slash/backslash from the end
+        path = os.path.split(path)[0]  # Remove file name
+        path = os.path.split(path)[0]  # Remove bottom dir name
+        path = os.path.join(path, "profile_collection_sim")
+        logger.info(f"Loading beamline profiles located at '%s'", path)
+        self._re_namespace = load_profile_collection(path)
+        self._allowed_plans = plans_from_nspace(self._re_namespace)
+        self._allowed_devices = devices_from_nspace(self._re_namespace)
 
         self._RE = RunEngine({})
 

--- a/bluesky_queueserver/profile_collection_sim/00-ophyd.py
+++ b/bluesky_queueserver/profile_collection_sim/00-ophyd.py
@@ -4,3 +4,4 @@ from ophyd.sim import hw
 
 # Import ALL simulated Ophyd objects in global namespace (borrowed from ophyd.sim)
 globals().update(hw().__dict__)
+del hw

--- a/bluesky_queueserver/profile_collection_sim/00-ophyd.py
+++ b/bluesky_queueserver/profile_collection_sim/00-ophyd.py
@@ -1,0 +1,6 @@
+# flake8: noqa
+
+from ophyd.sim import hw
+
+# Import ALL simulated Ophyd objects in global namespace (borrowed from ophyd.sim)
+globals().update(hw().__dict__)

--- a/bluesky_queueserver/profile_collection_sim/15-plans.py
+++ b/bluesky_queueserver/profile_collection_sim/15-plans.py
@@ -1,0 +1,9 @@
+# flake8: noqa
+
+from bluesky.plans import (count, list_scan, rel_list_scan, list_grid_scan,
+                           rel_list_grid_scan, log_scan, rel_log_scan, adaptive_scan,
+                           rel_adaptive_scan, tune_centroid, scan_nd, inner_product_scan,
+                           scan, grid_scan, rel_grid_scan, relative_inner_product_scan,
+                           rel_scan, tweak, spiral_fermat, rel_spiral_fermat, spiral,
+                           rel_spiral, spiral_square, rel_spiral_square,
+                           ramp_plan, fly, x2x_scan)

--- a/bluesky_queueserver/profile_collection_sim/99-custom.py
+++ b/bluesky_queueserver/profile_collection_sim/99-custom.py
@@ -1,0 +1,6 @@
+# flake8: noqa
+
+def move_then_count():
+    "Move motor1 and motor2 into position; then count det."
+    yield from mv(motor1, 1, motor2, 10)
+    yield from count([det1, det2])

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     include_package_data=True,
     package_data={
         'bluesky_queueserver': [
+            'profile_collection_sim/*'
             # When adding files here, remember to update MANIFEST.in as well,
             # or else they will not be included in the distribution on PyPI!
             # 'path/to/data_file',


### PR DESCRIPTION
Simulated beamline profiles are loaded from the directory specified with command-line option `-p` (use `-h`) to see all available options. If the option is not specified, then the 'default' profile collection is loaded. The 'default' profile collection loads all standard simulated Ophyd devices and standard Bluesky plans and intended to be used for testing and evaluation. Parsing of plans is performed from the namespace that contains the loaded devices and plans. The parser is also rewritten for better flexibility. 

Parsing is still performed before the plan is executed. In case a plan can not be parsed, the plan is substituted for a function that will raise exception in the same thread that is supposed to execute the plan. The error message is used to generate the report sent to the manager. In case of error, RE manager stops execution of the queue and leaves the plan which caused a problem at the beginning of the queue. There is no option to remove a plan from the beginning of the queue right now, so the only option right now is to clear the queue completely and load new plans to the queue. 