### PR TITLE
Basic client for async communication using 'json-rpc' package.

### DIFF
--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -116,8 +116,8 @@ class PipeJsonRpcReceive:
                     logger.exception("Exception occurred while waiting for "
                                      "RE Manager-> Watchdog message: %s", str(ex))
                     break
-                if not self._thread_running:  # Exit thread
-                    break
+            if not self._thread_running:  # Exit thread
+                break
 
     def _conn_received(self, msg):
 
@@ -271,5 +271,5 @@ class PipeJsonRpcSendAsync:
                 except Exception as ex:
                     logger.exception("Exception occurred while waiting for packet: %s", str(ex))
                     break
-                if not self._thread_running:  # Exit thread
-                    break
+            if not self._thread_running:  # Exit thread
+                break

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -20,13 +20,52 @@ class CommTimeoutError(TimeoutError):
 class CommJsonRpcError(RuntimeError):
     """
     Raised when returned json-rpc message contains error
+
+    Parameters
+    ----------
+    message: str
+        Error message
+    error_code: int
+        Error code (returned by `json-rpc`)
+    error_type: str
+        Error type (returned by `json-rpc` or set to `'CommJsonRpcError'`)
     """
-    # TODO: probably '__str__' and '__repr__' should be overloaded. Expand unit tests
-    #       to include other errors.
-    def __init__(self, message, code, type):
+    def __init__(self, message, error_code, error_type):
         super().__init__(message)
-        self.code = code
-        self.type = type
+        # TODO: change 'code' and 'type' to read-only properties
+        self.__error_code__ = error_code
+        self.__error_type__ = error_type
+
+    @property
+    def error_code(self):
+        return self.__error_code__
+
+    @error_code.setter
+    def error_code(self, error_code):
+        raise RuntimeError("Attempt to set read-only attribute 'error_code'")
+
+    @property
+    def error_type(self):
+        return self.__error_type__
+
+    @error_type.setter
+    def error_type(self, error_type):
+        raise RuntimeError("Attempt to set read-only attribute 'error_type'")
+
+    @property
+    def message(self):
+        return super().__str__()
+
+    @message.setter
+    def message(self, message):
+        raise RuntimeError("Attempt to set read-only attribute 'message'")
+
+    def __str__(self):
+        msg = super().__str__() + f"\nError code: {self.error_code}. Error type: {self.error_type}"
+        return msg
+
+    def __repr__(self):
+        return f"CommJsonRpcError('{self.message}',{self.error_code},'{self.error_type}')"
 
 
 def format_jsonrpc_msg(method, params=None, *, notification=False):
@@ -322,7 +361,7 @@ class PipeJsonRpcSendAsync:
                             # Other json-rpc errors
                             err_type = "CommJsonRpcError"
                             err_msg = response["error"]["message"]
-                        raise CommJsonRpcError(err_msg, code=err_code, type=err_type)
+                        raise CommJsonRpcError(err_msg, error_code=err_code, error_type=err_type)
                     else:
                         err_msg = f"Message {pprint.pformat(msg)}\n" \
                                   f"resulted in response with unknown format: {pprint.pformat(response)}"

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -332,15 +332,13 @@ class PipeJsonRpcSendAsync:
         async with self._lock_comm:
             msg = format_jsonrpc_msg(method, params, notification=notification)
             try:
-                if not notification:
-                    self._fut_comm = self._loop.create_future()
-
                 msg_json = json.dumps(msg)
                 self._conn.send(msg_json)
 
                 # No response is expected if this is a notification
                 if not notification:
                     self._expected_msg_id = msg["id"]
