### PR TITLE
Fix web-server address/port (0.0.0.0:8080 -> localhost:8080)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,16 +52,16 @@ In the first shell start RE Manager::
 
 The Web Server should be started from the second shell as follows::
 
-  uvicorn bluesky_queueserver.server.server:app --host "0.0.0.0" --port 8080
+  uvicorn bluesky_queueserver.server.server:app --host localhost --port 8080
 
 Use the third shell to send REST API requests to the server. Add plans to the queue::
 
-  http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
-  http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+  http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
 
 The following plan runs for 10 seconds. It is convenient for testing pausing/resuming/stopping the plan::
 
-  http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
+  http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
 
 The names of the plans and devices are strings. The strings are converted to references to plans and
 devices in the worker process. In this demo the server can recognize only 'det1', 'det2', 'motor' devices
@@ -72,31 +72,31 @@ from an empty queue).
 
 The last item can be removed from the back of the queue::
 
-  http POST 0.0.0.0:8080/pop_from_queue
+  http POST http://localhost:8080/pop_from_queue
 
 The number of entries in the queue may be checked as follows::
 
-  http GET 0.0.0.0:8080
+  http GET http://localhost:8080
 
 The contents of the queue can be retrieved as follows::
 
-  http GET 0.0.0.0:8080/queue_view
+  http GET http://localhost:8080/queue_view
 
 Before the queue can be executed, the worker environment must be created and initialized. This operation
 creates a new execution environment for Bluesky Run Engine and used to execute plans until it explicitly
 closed::
 
-  http POST 0.0.0.0:8080/create_environment
+  http POST http://localhost:8080/create_environment
 
 Execute the plans in the queue::
 
-  http POST 0.0.0.0:8080/process_queue
+  http POST http://localhost:8080/process_queue
 
 Request to execute an empty queue is a valid operation that does nothing.
 
 Environment may be closed as follows::
 
-  http POST 0.0.0.0:8080/close_environment
+  http POST http://localhost:8080/close_environment
 
 While a plan in a queue is executed, operation Run Engine can be paused. In the unlikely event
 if the request to pause is received while RunEngine is transitioning between two plans, the request
@@ -107,18 +107,18 @@ of the queue is stopped. Execution of the queue may be started again if needed.
 
 Immediate pausing of the Run Engine (returns to the last checkpoint in the plan)::
 
-  http POST 0.0.0.0:8080/re_pause option="immediate"
+  http POST http://localhost:8080/re_pause option="immediate"
 
 Deferred pausing of the Run Engine (plan is executed until the next checkpoint)::
 
-  http POST 0.0.0.0:8080/re_pause option="deferred"
+  http POST http://localhost:8080/re_pause option="deferred"
 
 Resuming, aborting, stopping or halting of currently executed plan::
 
-  http POST 0.0.0.0:8080/re_continue option="resume"
-  http POST 0.0.0.0:8080/re_continue option="abort"
-  http POST 0.0.0.0:8080/re_continue option="stop"
-  http POST 0.0.0.0:8080/re_continue option="halt"
+  http POST http://localhost:8080/re_continue option="resume"
+  http POST http://localhost:8080/re_continue option="abort"
+  http POST http://localhost:8080/re_continue option="stop"
+  http POST http://localhost:8080/re_continue option="halt"
 
 There is minimal user protection features implemented that will prevent execution of
 the commands that are not supported in current state of the server. Error messages are printed
@@ -130,7 +130,7 @@ used to collect documents from Run Engine. Data from all plans executed during Q
 are accumulated in the 'temp' database. The table that contains Run IDs and UIDs of the runs in
 the databased can be printed on the screen by sending the command::
 
-  http POST 0.0.0.0:8080/print_db_uids
+  http POST http://localhost:8080/print_db_uids
 
 The table will be printed in the RE Manager terminal::
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -21,13 +21,13 @@ logger = logging.getLogger(__name__)
 """
 #  The following plans that can be used to test the syste
 
-http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
+http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
 # This is the slowly running plan (convenient to test pausing)
-http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]],
+http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]],
 "kwargs":{"num":10, "delay":1}}'
 
-http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+http POST http://localhost:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
 """
 
 

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -20,13 +20,13 @@ qserver_version = bluesky_queueserver.__version__
 """
 #  The following plans that can be used to test the server
 
-http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
+http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
 # This is the slowly running plan (convenient to test pausing)
-http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]],
+http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]],
 "kwargs":{"num":10, "delay":1}}'
 
-http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+http POST http://localhost:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
 """
 
 

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -1,4 +1,3 @@
-# from aiohttp import web
 import asyncio
 import logging
 from enum import Enum
@@ -12,13 +11,13 @@ logger = logging.getLogger(__name__)
 """
 #  The following plans that can be used to test the server
 
-http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
+http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
 # This is the slowly running plan (convenient to test pausing)
-http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]],
+http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]],
 "kwargs":{"num":10, "delay":1}}'
 
-http POST 0.0.0.0:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+http POST http://localhost:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
 """
 
 
