### PR TITLE
FastAPI web server

### DIFF
--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -1,6 +1,7 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from enum import Enum
 
-from aiohttp import web
+# from aiohttp import web
 import asyncio
 import zmq
 import zmq.asyncio
@@ -20,25 +21,19 @@ http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "de
 http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
 """
 
-app = FastAPI()
 
-class WebServer:
-
-    def __init__(self, *args, **kwargs):
+class ZMQ_Comm:
+    def __init__(self, zmq_host='localhost', zmq_port='5555'):
         self._loop = asyncio.get_event_loop()
 
         # ZeroMQ communication
         self._ctx = zmq.asyncio.Context()
         self._zmq_socket = None
-        self._zmq_server_address = "tcp://localhost:5555"
+        self._zmq_server_address = f"tcp://{zmq_host}:{zmq_port}"
 
         # Start communication task
         self._event_zmq_stop = None
         self._task_zmq_client_conn = asyncio.ensure_future(self._zmq_start_client_conn())
-
-    def __call__(self, *args, **kwargs):
-        print(args)
-        print(kwargs)
 
     def __del__(self):
         # Cancel the communication task
@@ -86,9 +81,6 @@ class WebServer:
         # The event must be set somewhere else
         await self._event_zmq_stop.wait()
 
-    # =========================================================================
-    #    REST API handlers
-
     def _create_msg(self, *, command, value=None):
         return {"command": command, "value": value}
 
@@ -97,139 +89,222 @@ class WebServer:
         msg_in = await self._zmq_communicate(msg_out)
         return msg_in
 
-    async def _hello_handler(self):
-        """
-        May be called to get response from the server. Returns the number of plans in the queue.
-        """
-        msg = await self._send_command(command="")
-        return web.json_response(msg)
+    # =========================================================================
+    #    REST API handlers
 
-    async def _queue_view_handler(self):
-        """
-        Returns the contents of the current queue.
-        """
-        msg = await self._send_command(command="queue_view")
-        return web.json_response(msg)
+    # async def _hello_handler(self):
+    #     """
+    #     May be called to get response from the server. Returns the number of plans in the queue.
+    #     """
+    #     msg = await self._send_command(command="")
+    #     return web.json_response(msg)
 
-    async def _add_to_queue_handler(self, request):
-        """
-        Adds new plan to the end of the queue
-        """
-        data = await request.json()
-        # TODO: validate inputs!
-        msg = await self._send_command(command="add_to_queue", value=data)
-        return web.json_response(msg)
+    # async def _queue_view_handler(self):
+    #     """
+    #     Returns the contents of the current queue.
+    #     """
+    #     msg = await self._send_command(command="queue_view")
+    #     return web.json_response(msg)
 
-    async def _pop_from_queue_handler(self, request):
-        """
-        Pop the last item from back of the queue
-        """
-        msg = await self._send_command(command="pop_from_queue")
-        return web.json_response(msg)
+    # async def _add_to_queue_handler(self, request):
+    #     """
+    #     Adds new plan to the end of the queue
+    #     """
+    #     data = await request.json()
+    #     # TODO: validate inputs!
+    #     msg = await self._send_command(command="add_to_queue", value=data)
+    #     return web.json_response(msg)
 
-    async def _create_environment_handler(self, request):
-        """
-        Creates RE environment: creates RE Worker process, starts and configures Run Engine.
-        """
-        msg = await self._send_command(command="create_environment")
-        return web.json_response(msg)
+    # async def _pop_from_queue_handler(self, request):
+    #     """
+    #     Pop the last item from back of the queue
+    #     """
+    #     msg = await self._send_command(command="pop_from_queue")
+    #     return web.json_response(msg)
 
-    async def _close_environment_handler(self, request):
-        """
-        Deletes RE environment. In the current 'demo' prototype the environment will be deleted
-        only after RE completes the current scan.
-        """
-        msg = await self._send_command(command="close_environment")
-        return web.json_response(msg)
+    # async def _create_environment_handler(self, request):
+    #     """
+    #     Creates RE environment: creates RE Worker process, starts and configures Run Engine.
+    #     """
+    #     msg = await self._send_command(command="create_environment")
+    #     return web.json_response(msg)
 