+                    self._fut_comm = self._loop.create_future()
                     # Waiting for the future may raise 'asyncio.TimeoutError'
                     await asyncio.wait_for(self._fut_comm, timeout=timeout)
                     response = self._fut_comm.result()

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -243,7 +243,7 @@ class PipeJsonRpcSendAsync:
     """
     def __init__(self, conn, *, timeout=0.5, name="RE QServer Comm"):
         self._conn = conn
-        self._loop = self._loop = asyncio.get_running_loop()
+        self._loop = asyncio.get_running_loop()
 
         self._thread_name = name
 

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -156,7 +156,9 @@ class PipeJsonRpcSendAsync:
     """
     The class contains functions for supporting asyncio-based client for JSON RPC comminucation
     using interprocess communication pipe. The class object must be created on the loop (from one of
-    `async` functions).
+    `async` functions). This implementation allows calls only to one method at a time. Multiple
+    `send_msg` requests may be put on the loop, but the next message is never sent before
+    the response to the previous message is received or timeout occurred.
 
     Parameters
     ----------

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -356,7 +356,9 @@ class PipeJsonRpcSendAsync:
                         if "data" in response["error"]:
                             # Server Error (issue with execution of the method)
                             err_type = response["error"]["data"]["type"]
-                            err_msg = response["error"]["data"]["message"]
+                            # Message: "Server error: <message text>"
+                            err_msg = response["error"]["message"] + ": " + \
+                                response["error"]["data"]["message"]
                         else:
                             # Other json-rpc errors
                             err_type = "CommJsonRpcError"

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -1,11 +1,34 @@
 import threading
 import pprint
 import json
+import asyncio
+import uuid
 from jsonrpc import JSONRPCResponseManager
 from jsonrpc.dispatcher import Dispatcher
 
 import logging
 logger = logging.getLogger(__name__)
+
+
+def format_jsonrpc_msg(method, params=None, *, notification=False):
+    """
+    Returns dictionary that contains JSON RPC message.
+
+    Parameters
+    ----------
+    method: str
+        Method name
+    params: dict or list, optional
+        List of args or dictionary of kwargs.
+    notification: boolean
+        If the message is notification, no response will be expected.
+    """
+    msg = {"method": method, "jsonrpc": "2.0"}
+    if params is not None:
+        msg["params"] = params
+    if not notification:
+        msg["id"] = str(uuid.uuid4())
+    return msg
 
 
 class PipeJsonRpcReceive:
@@ -17,6 +40,8 @@ class PipeJsonRpcReceive:
     ----------
     conn: multiprocessing.Connection
         Reference to bidirectional end of a pipe (multiprocessing.Pipe)
