### PR TITLE
API for more accurate monitoring of RE Manager state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,9 +163,9 @@ Run 'qserver' in the monitoring mode (send 'ping' request to RE Manager every se
 
 Add a new plan to the queue::
 
-  qserver -c add_to_queue -v '{"name":"count", "args":[["det1", "det2"]]}'
-  qserver -c add_to_queue -v '{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
-  qserver -c add_to_queue -v '{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
+  qserver -c add_to_queue -p '{"name":"count", "args":[["det1", "det2"]]}'
+  qserver -c add_to_queue -p '{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+  qserver -c add_to_queue -p '{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
 
 View the contents of the queue::
 
@@ -193,15 +193,15 @@ Close and destroy RE environment::
 
 Pause the Run Engine (and the queue)::
 
-  qserver -c re_pause -v immediate
-  qserver -c re_pause -v deferred
+  qserver -c re_pause -p immediate
+  qserver -c re_pause -p deferred
 
 Countinue paused plan::
 
-  qserver -c re_continue -v resume
-  qserver -c re_continue -v abort
-  qserver -c re_continue -v stop
-  qserver -c re_continue -v halt
+  qserver -c re_continue -p resume
+  qserver -c re_continue -p abort
+  qserver -c re_continue -p stop
+  qserver -c re_continue -p halt
 
 Print UIDs in 'temp' Databroker::
 

--- a/bluesky_queueserver/manager/tests/test_general.py
+++ b/bluesky_queueserver/manager/tests/test_general.py
@@ -32,8 +32,8 @@ def test_qserver_cli_and_manager(re_manager):
 
     def get_queue_state():
         re_server = CliClient()
-        command, value = "ping", None
-        re_server.set_msg_out(command, value)
+        command, params = "ping", None
+        re_server.set_msg_out(command, params)
         asyncio.run(re_server.zmq_single_request())
         msg, _ = re_server.get_msg_in()
         if msg is None:
@@ -85,11 +85,11 @@ def test_qserver_cli_and_manager(re_manager):
     subprocess.call(["qserver", "-c", "clear_queue"])
 
     # Add a number of plans
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'count', 'args':[['det1', 'det2']]}"])
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'scan', 'args':[['det1', 'det2'], 'motor', -1, 1, 10]}"])
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}"])
 
     n_plans, is_plan_running = get_reduced_state_info()
@@ -113,7 +113,7 @@ def test_qserver_cli_and_manager(re_manager):
         "Timeout while waiting for process to finish"
 
     # Queue is expected to be empty (processed). Load one more plan.
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}"])
 
     n_plans, is_plan_running = get_reduced_state_info()
@@ -121,19 +121,19 @@ def test_qserver_cli_and_manager(re_manager):
 
     subprocess.call(["qserver", "-c", "process_queue"])
     ttime.sleep(1)
-    subprocess.call(["qserver", "-c", "re_pause", "-v", "immediate"])
-    subprocess.call(["qserver", "-c", "re_continue", "-v", "resume"])
+    subprocess.call(["qserver", "-c", "re_pause", "-p", "immediate"])
+    subprocess.call(["qserver", "-c", "re_continue", "-p", "resume"])
     ttime.sleep(1)
-    subprocess.call(["qserver", "-c", "re_pause", "-v", "deferred"])
+    subprocess.call(["qserver", "-c", "re_pause", "-p", "deferred"])
     ttime.sleep(2)  # Need some time to finish the current plan step
-    subprocess.call(["qserver", "-c", "re_continue", "-v", "resume"])
+    subprocess.call(["qserver", "-c", "re_continue", "-p", "resume"])
 
     assert wait_for_condition(time=60, condition=condition_queue_processing_finished), \
         "Timeout while waiting for process to finish"
 
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'count', 'args':[['det1', 'det2']]}"])
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'count', 'args':[['det1', 'det2']]}"])
 
     n_plans, is_plan_running = get_reduced_state_info()