-    async def _process_queue_handler(self, request):
-        """
-        Start execution of the loaded queue. Additional runs can be added to the queue while
-        it is executed. If the queue is empty, then nothing will happen.
-        """
-        msg = await self._send_command(command="process_queue")
-        return web.json_response(msg)
+    # async def _close_environment_handler(self, request):
+    #     """
+    #     Deletes RE environment. In the current 'demo' prototype the environment will be deleted
+    #     only after RE completes the current scan.
+    #     """
+    #     msg = await self._send_command(command="close_environment")
+    #     return web.json_response(msg)
 
-    async def _re_pause_handler(self, request):
-        """
-        Pause Run Engine
-        """
-        data = await request.json()
-        msg = await self._send_command(command="re_pause", value=data)
-        return web.json_response(msg)
+    # async def _process_queue_handler(self, request):
+    #     """
+    #     Start execution of the loaded queue. Additional runs can be added to the queue while
+    #     it is executed. If the queue is empty, then nothing will happen.
+    #     """
+    #     msg = await self._send_command(command="process_queue")
+    #     return web.json_response(msg)
 
-    async def _re_continue_handler(self, request):
-        """
-        Control Run Engine in the paused state
-        """
-        data = await request.json()
-        msg = await self._send_command(command="re_continue", value=data)
-        return web.json_response(msg)
+    # async def _re_pause_handler(self, request):
+    #     """
+    #     Pause Run Engine
+    #     """
+    #     data = await request.json()
+    #     msg = await self._send_command(command="re_pause", value=data)
+    #     return web.json_response(msg)
 
-    async def _print_db_uids_handler(self, request):
-        """
-        Prints the UIDs of the scans in 'temp' database. Just for the demo.
-        Not part of future API.
-        """
-        msg = await self._send_command(command="print_db_uids")
-        return web.json_response(msg)
+    # async def _re_continue_handler(self, request):
+    #     """
+    #     Control Run Engine in the paused state
+    #     """
+    #     data = await request.json()
+    #     msg = await self._send_command(command="re_continue", value=data)
+    #     return web.json_response(msg)
 
-    def setup_routes(self, app):
-        """
-        Setup routes to handler for web.Application
-        """
-        app.add_routes(
-            [
-                web.get("/", self._hello_handler),
-                web.get("/queue_view", self._queue_view_handler),
-                web.post("/add_to_queue", self._add_to_queue_handler),
-                web.post("/pop_from_queue", self._pop_from_queue_handler),
-                web.post("/create_environment", self._create_environment_handler),
-                web.post("/close_environment", self._close_environment_handler),
-                web.post("/process_queue", self._process_queue_handler),
-                web.post("/re_continue", self._re_continue_handler),
-                web.post("/re_pause", self._re_pause_handler),
-                web.post("/print_db_uids", self._print_db_uids_handler),
-            ]
-        )
+    # async def _print_db_uids_handler(self, request):
+    #     """
+    #     Prints the UIDs of the scans in 'temp' database. Just for the demo.
+    #     Not part of future API.
+    #     """
+    #     msg = await self._send_command(command="print_db_uids")
+    #     return web.json_response(msg)
 
-re_server = WebServer()
+    # def setup_routes(self, app):
+    #     """
+    #     Setup routes to handler for web.Application
+    #     """
+    #     app.add_routes(
+    #         [
+    #             # web.get("/", self._hello_handler),
+    #             # web.get("/queue_view", self._queue_view_handler),
+    #             # web.post("/add_to_queue", self._add_to_queue_handler),
+    #             # web.post("/pop_from_queue", self._pop_from_queue_handler),
+    #             # web.post("/create_environment", self._create_environment_handler),
+    #             # web.post("/close_environment", self._close_environment_handler),
+    #             # web.post("/process_queue", self._process_queue_handler),
+    #             # web.post("/re_continue", self._re_continue_handler),
+    #             # web.post("/re_pause", self._re_pause_handler),
+    #             # web.post("/print_db_uids", self._print_db_uids_handler),
+    #         ]
+    #     )
+
+
+
+
+logging.basicConfig(level=logging.WARNING)
+logging.getLogger('bluesky_queueserver').setLevel("DEBUG")
+
+# Use FastAPI
+app = FastAPI()
+re_server = ZMQ_Comm()
+
+
+class REPauseOptions(str, Enum):
+    deferred = 'deferred'
+    immediate = 'immediate'
+
+class REResumeOptions(str, Enum):
+    resume = 'resume'
+    abort = 'abort'
+    stop = 'stop'
+    halt = 'halt'
+
 
 @app.get('/')