+    name: str
+        Name of the receiving thread (it is better to assign meaningful unique names to threads.
 
     Examples
     --------
@@ -24,7 +49,7 @@ class PipeJsonRpcReceive:
     .. code-block:: python
 
         conn1, conn2 = multiprocessing.Pipe()
-        pc = PipeJsonRPC(conn=conn1)
+        pc = PipeJsonRPC(conn=conn1, name="RE QServer Receive")
 
         def func():
             print("Testing")
@@ -34,10 +59,12 @@ class PipeJsonRpcReceive:
         # The function 'func' is called when the message with method=="some_method" is received
         pc.stop()  # Stop before exit to stop the thread.
     """
-    def __init__(self, conn):
+    def __init__(self, conn, *, name="RE QServer Comm",):
         self._conn = conn
         self._dispatcher = Dispatcher()  # json-rpc dispatcher
-        self._stop_thread = False  # Set True to exit the thread
+        self._stop_thread = True  # Set True to exit the thread
+
+        self._thread_name = name
 
         self._conn_polling_timeout = 0.1  # in sec.
 
@@ -71,8 +98,9 @@ class PipeJsonRpcReceive:
         self._dispatcher.add_method(handler, name)
 
     def _start_conn_thread(self):
+        self._stop_thread = False
         self._thread_conn = threading.Thread(target=self._receive_conn_thread,
-                                             name="RE Watchdog Comm",
+                                             name=self._thread_name,
                                              daemon=True)
         self._thread_conn.start()
 
@@ -102,3 +130,142 @@ class PipeJsonRpcReceive:
         if response:
             response = response.json
             self._conn.send(response)
+
+
+class PipeJsonRpcSendAsync:
+    """
+    The class contains functions for supporting asyncio-based client for JSON RPC comminucation
+    using interprocess communication pipe. The class object must be created on the loop (from one of
+    `async` functions).
+
+    Parameters
+    ----------
+    conn: multiprocessing.Connection
+        Reference to bidirectional end of a pipe (multiprocessing.Pipe)
+    timeout: float
+        Default value of timeout: maximum time to wait for response after a message is sent
+    name: str
+        Name of the receiving thread (it is better to assign meaningful unique names to threads.
+    loop: asyncio loop
+        Running loop to execute async functions.
+    """
+    def __init__(self, conn, *, timeout=0.5, name="RE QServer Comm", loop=None):
+        self._conn = conn
+        if loop is None:
+            self._loop = self._loop = asyncio.get_running_loop()
+        else:
+            self._loop = loop
+
+        self._thread_name = name
+
+        self._fut_comm = None  # Future for waiting for messages from watchdog
+        self._event_comm = asyncio.Event()  # Event which is set when message is expected from watchdog
+        # Lock that prevents sending of the next message before response
+        #   to the previous message is received.
+        self._lock_comm = asyncio.Lock()
+        self._timeout_comm = timeout  # Timeout (time to wait for response to a message)
+
+        # Polling timeout for the pipe. The data will be read from the pipe instantly once it is available.
+        #   The timeout determines how long it would take to stop the thread when needed.
+        self._pipe_polling_timeout = 0.1
+
+        self._stop_thread = True  # Set True to exit the thread
+
+        # Expected ID of the received message. The ID must be the same as the ID of the sent message.
+        #   Ignore all message that don't have matching ID or no ID.
+        self._expected_msg_id = None
+
+    def start(self):
+        """
+        Start processing of the pipe messages
+        """
+        self._start_conn_thread()
+
+    def stop(self):
+        """
+        Stop processing of the pipe messages (and exit the tread)
+        """
+        self._stop_thread = True
+
+    def __del__(self):
+        self.stop()
+
+    def _start_conn_thread(self):
+        # Start 'receive' thread
+        self._stop_thread = False
+        self._pipe_receive_thread = threading.Thread(target=self._pipe_receive,
+                                                     name=self._thread_name,
+                                                     daemon=True)
+        self._pipe_receive_thread.start()
+
+    async def send_msg(self, method, params=None, *, notification=False, timeout=None):
+        """
+        The function will raise `asyncio.TimeoutError` in case of communication timeout
+        """
+        # The lock protects from sending the next message
+        #   before response to the previous message is received.
+
+        if timeout is None:
+            timeout = self._timeout_comm
+
+        async with self._lock_comm:
+            msg = format_jsonrpc_msg(method, params, notification=notification)
+            try:
+                if not notification:
+                    self._fut_comm = self._loop.create_future()
+                    self._event_comm.set()  # We don't expect response if this is not a notification
+
+                msg_json = json.dumps(msg)
+                self._conn.send(msg_json)
+
+                # No response is expected if this is a notification
+                if not notification:
+                    self._expected_msg_id = msg["id"]
+                    # Waiting for the future may raise 'asyncio.TimeoutError'
+                    await asyncio.wait_for(self._fut_comm,
+                                           timeout=timeout)
+                    response = self._fut_comm.result()
+                else:
+                    response = None
+                return response
+
+            finally:
+                self._event_comm.clear()  # Clear before the exit as well
+
+    async def _response_received(self, response):
+        """
+        Set the future with the results. Ignore all messages with unexpected or missing IDs.
+        """
+        if self._event_comm.is_set():
+            if "id" in response:
+                if response["id"] != self._expected_msg_id["id"]:
+                    # Incorrect ID: ignore the message.
+                    logger.error("Response Watchdog->RE Manager contains incorrect ID: %s. Expected %s.\n"
+                                 "Message: %s",
+                                 response["id"], self._expected_msg_id["id"], pprint.pformat(response))
+                else:
+                    # Accept the message. Otherwise wait for timeout
+                    self._event_comm.clear()  # Clear once the message received
+                    self._fut_comm.set_result(response)
+            else:
+                # Missing ID: ignore the message
+                logger.error("Response Watchdog->RE Manager contains no id: %s", pprint.pformat(response))
+        else:
+            logger.error("Unsolicited message received Watchdog->Re Manager: %s. Message is ignored",
+                         pprint.pformat(response))
+
+    def _conn_received(self, response):
+        asyncio.create_task(self._response_received(response))
+
+    def _pipe_receive(self):
+        while True:
+            if self._conn.poll(self._pipe_polling_timeout):
+                try:
+                    msg_json = self._conn.recv()
+                    msg = json.loads(msg_json)
+                    logger.debug("Message Watchdog->Manager received: '%s'", pprint.pformat(msg))
+                    # Messages should be handled in the event loop
+                    self._loop.call_soon_threadsafe(self._conn_received, msg)
+                except Exception as ex:
+                    logger.exception("Exception occurred while waiting for packet: %s", str(ex))
+                    break

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -168,15 +168,43 @@ class PipeJsonRpcSendAsync:
         Default value of timeout: maximum time to wait for response after a message is sent
     name: str
         Name of the receiving thread (it is better to assign meaningful unique names to threads.
-    loop: asyncio loop
-        Running loop to execute async functions.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        conn1, conn2 = multiprocessing.Pipe()
+
+        async def send_messages():
+            # Must be instantiated and used within the loop
+            p_send = PipeJsonRpcSendAsync(conn=conn1, name="comm-client")
+            p_send.start()
+
+            method = "method_name"
+            params = {"value": 10}   #   or list of args [10, 25]
+            response = await p_send.send_msg(method, params, notification=notification)
+
+            p_send.stop()
+
+        asyncio.run(send_messages())
+        pc.stop()
+
+
+        pc = PipeJsonRpcSendAsync(conn=conn1, name="RE QServer Receive")
+
+        def func():
+            print("Testing")
+
+        pc.add_handler(func, "some_method")
+        pc.start()   # Wait and process commands
+        # The function 'func' is called when the message with method=="some_method" is received
+        pc.stop()  # Stop before exit to stop the thread.
+
     """
-    def __init__(self, conn, *, timeout=0.5, name="RE QServer Comm", loop=None):
+    def __init__(self, conn, *, timeout=0.5, name="RE QServer Comm"):
         self._conn = conn
-        if loop is None:
-            self._loop = self._loop = asyncio.get_running_loop()
-        else:
-            self._loop = loop
+        self._loop = self._loop = asyncio.get_running_loop()
 
         self._thread_name = name
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -10,7 +10,7 @@ import pprint
 import uuid
 
 from .worker import DB
-from .comms import PipeJsonRpcSendAsync
+from .comms import PipeJsonRpcSendAsync, CommTimeoutError
 
 import logging
 
@@ -630,9 +630,10 @@ class RunEngineManager(Process):
         """
         try:
             response = await self._comm_to_watchdog.send_msg("start_re_worker")
-            success = response["result"]["success"]
-        except asyncio.TimeoutError:
+            success = response["success"]
+        except CommTimeoutError:
             success = False
+        # TODO: add processing of CommJsonRpcError and RuntimeError to all handlers !!!
         return success
 
     async def _watchdog_join_re_worker(self, timeout_join=0.5):
@@ -642,8 +643,8 @@ class RunEngineManager(Process):
         """
         try:
             response = await self._comm_to_watchdog.send_msg("join_re_worker", {"timeout": timeout_join})
-            success = response["result"]["success"]
-        except asyncio.TimeoutError:
+            success = response["success"]
+        except CommTimeoutError:
             success = False
         return success
 
@@ -653,8 +654,8 @@ class RunEngineManager(Process):
         """
         try:
             response = await self._comm_to_watchdog.send_msg("kill_re_worker")
-            success = response["result"]["success"]
-        except asyncio.TimeoutError:
+            success = response["success"]
+        except CommTimeoutError:
             success = False
         return success
 
@@ -664,7 +665,7 @@ class RunEngineManager(Process):
         """
         try:
             response = await self._comm_to_watchdog.send_msg("is_worker_alive")
-            worker_alive = response["result"]["worker_alive"]
+            worker_alive = response["worker_alive"]
         except asyncio.TimeoutError:
             worker_alive = False
         return worker_alive

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -548,8 +548,7 @@ class RunEngineManager(Process):
         self._loop = asyncio.get_running_loop()
 
         self._comm_to_watchdog = PipeJsonRpcSendAsync(conn=self._watchdog_conn,
-                                                      name="RE Manager-Watchdog Comm",
-                                                      loop=self._loop)
+                                                      name="RE Manager-Watchdog Comm")
         self._comm_to_watchdog.start()
 
         self._start_conn_threads()

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -10,6 +10,7 @@ import pprint
 import uuid
 
 from .worker import DB
+from .comms import PipeJsonRpcSendAsync
 
 import logging
 
@@ -62,7 +63,6 @@ class RunEngineManager(Process):
 
         # Threads must be started in the 'run' function so that they run in the correct process.
         self._thread_conn_worker = None
-        self._thread_conn_watchdog = None
 
         self._loop = None
 
@@ -79,18 +79,11 @@ class RunEngineManager(Process):
         self._event_worker_closed = None
         self._fut_worker_status = None
 
-        self._fut_watchdog_comm = None  # Future for waiting for messages from watchdog
-        self._event_watchdog_comm = None  # Event which is set when message is expected from watchdog
-        # Lock that prevents sending of the next message before response
-        #   to the previous message is received
-        self._lock_watchdog_comm = None
-        self._timeout_watchdog_comm = 0.5  # Timeout (time to wait for response to a message)
+        # The object of PipeJsonRpcSendAsync. Communciation with Watchdog module.
+        #    The object must be created on the loop.
+        self._comm_to_watchdog = None
 
     def _start_conn_threads(self):
-        self._thread_conn_watchdog = threading.Thread(target=self._receive_packet_watchdog_thread,
-                                                      name="RE QServer Comm1",
-                                                      daemon=True)
-        self._thread_conn_watchdog.start()
         self._thread_conn_worker = threading.Thread(target=self._receive_packet_worker_thread,
                                                     name="RE QServer Comm2",
                                                     daemon=True)
@@ -152,7 +145,7 @@ class RunEngineManager(Process):
         self._event_worker_created = asyncio.Event()
 
         try:
-            success = await self._watchdog_start_re_worker(timeout=0.5)
+            success = await self._watchdog_start_re_worker()
             if not success:
                 raise RuntimeError("Failed to create Worker process")
             logger.debug("Waiting for RE worker to start ...")
@@ -181,7 +174,7 @@ class RunEngineManager(Process):
             await self._event_worker_closed.wait()
             logger.debug("RE Worker to closed")
 
-            if not await self._watchdog_join_re_worker(timeout=0.5):
+            if not await self._watchdog_join_re_worker(timeout_join=0.5):
                 success = False
                 # TODO: this error should probably be handled differently than this,
                 #   since it may indicate that the worker process is stalled.
@@ -283,20 +276,6 @@ class RunEngineManager(Process):
 
     # ================================================================================
     #         Functions for communication with the worker process (via Pipe)
-
-    def _receive_packet_watchdog_thread(self):
-        while True:
-            if self._watchdog_conn.poll(0.1):
-                try:
-                    msg_json = self._watchdog_conn.recv()
-                    msg = json.loads(msg_json)
-                    logger.debug("Message Watchdog->Manager received: '%s'", pprint.pformat(msg))
-                    # Messages should be handled in the event loop
-                    self._loop.call_soon_threadsafe(self._conn_watchdog_received, msg)
-                except Exception as ex:
-                    logger.exception("Exception occurred while waiting for packet: %s", str(ex))
-                    break
-
     def _receive_packet_worker_thread(self):
         while True:
             if self._worker_conn.poll(0.1):
@@ -368,9 +347,6 @@ class RunEngineManager(Process):
                     await self._worker_status_received(value)
 
         asyncio.create_task(process_message(msg))
-
-    def _conn_watchdog_received(self, response):
-        asyncio.create_task(self._watchdog_response(response))
 
     # =========================================================================
     #                        ZMQ message handlers
@@ -571,9 +547,12 @@ class RunEngineManager(Process):
 
         self._loop = asyncio.get_running_loop()
 
+        self._comm_to_watchdog = PipeJsonRpcSendAsync(conn=self._watchdog_conn,
+                                                      name="RE Manager-Watchdog Comm",
+                                                      loop=self._loop)
+        self._comm_to_watchdog.start()
+
         self._start_conn_threads()
-        self._event_watchdog_comm = asyncio.Event()  # Create the event on the loop
-        self._lock_watchdog_comm = asyncio.Lock()
 
         # Start heartbeat generator
         self._heartbeat_generator_task = asyncio.ensure_future(self._heartbeat_generator(), loop=self._loop)
@@ -636,91 +615,33 @@ class RunEngineManager(Process):
             if self._manager_stopping:
                 await self._stop_re_worker()  # Quitting RE Manager
                 await self._watchdog_manager_stopping()
+                self._comm_to_watchdog.close()
                 self._zmq_socket.close()
                 logger.info("RE Manager was stopped by ZMQ command.")
                 break
 
-    # ======================================================================
-    #            Support of communication with Watchdog process
-
-    async def _watchdog_send(self, method, notification=False, **kwargs):
-        """
-        The function will raise `asyncio.TimeoutError` in case of communication timeout
-        """
-        # The lock protects from sending the next message
-        #   before response to the previous message is received.
-        async with self._lock_watchdog_comm:
-            msg = {"method": method, "jsonrpc": "2.0"}
-
-            # Don't include parameters if there are none
-            if kwargs:
-                msg["params"] = kwargs
-
-            # Don't include 'id' if this is notification
-            if not notification:
-                msg["id"] = str(uuid.uuid4())
-
-            try:
-                if not notification:
-                    self._fut_watchdog_comm = self._loop.create_future()
-                    self._event_watchdog_comm.set()  # We don't expect response if this is not a notification
-
-                msg_json = json.dumps(msg)
-                self._watchdog_conn.send(msg_json)
-
-                # No response is expected if this is a notification
-                if not notification:
-                    # Waiting for the future may raise 'asyncio.TimeoutError'
-                    await asyncio.wait_for(self._fut_watchdog_comm,
-                                           timeout=self._timeout_watchdog_comm)
-                    response = self._fut_watchdog_comm.result()
-                    if "id" in response:
-                        if response["id"] != msg["id"]:
-                            logger.error("Response Watchdog->RE Manager contains incorrect ID: %s. Expected %s",
-                                         response["id"], msg["id"])
-                        del response["id"]
-                    else:
-                        logger.error("Response Watchdog->RE Manager contains no id: %s", pprint.pformat(response))
-                else:
-                    response = None
-                return response
-
-            finally:
-                self._event_watchdog_comm.clear()  # Clear before the exit as well
-
-    async def _watchdog_response(self, response):
-        """
-        Set the future with the results
-        """
-        if self._event_watchdog_comm.is_set():
-            self._event_watchdog_comm.clear()  # Clear once the message received
-            self._fut_watchdog_comm.set_result(response)
-        else:
-            logger.error("Unsolicited message received Watchdog->Re Manager: %s. Message is ignored",
-                         pprint.pformat(response))
-
     # ===============================================================================
     #         Functions that send commands/request data from Watchdog process
 
-    async def _watchdog_start_re_worker(self, timeout=0.5):
+    async def _watchdog_start_re_worker(self):
         """
         Initiate the startup of the RE Worker. Returned 'success==True' means that the process
         was created successfully and RE environment initialization is started.
         """
         try:
-            response = await self._watchdog_send("start_re_worker")
+            response = await self._comm_to_watchdog.send_msg("start_re_worker")
             success = response["result"]["success"]
         except asyncio.TimeoutError:
             success = False
         return success
 
-    async def _watchdog_join_re_worker(self, timeout=0.5):
+    async def _watchdog_join_re_worker(self, timeout_join=0.5):
         """
         Request Watchdog to join RE Worker process. The sequence of orderly closing of the process
         needs to be initiated before attempting to join the process.
         """
         try:
-            response = await self._watchdog_send("join_re_worker", timeout=timeout)
+            response = await self._comm_to_watchdog.send_msg("join_re_worker", {"timeout": timeout_join})
             success = response["result"]["success"]
         except asyncio.TimeoutError:
             success = False
@@ -731,7 +652,7 @@ class RunEngineManager(Process):
         Request Watchdog to kill RE Worker process (justified only if the process is not responsive).
         """
         try:
-            response = await self._watchdog_send("kill_re_worker")
+            response = await self._comm_to_watchdog.send_msg("kill_re_worker")
             success = response["result"]["success"]
         except asyncio.TimeoutError:
             success = False
@@ -742,7 +663,7 @@ class RunEngineManager(Process):
         Check if RE Worker process is alive.
         """
         try:
-            response = await self._watchdog_send("is_worker_alive")
+            response = await self._comm_to_watchdog.send_msg("is_worker_alive")
             worker_alive = response["result"]["worker_alive"]
         except asyncio.TimeoutError:
             worker_alive = False
@@ -753,14 +674,15 @@ class RunEngineManager(Process):
         Inform Watchdog process that the manager is intentionally being stopped and
         it should not be restarted.
         """
-        await self._watchdog_send("manager_stopping", notification=True)
+        await self._comm_to_watchdog.send_msg("manager_stopping", notification=True)
 
     async def _watchdog_send_heartbeat(self):
         """
         Send (periodic) heartbeat signal to Watchdog.
         """
-        await self._watchdog_send("heartbeat", notification=True,
-                                  value="alive")
+        await self._comm_to_watchdog.send_msg("heartbeat",
+                                              {"value": "alive"},
+                                              notification=True)
 
     # ======================================================================
 

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -34,7 +34,8 @@ class WatchdogProcess:
         self._create_conn_pipes()
 
         # Class that supports communication over the pipe
-        self._comm_to_manager = PipeJsonRpcReceive(conn=self._watchdog_to_manager_conn)
+        self._comm_to_manager = PipeJsonRpcReceive(conn=self._watchdog_to_manager_conn,
+                                                   name="RE Watchdog-Manager Comm")
 
         self._watchdog_state = 0  # State is currently just time since last notification
         self._watchdog_state_lock = threading.Lock()

--- a/bluesky_queueserver/manager/tests/test_comms.py
+++ b/bluesky_queueserver/manager/tests/test_comms.py
@@ -21,6 +21,52 @@ def count_threads_with_name(name):
 
 
 # =======================================================================
+#                       Class CommJsonRpcError
+
+def test_CommJsonRpcError_1():
+    """
+    Basic test for `CommJsonRpcError` class.
+    """
+    err_msg, err_code, err_type = "Some error occured", 25, "RuntimeError"
+    ex = CommJsonRpcError(err_msg, err_code, err_type)
+
+    assert ex.message == err_msg, "Message set incorrectly"
+    assert ex.error_code == err_code, "Error code set incorrectly"
+    assert ex.error_type == err_type, "Error type set incorrectly"
+
+
+def test_CommJsonRpcError_2():
+    """
+    Basic test for `CommJsonRpcError` class.
+    """
+    err_msg, err_code, err_type = "Some error occured", 25, "RuntimeError"
+    ex = CommJsonRpcError(err_msg, err_code, err_type)
+
+    s = str(ex)
+    assert err_msg in s, "Error message is not found in printed error message"
+    assert str(err_code) in s, "Error code is not found in printed error message"
+    assert err_type in s, "Error type is not found in printed error message"
+
+    repr = f"CommJsonRpcError('{err_msg}',{err_code},'{err_type}')"
+    assert ex.__repr__() == repr, "Error representation is printed incorrectly"
+
+
+def test_CommJsonRpcError_3_fail():
+    """
+    `CommJsonRpcError` class. Failing cases
+    """
+    err_msg, err_code, err_type = "Some error occured", 25, "RuntimeError"
+    ex = CommJsonRpcError(err_msg, err_code, err_type)
+
+    with pytest.raises(RuntimeError, match="Attempt to set read-only attribute"):
+        ex.message = err_msg
+    with pytest.raises(RuntimeError, match="Attempt to set read-only attribute"):
+        ex.error_code = err_code
+    with pytest.raises(RuntimeError, match="Attempt to set read-only attribute"):
+        ex.error_type = err_type
+
+
+# =======================================================================
 #                       Class PipeJsonRpcReceive
 
 def test_PipeJsonRpcReceive_1():


### PR DESCRIPTION
Implementation of basic async client that sends messages and processes responses using 'json-rpc' package. The features include timeout and basic handling of `json-rpc` errors. The functionality of the client is covered by unit tests.

The client is currently used for communication between RE Manager and Watchdog modules on the side of RE Manager. One of the next steps will be to convert communication between RE Manager and RE Worker to `json-rpc` using this client.