@@ -147,11 +147,11 @@ def test_qserver_cli_and_manager(re_manager):
     # Test 'killing' the manager during running plan. Load long plan and two short ones.
     #   The tests checks if execution of the queue is continued uninterrupted after
     #   the manager restart
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}"])
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'count', 'args':[['det1', 'det2']]}"])
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'count', 'args':[['det1', 'det2']]}"])
     n_plans, is_plan_running = get_reduced_state_info()
     assert n_plans == 3, "Incorrect number of plans in the queue"

--- a/bluesky_queueserver/manager/tests/test_general.py
+++ b/bluesky_queueserver/manager/tests/test_general.py
@@ -30,7 +30,7 @@ def test_qserver_cli_and_manager(re_manager):
     # TODO: Redis pool should be cleaned before each test. Now it's only one tests,
     #   so it is not important, but cleaning should be implemented.
 
-    def get_queue_status():
+    def get_queue_state():
         re_server = CliClient()
         command, value = "ping", None
         re_server.set_msg_out(command, value)
@@ -38,10 +38,29 @@ def test_qserver_cli_and_manager(re_manager):
         msg, _ = re_server.get_msg_in()
         if msg is None:
             raise TimeoutError("Timeout occured while monitoring RE Manager state")
-        n_plans, is_plan_running = msg["n_plans"], msg["is_plan_running"]
-        return n_plans, is_plan_running
+        return msg
 