-async def hello_handler():
+async def _hello_handler():
     """
     May be called to get response from the server. Returns the number of plans in the queue.
     """
-    res = await re_server._hello_handler()
-    return res
+    msg = await re_server._send_command(command="")
+    return msg
+
 
 @app.get('/queue_view')
-async def queue_view():
+async def _queue_view_handler():
     """
-    May be called to get response from the server. Returns the number of plans in the queue.
+    Returns the contents of the current queue.
     """
-    res = await re_server._queue_view_handler()
-    return res
+    msg = await re_server._send_command(command="queue_view")
+    return msg
 
 
-@app.get('/add_to_queue')
-async def queue_view(request):
+@app.post('/add_to_queue')
+async def _add_to_queue_handler(payload: dict):
     """
-    May be called to get response from the server. Returns the number of plans in the queue.
+    Adds new plan to the end of the queue
     """
-    res = await re_server._queue_view_handler()
-    return res
+    # TODO: validate inputs!
+    msg = await re_server._send_command(command="add_to_queue", value=payload)
+    return msg
 
 
-def init_func(argv):
+@app.post('/pop_from_queue')
+async def _pop_from_queue_handler():
+    """
+    Pop the last item from back of the queue
+    """
+    msg = await re_server._send_command(command="pop_from_queue")
+    return msg
 
-    logging.basicConfig(level=logging.WARNING)
-    logging.getLogger('bluesky_queueserver').setLevel("DEBUG")
 
-    re_server = WebServer(argv)
-    #
-    # app = web.Application(loop=re_server.get_loop())
-    # re_server.setup_routes(app)
-    # app["re_server"] = re_server  # To keep it alive
-    # return app
-    return re_server
+@app.post('/create_environment')
+async def _create_environment_handler():
+    """
+    Creates RE environment: creates RE Worker process, starts and configures Run Engine.
+    """
+    msg = await re_server._send_command(command="create_environment")
+    return msg
+
+
+@app.post('/close_environment')
+async def _close_environment_handler():
+    """
+    Deletes RE environment. In the current 'demo' prototype the environment will be deleted
+    only after RE completes the current scan.
+    """
+    msg = await re_server._send_command(command="close_environment")
+    return msg
+
+
+@app.post('/process_queue')
+async def _process_queue_handler():
+    """
+    Start execution of the loaded queue. Additional runs can be added to the queue while
+    it is executed. If the queue is empty, then nothing will happen.
+    """
+    msg = await re_server._send_command(command="process_queue")
+    return msg
+
+
+@app.post('/re_pause')
+async def _re_pause_handler(payload: dict):
+    """
+    Pause Run Engine
+    """
+    if not hasattr(REResumeOptions, payload['option']):
+        msg = f'The specified option "{payload["option"]}" is not allowed.'
+        raise HTTPException(status_code=444, detail=msg)
+    msg = await re_server._send_command(command="re_pause", value=payload)
+    return msg
+
+
+@app.post('/re_continue')
+async def _re_continue_handler(payload: dict):
+    """
+    Control Run Engine in the paused state
+    """
+    if not hasattr(REResumeOptions, payload['option']):
+        msg = f'The specified option "{payload["option"]}" is not allowed.'
+        raise HTTPException(status_code=444, detail=msg)
+    msg = await re_server._send_command(command="re_continue", value=payload)
+    return msg
+
+
+@app.post('/print_db_uids')
+async def _print_db_uids_handler():
+    """
+    Prints the UIDs of the scans in 'temp' database. Just for the demo.
+    Not part of future API.
+    """
+    msg = await re_server._send_command(command="print_db_uids")
+    return msg

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -1,12 +1,12 @@
-from fastapi import FastAPI, HTTPException
-from enum import Enum
-
 # from aiohttp import web
 import asyncio
