### PR TITLE
Expand installation instructions and requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ and then kill the processes::
 
 Installation of QueueServer from source::
 
+  sudo apt install redis
   pip install -e .
 
 This also sets up an entry point for the 'qserver' CLI tool.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ bluesky-kafka
 databroker
 fastapi
 json-rpc
-msgpack
+matplotlib # Needed for BEC, should be factored out
+scikit-image # Needed for BEC/other stuff to run, factor out
+msgpack>=1.0.0
 msgpack_numpy
 ophyd
 pyyaml


### PR DESCRIPTION
The server needs redis installed to run, and matplotlib is required for
the best effort callback currently used to output debug information.
There is a msgpack minimum version of 1.0 for bluesky kafka that the
version specifications fixes in default installs.