-    def wait_for_processing_to_finish(time):
+    def get_reduced_state_info():
+        msg = get_queue_state()
+        plans_in_queue = msg["plans_in_queue"]
+        queue_is_running = (msg["manager_state"] == "executing_queue")
+        return plans_in_queue, queue_is_running
+
+    def condition_manager_idle(msg):
+        return msg["manager_state"] == "idle"
+
+    def condition_environment_created(msg):
+        return msg["worker_environment_exists"]
+
+    def condition_environment_closed(msg):
+        return not msg["worker_environment_exists"]
+
+    def condition_queue_processing_finished(msg):
+        plans_in_queue = msg["plans_in_queue"]
+        queue_is_running = (msg["manager_state"] == "executing_queue")
+        return (plans_in_queue == 0) and not queue_is_running
+
+    def wait_for_condition(time, condition):
         """
         Wait until queue is processed. Note: processing of TimeoutError is needed for
         monitoring RE Manager while it is restarted.
@@ -51,13 +70,16 @@ def test_qserver_cli_and_manager(re_manager):
         while ttime.time() < time_stop:
             ttime.sleep(dt/2)
             try:
-                n_plans, is_plan_running = get_queue_status()
-                if (n_plans == 0) and not is_plan_running:
+                msg = get_queue_state()
+                if condition(msg):
                     return True
             except TimeoutError:
                 pass
             ttime.sleep(dt/2)
         return False
+
+    assert wait_for_condition(time=3, condition=condition_manager_idle), \
+        "Timeout while waiting for manager to initialize."
 
     # Clear queue
     subprocess.call(["qserver", "-c", "clear_queue"])
@@ -70,27 +92,31 @@ def test_qserver_cli_and_manager(re_manager):
     subprocess.call(["qserver", "-c", "add_to_queue", "-v",
                      "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}"])
 
-    n_plans, is_plan_running = get_queue_status()
+    n_plans, is_plan_running = get_reduced_state_info()
     assert n_plans == 3, "Incorrect number of plans in the queue"
     assert not is_plan_running, "Plan is executed while it shouldn't"
 
     subprocess.call(["qserver", "-c", "queue_view"])
     subprocess.call(["qserver", "-c", "pop_from_queue"])
 
-    n_plans, is_plan_running = get_queue_status()
+    n_plans, is_plan_running = get_reduced_state_info()
     assert n_plans == 2, "Incorrect number of plans in the queue"
 
     subprocess.call(["qserver", "-c", "create_environment"])
-    ttime.sleep(1)  # TODO: implement API to check if environment exists. Use delay for now.
+
+    assert wait_for_condition(time=3, condition=condition_environment_created), \
+        "Timeout while waiting for environment to be created"
+
     subprocess.call(["qserver", "-c", "process_queue"])
 
-    assert wait_for_processing_to_finish(60), "Timeout while waiting for process to finish"
+    assert wait_for_condition(time=60, condition=condition_queue_processing_finished), \
+        "Timeout while waiting for process to finish"
 
     # Queue is expected to be empty (processed). Load one more plan.
     subprocess.call(["qserver", "-c", "add_to_queue", "-v",
                      "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}"])
 
-    n_plans, is_plan_running = get_queue_status()
+    n_plans, is_plan_running = get_reduced_state_info()
     assert n_plans == 1, "Incorrect number of plans in the queue"
 
     subprocess.call(["qserver", "-c", "process_queue"])
@@ -102,18 +128,21 @@ def test_qserver_cli_and_manager(re_manager):
     ttime.sleep(2)  # Need some time to finish the current plan step
     subprocess.call(["qserver", "-c", "re_continue", "-v", "resume"])
 
-    assert wait_for_processing_to_finish(60), "Timeout while waiting for process to finish"
+    assert wait_for_condition(time=60, condition=condition_queue_processing_finished), \
+        "Timeout while waiting for process to finish"
 
     subprocess.call(["qserver", "-c", "add_to_queue", "-v",
                      "{'name':'count', 'args':[['det1', 'det2']]}"])
     subprocess.call(["qserver", "-c", "add_to_queue", "-v",
                      "{'name':'count', 'args':[['det1', 'det2']]}"])
 
-    n_plans, is_plan_running = get_queue_status()
+    n_plans, is_plan_running = get_reduced_state_info()
     assert n_plans == 2, "Incorrect number of plans in the queue"
 
     subprocess.call(["qserver", "-c", "process_queue"])
-    assert wait_for_processing_to_finish(60), "Timeout while waiting for process to finish"
+
+    assert wait_for_condition(time=60, condition=condition_queue_processing_finished), \
+        "Timeout while waiting for process to finish"
 
     # Test 'killing' the manager during running plan. Load long plan and two short ones.
     #   The tests checks if execution of the queue is continued uninterrupted after
@@ -124,11 +153,15 @@ def test_qserver_cli_and_manager(re_manager):
                      "{'name':'count', 'args':[['det1', 'det2']]}"])
     subprocess.call(["qserver", "-c", "add_to_queue", "-v",
                      "{'name':'count', 'args':[['det1', 'det2']]}"])
-    n_plans, is_plan_running = get_queue_status()
+    n_plans, is_plan_running = get_reduced_state_info()
     assert n_plans == 3, "Incorrect number of plans in the queue"
     subprocess.call(["qserver", "-c", "process_queue"])
     ttime.sleep(1)
     subprocess.call(["qserver", "-c", "kill_manager"])
-    assert wait_for_processing_to_finish(60), "Timeout while waiting for process to finish"
+    assert wait_for_condition(time=60, condition=condition_queue_processing_finished), \
+        "Timeout while waiting for process to finish"
 
     subprocess.call(["qserver", "-c", "close_environment"])
+
+    assert wait_for_condition(time=5, condition=condition_environment_closed), \
+        "Timeout while waiting for environment to be closed"

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -81,11 +81,11 @@ class ZMQ_Comm:
         # The event must be set somewhere else
         await self._event_zmq_stop.wait()
 
-    def _create_msg(self, *, command, value=None):
-        return {"command": command, "value": value}
+    def _create_msg(self, *, command, params=None):
+        return {"method": command, "params": params}
 
-    async def _send_command(self, *, command, value=None):
-        msg_out = self._create_msg(command=command, value=value)
+    async def _send_command(self, *, command, params=None):
+        msg_out = self._create_msg(command=command, params=params)
         msg_in = await self._zmq_communicate(msg_out)
         return msg_in
 
@@ -112,7 +112,7 @@ class ZMQ_Comm:
     #     """
     #     data = await request.json()
     #     # TODO: validate inputs!
-    #     msg = await self._send_command(command="add_to_queue", value=data)
+    #     msg = await self._send_command(command="add_to_queue", params=data)
     #     return web.json_response(msg)
 
     # async def _pop_from_queue_handler(self, request):
@@ -150,7 +150,7 @@ class ZMQ_Comm:
     #     Pause Run Engine
     #     """
     #     data = await request.json()