+import logging
+from enum import Enum
+
 import zmq
 import zmq.asyncio
+from fastapi import FastAPI, HTTPException
 
-import logging
 logger = logging.getLogger(__name__)
 
 """
@@ -189,8 +189,6 @@ class ZMQ_Comm:
     #     )
 
 
-
-
 logging.basicConfig(level=logging.WARNING)
 logging.getLogger('bluesky_queueserver').setLevel("DEBUG")
 
@@ -202,6 +200,7 @@ re_server = ZMQ_Comm()
 class REPauseOptions(str, Enum):
     deferred = 'deferred'
     immediate = 'immediate'
+
 
 class REResumeOptions(str, Enum):
     resume = 'resume'

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -280,8 +280,9 @@ async def _re_pause_handler(payload: dict):
     """
     Pause Run Engine
     """
-    if not hasattr(REResumeOptions, payload['option']):
-        msg = f'The specified option "{payload["option"]}" is not allowed.'
+    if not hasattr(REPauseOptions, payload['option']):
+        msg = (f'The specified option "{payload["option"]}" is not allowed.\n'
+               f'Allowed options: {list(REPauseOptions.__members__.keys())}')
         raise HTTPException(status_code=444, detail=msg)
     msg = await re_server._send_command(command="re_pause", value=payload)
     return msg
@@ -293,7 +294,8 @@ async def _re_continue_handler(payload: dict):
     Control Run Engine in the paused state
     """
     if not hasattr(REResumeOptions, payload['option']):
-        msg = f'The specified option "{payload["option"]}" is not allowed.'
+        msg = (f'The specified option "{payload["option"]}" is not allowed.\n'
+               f'Allowed options: {list(REResumeOptions.__members__.keys())}')
         raise HTTPException(status_code=444, detail=msg)
     msg = await re_server._send_command(command="re_continue", value=payload)
     return msg

--- a/bluesky_queueserver/server/tests/conftest.py
+++ b/bluesky_queueserver/server/tests/conftest.py
@@ -5,15 +5,15 @@ from xprocess import ProcessStarter
 
 import bluesky_queueserver.server.server as bqss
 
-SERVER_IP = '0.0.0.0'
-SERVER_PORT = '8080'
+SERVER_ADDRESS = 'localhost'
+SERVER_PORT = '8000'
 
 
 @pytest.fixture
 def fastapi_server(xprocess):
     class Starter(ProcessStarter):
         pattern = "Connected to ZeroMQ server"
-        args = f'uvicorn --host={SERVER_IP} --port {SERVER_PORT} {bqss.__name__}:app'.split()
+        args = f'uvicorn --host={SERVER_ADDRESS} --port {SERVER_PORT} {bqss.__name__}:app'.split()
     xprocess.ensure("fastapi_server", Starter)
     # Clear the queue before the run:
     subprocess.run('qserver -c clear_queue'.split())

--- a/bluesky_queueserver/server/tests/conftest.py
+++ b/bluesky_queueserver/server/tests/conftest.py
@@ -1,0 +1,40 @@
+import subprocess
+
+import pytest
+from xprocess import ProcessStarter
+
+import bluesky_queueserver.server.server as bqss
+
+SERVER_IP = '0.0.0.0'
+SERVER_PORT = '8080'
+
+
+@pytest.fixture
+def fastapi_server(xprocess):
+    class Starter(ProcessStarter):
+        pattern = "Connected to ZeroMQ server"
+        args = f'uvicorn --host={SERVER_IP} --port {SERVER_PORT} {bqss.__name__}:app'.split()
+    xprocess.ensure("fastapi_server", Starter)
+    # Clear the queue before the run:
+    subprocess.run('qserver -c clear_queue'.split())
+
+    yield
+
+    # Clear the queue after the run:
+    subprocess.run('qserver -c clear_queue'.split())
+    xprocess.getinfo("fastapi_server").terminate()
+
+
+@pytest.fixture
+def add_plans_to_queue():
+    subprocess.run('qserver -c clear_queue'.split())
+    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+                     "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}"])
+    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+                     "{'name':'count', 'args':[['det1', 'det2']]}"])
+    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+                     "{'name':'count', 'args':[['det1', 'det2']]}"])
+
+    yield
+
+    subprocess.run('qserver -c clear_queue'.split())

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -4,14 +4,14 @@ import requests
 
 from bluesky_queueserver.manager.tests.test_general import \
     re_manager  # noqa F401