@@ -88,105 +87,6 @@ class ZMQ_Comm:
         msg_out = self._create_msg(command=command, params=params)
         msg_in = await self._zmq_communicate(msg_out)
         return msg_in
-
-    # =========================================================================
-    #    REST API handlers
-
-    # async def _hello_handler(self):
-    #     """
-    #     May be called to get response from the server. Returns the number of plans in the queue.
-    #     """
-    #     msg = await self._send_command(command="")
-    #     return web.json_response(msg)
-
-    # async def _queue_view_handler(self):
-    #     """
-    #     Returns the contents of the current queue.
-    #     """
-    #     msg = await self._send_command(command="queue_view")
-    #     return web.json_response(msg)
-
-    # async def _add_to_queue_handler(self, request):
-    #     """
-    #     Adds new plan to the end of the queue
-    #     """
-    #     data = await request.json()
-    #     # TODO: validate inputs!
-    #     msg = await self._send_command(command="add_to_queue", params=data)
-    #     return web.json_response(msg)
-
-    # async def _pop_from_queue_handler(self, request):
-    #     """
-    #     Pop the last item from back of the queue
-    #     """
-    #     msg = await self._send_command(command="pop_from_queue")
-    #     return web.json_response(msg)
-
-    # async def _create_environment_handler(self, request):
-    #     """
-    #     Creates RE environment: creates RE Worker process, starts and configures Run Engine.
-    #     """
-    #     msg = await self._send_command(command="create_environment")
-    #     return web.json_response(msg)
-
-    # async def _close_environment_handler(self, request):
-    #     """
-    #     Deletes RE environment. In the current 'demo' prototype the environment will be deleted
-    #     only after RE completes the current scan.
-    #     """
-    #     msg = await self._send_command(command="close_environment")
-    #     return web.json_response(msg)
-
-    # async def _process_queue_handler(self, request):
-    #     """
-    #     Start execution of the loaded queue. Additional runs can be added to the queue while
-    #     it is executed. If the queue is empty, then nothing will happen.
-    #     """
-    #     msg = await self._send_command(command="process_queue")
-    #     return web.json_response(msg)
-
-    # async def _re_pause_handler(self, request):
-    #     """
-    #     Pause Run Engine
-    #     """
-    #     data = await request.json()
-    #     msg = await self._send_command(command="re_pause", params=data)
-    #     return web.json_response(msg)
-
-    # async def _re_continue_handler(self, request):
-    #     """
-    #     Control Run Engine in the paused state
-    #     """
-    #     data = await request.json()
-    #     msg = await self._send_command(command="re_continue", params=data)
-    #     return web.json_response(msg)
-
-    # async def _print_db_uids_handler(self, request):
-    #     """
-    #     Prints the UIDs of the scans in 'temp' database. Just for the demo.
-    #     Not part of future API.
-    #     """
-    #     msg = await self._send_command(command="print_db_uids")
-    #     return web.json_response(msg)
-
-    # def setup_routes(self, app):
-    #     """
-    #     Setup routes to handler for web.Application
-    #     """
-    #     app.add_routes(
-    #         [
-    #             # web.get("/", self._hello_handler),
-    #             # web.get("/queue_view", self._queue_view_handler),
-    #             # web.post("/add_to_queue", self._add_to_queue_handler),
-    #             # web.post("/pop_from_queue", self._pop_from_queue_handler),
-    #             # web.post("/create_environment", self._create_environment_handler),
-    #             # web.post("/close_environment", self._close_environment_handler),
-    #             # web.post("/process_queue", self._process_queue_handler),
-    #             # web.post("/re_continue", self._re_continue_handler),
-    #             # web.post("/re_pause", self._re_pause_handler),
-    #             # web.post("/print_db_uids", self._print_db_uids_handler),
-    #         ]
-    #     )
 
 
 logging.basicConfig(level=logging.WARNING)

--- a/bluesky_queueserver/server/tests/conftest.py
+++ b/bluesky_queueserver/server/tests/conftest.py
@@ -6,7 +6,7 @@ from xprocess import ProcessStarter
 import bluesky_queueserver.server.server as bqss
 
 SERVER_ADDRESS = 'localhost'
-SERVER_PORT = '8000'
+SERVER_PORT = '8080'
 
 
 @pytest.fixture

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,5 @@ matplotlib
 numpydoc
 sphinx-copybutton
 sphinx_rtd_theme
+# Extra dependencies for development
+fastapi[all]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aioredis
 bluesky
 bluesky-kafka
 databroker
-fastapi[all]
+fastapi
 json-rpc
 msgpack
 msgpack_numpy
@@ -11,3 +11,4 @@ pyyaml
 pyzmq
 requests
 super_state_machine
+uvicorn


### PR DESCRIPTION
After discussion in Teams with @cryos and @tacaswell we decided it's safer to switch to `localhost:8080` from a less-restricted `0.0.0.0:8080` (which is a default address/port for formerly used `aiohttp` library).

Also, less dependencies for production - we need `fastapi` and `uvicorn`, but `fastapi[all]` can be installed for dev purposes.