-    #     msg = await self._send_command(command="re_pause", value=data)
+    #     msg = await self._send_command(command="re_pause", params=data)
     #     return web.json_response(msg)
 
     # async def _re_continue_handler(self, request):
@@ -158,7 +158,7 @@ class ZMQ_Comm:
     #     Control Run Engine in the paused state
     #     """
     #     data = await request.json()
-    #     msg = await self._send_command(command="re_continue", value=data)
+    #     msg = await self._send_command(command="re_continue", params=data)
     #     return web.json_response(msg)
 
     # async def _print_db_uids_handler(self, request):
@@ -233,7 +233,7 @@ async def _add_to_queue_handler(payload: dict):
     Adds new plan to the end of the queue
     """
     # TODO: validate inputs!
-    msg = await re_server._send_command(command="add_to_queue", value=payload)
+    msg = await re_server._send_command(command="add_to_queue", params=payload)
     return msg
 
 
@@ -284,7 +284,7 @@ async def _re_pause_handler(payload: dict):
         msg = (f'The specified option "{payload["option"]}" is not allowed.\n'
                f'Allowed options: {list(REPauseOptions.__members__.keys())}')
         raise HTTPException(status_code=444, detail=msg)
-    msg = await re_server._send_command(command="re_pause", value=payload)
+    msg = await re_server._send_command(command="re_pause", params=payload)
     return msg
 
 
@@ -297,7 +297,7 @@ async def _re_continue_handler(payload: dict):
         msg = (f'The specified option "{payload["option"]}" is not allowed.\n'
                f'Allowed options: {list(REResumeOptions.__members__.keys())}')
         raise HTTPException(status_code=444, detail=msg)
-    msg = await re_server._send_command(command="re_continue", value=payload)
+    msg = await re_server._send_command(command="re_continue", params=payload)
     return msg
 
 

--- a/bluesky_queueserver/server/tests/conftest.py
+++ b/bluesky_queueserver/server/tests/conftest.py
@@ -28,11 +28,11 @@ def fastapi_server(xprocess):
 @pytest.fixture
 def add_plans_to_queue():
     subprocess.run('qserver -c clear_queue'.split())
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}"])
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'count', 'args':[['det1', 'det2']]}"])
-    subprocess.call(["qserver", "-c", "add_to_queue", "-v",
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p",
                      "{'name':'count', 'args':[['det1', 'det2']]}"])
 
     yield

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -18,8 +18,10 @@ def _request_to_json(request_type, path, **kwargs):
 def test_http_server_hello_handler(re_manager, fastapi_server):  # noqa F811
     resp = _request_to_json('get', '/')
     assert resp['msg'] == 'RE Manager'
-    assert resp['n_plans'] == 0
-    assert resp['is_plan_running'] is False
+    assert resp['manager_state'] == 'idle'
+    assert resp['plans_in_queue'] == 0
+    assert resp['running_plan_uid'] is None
+    assert resp['worker_environment_exists'] is False
 
 
 def test_http_server_queue_view_handler(re_manager, fastapi_server):  # noqa F811

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ msgpack_numpy
 ophyd
 pyzmq
 requests
+super_state_machine


### PR DESCRIPTION
Changes:
- Extended the information returned by 'ping' request. The returned state contains data sufficient to determine if current operation is completed. More convenient APIs may be implemented in the future for waiting for completion of specific operations.
- Changed variable that keeps current state of RE Manager process from string to `super_state_machine.machines.StateMachine` (same as in Bluesky). Currently it is used as enhanced enum (ensures that assigned values are from a fixed set and reduces the chance of an error), but may eventually be used as a state machine when the rest of the code is ready.
- Modified the CLI tests so they are working without artificial delays. The delays are replaced with polling RE Manager state.
- Renamed command/value to method/params in ZMQ-related code to make it consistent with 'json-rpc' naming. Changed option `-v` to `-p (--parameters)` in CLI tool. `Parameters` seem to be better name than `value`. Also `-v` is often used to control verbosity of the output. Option `-c (--command)` was kept unchanged, since it is more suitable for user interface than 'method'. Updated `README.rst` to reflect the changes.