-from bluesky_queueserver.server.tests.conftest import (SERVER_IP,  # noqa F401
+from bluesky_queueserver.server.tests.conftest import (SERVER_ADDRESS,  # noqa F401
                                                        SERVER_PORT,
                                                        add_plans_to_queue,
                                                        fastapi_server)
 
 
 def _request_to_json(request_type, path, **kwargs):
-    resp = getattr(requests, request_type)(f'http://{SERVER_IP}:{SERVER_PORT}{path}', **kwargs).json()
+    resp = getattr(requests, request_type)(f'http://{SERVER_ADDRESS}:{SERVER_PORT}{path}', **kwargs).json()
     return resp
 
 

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -1,49 +1,13 @@
-import subprocess
-import sys
 import time as ttime
 
-import pytest
 import requests
-from xprocess import ProcessStarter
 
-import bluesky_queueserver.server.server as bqss
 from bluesky_queueserver.manager.tests.test_general import \
     re_manager  # noqa F401
-# from bluesky_queueserver.server.server import init_func
-
-SERVER_IP = '0.0.0.0'
-SERVER_PORT = '8080'
-
-
-@pytest.fixture
-def fastapi_server(xprocess):
-    class Starter(ProcessStarter):
-        pattern = "Connected to ZeroMQ server"
-        args = f'uvicorn --host={SERVER_IP} --port {SERVER_PORT} {bqss.__name__}:app'.split()
-    xprocess.ensure("fastapi_server", Starter)
-    # Clear the queue before the run:
-    subprocess.run('qserver -c clear_queue'.split())
-
-    yield
-
-    # Clear the queue after the run:
-    subprocess.run('qserver -c clear_queue'.split())
-    xprocess.getinfo("fastapi_server").terminate()
-
-
-@pytest.fixture
-def add_plans_to_queue():
-    subprocess.run('qserver -c clear_queue'.split())
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
-                     "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}"])
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
-                     "{'name':'count', 'args':[['det1', 'det2']]}"])
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
-                     "{'name':'count', 'args':[['det1', 'det2']]}"])
-
-    yield
-
-    subprocess.run('qserver -c clear_queue'.split())
+from bluesky_queueserver.server.tests.conftest import (SERVER_IP,  # noqa F401
+                                                       SERVER_PORT,
+                                                       add_plans_to_queue,
+                                                       fastapi_server)
 
 
 def _request_to_json(request_type, path, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aioredis
 bluesky
 bluesky-kafka
 databroker
-fastapi
+fastapi[all]
 json-rpc
 msgpack
 msgpack_numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
-# List required packages in this file, one per line.
-aiohttp
 aioredis
 bluesky
 bluesky-kafka
 databroker
+fastapi
+json-rpc
 msgpack
 msgpack_numpy
 ophyd
 pyzmq
 requests
-json-rpc


### PR DESCRIPTION
Summary:
--------------
- Converted all `aiohttp` calls to `fastapi` with corresponding `get`/`post` decorators. That resulted in getting rid of most handler methods from the `WebServer` class, so I use the latter for the ZMQ communications only (the code for those handler methods is commented out for now, but will eventually be removed).
- Used enum validations for `re_pause`/`re_continue` operations.
- Moved the test fixtures for the server into the corresponding `conftest.py` module.
- All tests passed with the existing tests (just with a different web-server fixture, but the same REST API calls).
- Parametrized ZMQ server/port.

**Note**: we have to install `uvicorn` explicitly, or I opted to use `fastapi[all]` which has that dependency.