### PR TITLE
Expansion of RE Manager API

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -656,6 +656,23 @@ class RunEngineManager(Process):
         await self._plan_queue.clear_plan_queue()
         return {"success": True, "msg": "Plan queue is now empty."}
 
+    async def _get_history_handler(self, request):
+        """
+        Returns the contents of the plan history.
+        """
+        logger.info("Returning plan history.")
+        plan_history = await self._plan_queue.get_plan_history()
+
+        return {"history": plan_history}
+
+    async def _clear_history_handler(self, request):
+        """
+        Remove all entries from the plan history
+        """
+        logger.info("Clearing the plan execution history")
+        await self._plan_queue.clear_plan_history()
+        return {"success": True, "msg": "Plan history is now empty."}
+
     async def _create_environment_handler(self, request):
         """
         Creates RE environment: creates RE Worker process, starts and configures Run Engine.
@@ -763,6 +780,8 @@ class RunEngineManager(Process):
             "add_to_queue": "_add_to_queue_handler",
             "pop_from_queue": "_pop_from_queue_handler",
             "clear_queue": "_clear_queue_handler",
+            "get_history": "_get_history_handler",
+            "clear_history": "_clear_history_handler",
             "create_environment": "_create_environment_handler",
             "close_environment": "_close_environment_handler",
             "process_queue": "_process_queue_handler",

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -614,14 +614,15 @@ class RunEngineManager(Process):
             "allowed_devices": self._allowed_devices,
         }
 
-    async def _queue_view_handler(self, request):
+    async def _get_queue_handler(self, request):
         """
         Returns the contents of the current queue.
         """
-        logger.info("Returning current queue.")
-        all_plans = await self._plan_queue.get_plan_queue()
+        logger.info("Returning current queue and running plan.")
+        plan_queue = await self._plan_queue.get_plan_queue()
+        running_plan = await self._plan_queue.get_running_plan_info()
 
-        return {"queue": all_plans}
+        return {"queue": plan_queue, "running_plan": running_plan}
 
     async def _add_to_queue_handler(self, request):
         """
@@ -757,7 +758,7 @@ class RunEngineManager(Process):
         params = msg["params"]
         handler_dict = {
             "": "_ping_handler",
-            "queue_view": "_queue_view_handler",
+            "get_queue": "_get_queue_handler",
             "list_allowed_plans_and_devices": "_list_allowed_plans_and_devices_handler",
             "add_to_queue": "_add_to_queue_handler",
             "pop_from_queue": "_pop_from_queue_handler",

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -335,7 +335,7 @@ class PlanQueueOperations:
         Raises
         ------
         TypeError
-            Incorrect text for
+            Incorrect value of `pos` (most likely a string different from `front` or `black`
         """
         async with self._lock:
             return await self._get_plan(pos)

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -101,7 +101,7 @@ class PlanQueueOperations:
 
     async def _delete_pool_entries(self):
         """
-        See ``self.delete_pool_entries`` method.
+        See ``self.delete_pool_entries()`` method.
         """
         await self._r_pool.delete(self._name_running_plan)
         await self._r_pool.delete(self._name_plan_queue)
@@ -212,7 +212,7 @@ class PlanQueueOperations:
 
     async def _is_plan_running(self):
         """
-        See ``self.is_plan_running`` method.
+        See ``self.is_plan_running()`` method.
         """
         return bool(await self._get_running_plan_info())
 
@@ -230,7 +230,7 @@ class PlanQueueOperations:
 
     async def _get_running_plan_info(self):
         """
-        See ``self._get_running_plan_info`` method.
+        See ``self._get_running_plan_info()`` method.
         """
         plan = await self._r_pool.get(self._name_running_plan)
         return json.loads(plan) if plan else {}
@@ -309,7 +309,7 @@ class PlanQueueOperations:
 
     async def _get_plan(self, pos):
         """
-        See ``self._get_plan`` method.
+        See ``self._get_plan()`` method.
         """
         if pos == "back":
             index = -1
@@ -331,7 +331,7 @@ class PlanQueueOperations:
         Parameters
         ----------
         pos: int or str
-            Position of the element (0, ..) or (-1, ..), ``front`` or ``back``.
+            Position of the element ``(0, ..)`` or ``(-1, ..)``, ``front`` or ``back``.
 
         Returns
         -------
@@ -376,7 +376,7 @@ class PlanQueueOperations:
 
     async def _pop_plan_from_queue(self, pos="back"):
         """
-        See ``self._pop_plan_from_queue`` method
+        See ``self._pop_plan_from_queue()`` method
         """
         if pos == "back":
             plan_json = await self._r_pool.rpop(self._name_plan_queue)

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -341,7 +341,7 @@ class PlanQueueOperations:
         Raises
         ------
         TypeError
-            Incorrect value of ``pos`` (most likely a string different from ``front`` or ``black``)
+            Incorrect value of ``pos`` (most likely a string different from ``front`` or ``back``)
         """
         async with self._lock:
             return await self._get_plan(pos)

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -7,7 +7,7 @@ import uuid
 class PlanQueueOperations:
     """
     The class supports operations with plan queue based on Redis. The public methods
-    of the class are protected with `asyncio.Lock`.
+    of the class are protected with ``asyncio.Lock``.
 
     Parameters
     ----------
@@ -126,7 +126,7 @@ class PlanQueueOperations:
     def _verify_plan(self, plan):
         """
         Verify that plan structure is valid enough to be put in the queue.
-        Current checks: plan is a dictionary, `plan_uid` key is present, Plan with the UID is not in
+        Current checks: plan is a dictionary, ``plan_uid`` key is present, Plan with the UID is not in
         the queue or currently running.
         """
         self._verify_plan_type(plan)
@@ -149,7 +149,7 @@ class PlanQueueOperations:
         Parameters
         ----------
         plan: dict
-            Dictionary of plan parameters. The dictionary may or may not have the key `plan_uid`
+            Dictionary of plan parameters. The dictionary may or may not have the key ``plan_uid``.
 
         Returns
         -------
@@ -162,34 +162,40 @@ class PlanQueueOperations:
 
     # --------------------------------------------------------------------------
     #                          Operations with UID set
-
+    # TODO: in future consider replacing this method with `self._uid_set.clear()`
+    #   The following private methods were introduced in case the set of UIDs
+    #   need to be moved to a different structure (e.g. to Redis). They could
+    #   be removed if such need does not materialize.
     def _uid_set_clear(self):
         """
-        Clear `self._uid_set`.
+        Clear ``self._uid_set``.
         """
-        self._uid_set = set()
+        self._uid_set.clear()
 
+    # TODO: in future consider replacing this method with `in self._uid_set`
     def _is_uid_in_set(self, uid):
         """
-        Checks if UID exists in `self._uid_set`.
+        Checks if UID exists in ``self._uid_set``.
         """
         return uid in self._uid_set
 
+    # TODO: in future consider replacing this method with `self._uid_set.add()`
     def _uid_set_add(self, uid):
         """
-        Add UID to `self._uid_set`.
+        Add UID to ``self._uid_set``.
         """
         self._uid_set.add(uid)
 
+    # TODO: in future consider replacing this method with `self._uid_set.remove()`
     def _uid_set_remove(self, uid):
         """
-        Remove UID from `self._uid_set`.
+        Remove UID from ``self._uid_set``.
         """
         self._uid_set.remove(uid)
 
     async def _uid_set_initialize(self):
         """
-        Initialize `self._uid_set` with UIDs extracted from the plans in the queue.
+        Initialize ``self._uid_set`` with UIDs extracted from the plans in the queue.
         """
         pq = await self._get_plan_queue()
         self._uid_set_clear()
@@ -264,7 +270,7 @@ class PlanQueueOperations:
 
     async def _get_plan_queue_size(self):
         """
-        See `self.get_plan_queue_size()` method.
+        See ``self.get_plan_queue_size()`` method.
         """
         return await self._r_pool.llen(self._name_plan_queue)
 
@@ -282,7 +288,7 @@ class PlanQueueOperations:
 
     async def _get_plan_queue(self):
         """
-        See `self.get_plan_queue()` method.
+        See ``self.get_plan_queue()`` method.
         """
         all_plans_json = await self._r_pool.lrange(self._name_plan_queue, 0, -1)
         return [json.loads(_) for _ in all_plans_json]
@@ -303,7 +309,7 @@ class PlanQueueOperations:
 
     async def _get_plan(self, pos):
         """
-        See `self._get_plan` method.
+        See ``self._get_plan`` method.
         """
         if pos == "back":
             index = -1
@@ -325,24 +331,24 @@ class PlanQueueOperations:
         Parameters
         ----------
         pos: int or str
-            Position of the element (0, ..) or (-1, ..), `front` or `back`.
+            Position of the element (0, ..) or (-1, ..), ``front`` or ``back``.
 
         Returns
         -------
         dict
-            Dictionary of plan parameters. Returns `{}` if no plan is found at the index.
+            Dictionary of plan parameters. Returns ``{}`` if no plan is found at the index.
 
         Raises
         ------
         TypeError
-            Incorrect value of `pos` (most likely a string different from `front` or `black`
+            Incorrect value of ``pos`` (most likely a string different from ``front`` or ``black``
         """
         async with self._lock:
             return await self._get_plan(pos)
 
     async def _remove_plan(self, plan, single=True):
         """
-        Remove exactly a plan from the queue. If `single=True` then the exception is
+        Remove exactly a plan from the queue. If ``single=True`` then the exception is
         raised in case of no or multiple matching plans are found in the queue.
         The function is not part of user API and shouldn't be used on exception from
         the other methods of the class.
@@ -360,7 +366,7 @@ class PlanQueueOperations:
         Raises
         ------
         RuntimeError
-            No or multiple matching plans are removed and `single=True`.
+            No or multiple matching plans are removed and ``single=True``.
         """
         n_rem_plans = await self._r_pool.lrem(self._name_plan_queue, 0, json.dumps(plan))
         if (n_rem_plans != 1) and single:
@@ -370,7 +376,7 @@ class PlanQueueOperations:
 
     async def _pop_plan_from_queue(self, pos="back"):
         """
-        See `self._pop_plan_from_queue` method
+        See ``self._pop_plan_from_queue`` method
         """
         if pos == "back":
             plan_json = await self._r_pool.rpop(self._name_plan_queue)
@@ -397,18 +403,18 @@ class PlanQueueOperations:
         ----------
         pos: int or str
             Integer index specified position in the queue. Available string values: "front" or "back".
-            The range for the index is `-qsize..qsize-1`: `0, -qsize` - front element of the queue,
-            `-1, qsize-1` - back element of the queue.
+            The range for the index is ``-qsize..qsize-1``: ``0, -qsize`` - front element of the queue,
+            ``-1, qsize-1`` - back element of the queue.
 
         Returns
         -------
         dict or None
-            The last plan in the queue represented as a dictionary or `{}` if the queue is empty.
+            The last plan in the queue represented as a dictionary or ``{}`` if the queue is empty.
 
         Raises
         ------
         ValueError
-            Incorrect value of the parameter `pos` (typically unrecognized string).
+            Incorrect value of the parameter ``pos`` (typically unrecognized string).
 
         """
         async with self._lock:
@@ -416,7 +422,7 @@ class PlanQueueOperations:
 
     async def _add_plan_to_queue(self, plan, pos="back"):
         """
-        See `self.add_plan_to_queue` method.
+        See ``self.add_plan_to_queue`` method.
         """
         if "plan_uid" not in plan:
             plan = self.set_new_plan_uuid(plan)
@@ -455,13 +461,13 @@ class PlanQueueOperations:
             Plan represented as a dictionary of parameters
         pos: int or str
             Integer that specifies the position index, "front" or "back".
-            If `pos` is in the range `1..qsize-1` the plan is inserted
-            to the specified position and plans at positions `pos..qsize-1`
-            are shifted by one position to the right. If `-qsize<pos<0` the
+            If ``pos`` is in the range ``1..qsize-1`` the plan is inserted
+            to the specified position and plans at positions ``pos..qsize-1``
+            are shifted by one position to the right. If ``-qsize<pos<0`` the
             plan is inserted at the positon counting from the back of the queue
-            (-1 - the last element of the queue). If `pos>=qsize`,
-            the plan is added to the back of the queue. If `pos==0` or
-            `pos<=-qsize`, the plan is pushed to the front of the queue.
+            (-1 - the last element of the queue). If ``pos>=qsize``,
+            the plan is added to the back of the queue. If ``pos==0`` or
+            ``pos<=-qsize``, the plan is pushed to the front of the queue.
 
         Returns
         -------
@@ -471,16 +477,16 @@ class PlanQueueOperations:
         Raises
         ------
         ValueError
-            Incorrect value of the parameter `pos` (typically unrecognized string).
+            Incorrect value of the parameter ``pos`` (typically unrecognized string).
         TypeError
-            Incorrect type of `plan` (should be dict)
+            Incorrect type of ``plan`` (should be dict)
         """
         async with self._lock:
             return await self._add_plan_to_queue(plan, pos=pos)
 
     async def _clear_plan_queue(self):
         """
-        See `self.clear_plan_queue()` method.
+        See ``self.clear_plan_queue()`` method.
         """
         while await self._get_plan_queue_size():
             await self._pop_plan_from_queue()
@@ -516,7 +522,7 @@ class PlanQueueOperations:
 
     async def _get_plan_history_size(self):
         """
-        See `self.get_plan_history_size()` method.
+        See ``self.get_plan_history_size()`` method.
         """
         return await self._r_pool.llen(self._name_plan_history)
 
@@ -534,7 +540,7 @@ class PlanQueueOperations:
 
     async def _get_plan_history(self):
         """
-        See `self.get_plan_history()` method.
+        See ``self.get_plan_history()`` method.
         """
         all_plans_json = await self._r_pool.lrange(self._name_plan_history, 0, -1)
         return [json.loads(_) for _ in all_plans_json]
@@ -555,7 +561,7 @@ class PlanQueueOperations:
 
     async def _clear_plan_history(self):
         """
-        See `self.clear_plan_history()` method.
+        See ``self.clear_plan_history()`` method.
         """
         while await self._get_plan_history_size():
             await self._r_pool.rpop(self._name_plan_history)
@@ -573,7 +579,7 @@ class PlanQueueOperations:
 
     async def _set_next_plan_as_running(self):
         """
-        See `self.set_next_plan_as_running()` method.
+        See ``self.set_next_plan_as_running()`` method.
         """
         # UID remains in the `self._uid_set` after this operation.
         if not await self._is_plan_running():
@@ -590,21 +596,21 @@ class PlanQueueOperations:
     async def set_next_plan_as_running(self):
         """
         Sets the next plan from the queue as a running plan. The plan is removed
-        from the queue. UID remains in `self._uid_set`, i.e. plan with the same UID
+        from the queue. UID remains in ``self._uid_set``, i.e. plan with the same UID
         may not be added to the queue while it is being executed.
 
         Returns
         -------
         dict
             The plan that was set as currently running. If another plan is currently
-            running or the queue is empty, then `{}` is returned.
+            running or the queue is empty, then ``{}`` is returned.
         """
         async with self._lock:
             return await self._set_next_plan_as_running()
 
     async def _set_processed_plan_as_completed(self, exit_status):
         """
-        See `self.set_processed_plan_as_completed` method.
+        See ``self.set_processed_plan_as_completed`` method.
         """
         # Note: UID remains in the `self._uid_set` after this operation
         if await self._is_plan_running():
@@ -619,8 +625,8 @@ class PlanQueueOperations:
 
     async def set_processed_plan_as_completed(self, exit_status):
         """
-        Moves currently executed plan to history and sets `exit_status` key.
-        UID is removed from `self._uid_set`, so a copy of the plan with
+        Moves currently executed plan to history and sets ``exit_status`` key.
+        UID is removed from ``self._uid_set``, so a copy of the plan with
         the same UID may be added to the queue.
 
         Parameters
@@ -631,15 +637,15 @@ class PlanQueueOperations:
         Returns
         -------
         dict
-            The plan added to the history including `exit_status`. If another no plan is currently
-            running, then `{}` is returned.
+            The plan added to the history including ``exit_status``. If another no plan is currently
+            running, then ``{}`` is returned.
         """
         async with self._lock:
             return await self._set_processed_plan_as_completed(exit_status=exit_status)
 
     async def _set_processed_plan_as_stopped(self, exit_status):
         """
-        See `self.set_prcessed_plan_as_stopped()` method.
+        See ``self.set_prcessed_plan_as_stopped()`` method.
         """
         # Note: UID is removed from `self._uid_set`.
         if await self._is_plan_running():
@@ -655,8 +661,8 @@ class PlanQueueOperations:
     async def set_processed_plan_as_stopped(self, exit_status):
         """
         Pushes currently executed plan to the beginning of the queue and adds
-        it to history with additional sets `exit_status` key.
-        UID is remains in `self._uid_set`.
+        it to history with additional sets ``exit_status`` key.
+        UID is remains in ``self._uid_set``.
 
         Parameters
         ----------
@@ -666,8 +672,8 @@ class PlanQueueOperations:
         Returns
         -------
         dict
-            The plan added to the history including `exit_status`. If another no plan is currently
-            running, then `{}` is returned.
+            The plan added to the history including ``exit_status``. If another no plan is currently
+            running, then ``{}`` is returned.
         """
         async with self._lock:
             return await self._set_processed_plan_as_stopped(exit_status=exit_status)

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -553,6 +553,21 @@ class PlanQueueOperations:
         async with self._lock:
             return await self._get_plan_history()
 
+    async def _clear_plan_history(self):
+        """
+        See `self.clear_plan_history()` method.
+        """
+        while await self._get_plan_history_size():
+            await self._r_pool.rpop(self._name_plan_history)
+
+    async def clear_plan_history(self):
+        """
+        Remove all entries from the plan queue. Does not touch the running plan.
+        The plan may be pushed back into the queue if it is stopped.
+        """
+        async with self._lock:
+            await self._clear_plan_history()
+
     # ----------------------------------------------------------------------
     #          Standard plan operations during queue execution
 

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -341,7 +341,7 @@ class PlanQueueOperations:
         Raises
         ------
         TypeError
-            Incorrect value of ``pos`` (most likely a string different from ``front`` or ``black``
+            Incorrect value of ``pos`` (most likely a string different from ``front`` or ``black``)
         """
         async with self._lock:
             return await self._get_plan(pos)

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -61,7 +61,7 @@ class CliClient:
         """
         command_dict = {
             "ping": "",
-            "queue_view": "queue_view",
+            "get_queue": "get_queue",
             "list_allowed_plans_and_devices": "list_allowed_plans_and_devices",
             "add_to_queue": "add_to_queue",
             "pop_from_queue": "pop_from_queue",

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -66,6 +66,8 @@ class CliClient:
             "add_to_queue": "add_to_queue",
             "pop_from_queue": "pop_from_queue",
             "clear_queue": "clear_queue",
+            "get_history": "get_history",
+            "clear_history": "clear_history",
             "create_environment": "create_environment",
             "close_environment": "close_environment",
             "process_queue": "process_queue",
@@ -215,6 +217,8 @@ def qserver():
         command = "ping"
         print("Running QSever monitor. Press Ctrl-C to exit ...")
 
+    exit_code = None
+
     re_server = CliClient(address=args.address)
     try:
         while True:
@@ -227,11 +231,20 @@ def qserver():
 
             if not msg_err:
                 print(f"{current_time} - MESSAGE: {pprint.pformat(msg)}")
+                exit_code = None
             else:
                 print(f"{current_time} - ERROR: {msg_err}")
+                exit_code = 2
 
             if not monitor_on:
                 break
             ttime.sleep(1)
+    except Exception as ex:
+        logger.exception("Exception occurred: %s.", str(ex))
+        exit_code = 3
     except KeyboardInterrupt:
         print("\nThe program was manually stopped.")
+        exit_code = None
+
+    # Note: exit codes are arbitrarily selected. None translates to 0.
+    return exit_code

--- a/bluesky_queueserver/manager/tests/test_general.py
+++ b/bluesky_queueserver/manager/tests/test_general.py
@@ -108,7 +108,7 @@ def test_qserver_cli_and_manager(re_manager):
     assert n_plans == 3, "Incorrect number of plans in the queue"
     assert not is_plan_running, "Plan is executed while it shouldn't"
 
-    subprocess.call(["qserver", "-c", "queue_view"])
+    subprocess.call(["qserver", "-c", "get_queue"])
     subprocess.call(["qserver", "-c", "pop_from_queue"])
 
     n_plans, is_plan_running = get_reduced_state_info()

--- a/bluesky_queueserver/manager/tests/test_general.py
+++ b/bluesky_queueserver/manager/tests/test_general.py
@@ -4,6 +4,7 @@ import asyncio
 import pytest
 
 from bluesky_queueserver.manager.qserver_cli import CliClient
+from bluesky_queueserver.manager.plan_queue_ops import PlanQueueOperations
 
 
 @pytest.fixture
@@ -17,13 +18,25 @@ def re_manager():
 
     yield  # Nothing to return
 
+    def clear_redis_pool():
+        # Remove all Redis entries.
+        pq = PlanQueueOperations()
+
+        async def run():
+            await pq.start()
+            await pq.delete_pool_entries()
+
+        asyncio.run(run())
+
     # Try to stop the manager in a nice way first by sending the command
     subprocess.call(["qserver", "-c", "stop_manager"])
     try:
         p.wait(5)
+        clear_redis_pool()
     except subprocess.TimeoutExpired:
         # The manager is not responsive, so just kill the process.
         p.kill()
+        clear_redis_pool()
         assert False, "RE Manager failed to stop"
 
 
@@ -84,82 +97,71 @@ def test_qserver_cli_and_manager(re_manager):
     ), "Timeout while waiting for manager to initialize."
 
     # Clear queue
-    subprocess.call(["qserver", "-c", "clear_queue"])
+    assert subprocess.call(["qserver", "-c", "clear_queue"]) == 0
 
     # Request the list of allowed plans and devices (we don't check what is returned)
-    subprocess.call(["qserver", "-c", "list_allowed_plans_and_devices"], stdout=subprocess.DEVNULL)
+    assert subprocess.call(["qserver", "-c", "list_allowed_plans_and_devices"], stdout=subprocess.DEVNULL) == 0
 
     # Add a number of plans
-    subprocess.call(["qserver", "-c", "add_to_queue", "-p", "{'name':'count', 'args':[['det1', 'det2']]}"])
-    subprocess.call(
-        ["qserver", "-c", "add_to_queue", "-p", "{'name':'scan', 'args':[['det1', 'det2'], 'motor', -1, 1, 10]}"]
-    )
-    subprocess.call(
-        [
-            "qserver",
-            "-c",
-            "add_to_queue",
-            "-p",
-            "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}",
-        ]
-    )
+    plan_1 = "{'name':'count', 'args':[['det1', 'det2']]}"
+    plan_2 = "{'name':'scan', 'args':[['det1', 'det2'], 'motor', -1, 1, 10]}"
+    plan_3 = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}"
+    assert subprocess.call(["qserver", "-c", "add_to_queue", "-p", plan_1]) == 0
+    assert subprocess.call(["qserver", "-c", "add_to_queue", "-p", plan_2]) == 0
+    assert subprocess.call(["qserver", "-c", "add_to_queue", "-p", plan_3]) == 0
 
     n_plans, is_plan_running = get_reduced_state_info()
     assert n_plans == 3, "Incorrect number of plans in the queue"
     assert not is_plan_running, "Plan is executed while it shouldn't"
 
-    subprocess.call(["qserver", "-c", "get_queue"])
-    subprocess.call(["qserver", "-c", "pop_from_queue"])
+    assert subprocess.call(["qserver", "-c", "get_queue"]) == 0
+    assert subprocess.call(["qserver", "-c", "pop_from_queue"]) == 0
 
     n_plans, is_plan_running = get_reduced_state_info()
     assert n_plans == 2, "Incorrect number of plans in the queue"
 
-    subprocess.call(["qserver", "-c", "create_environment"])
+    assert subprocess.call(["qserver", "-c", "create_environment"]) == 0
 
     assert wait_for_condition(
         time=3, condition=condition_environment_created
     ), "Timeout while waiting for environment to be created"
 
-    subprocess.call(["qserver", "-c", "process_queue"])
+    assert subprocess.call(["qserver", "-c", "process_queue"]) == 0
 
     assert wait_for_condition(
         time=60, condition=condition_queue_processing_finished
     ), "Timeout while waiting for process to finish"
 
+    # Smoke test for 'get_history' and 'clear_history'
+    assert subprocess.call(["qserver", "-c", "get_history"]) == 0
+    assert subprocess.call(["qserver", "-c", "clear_history"]) == 0
+
     # Queue is expected to be empty (processed). Load one more plan.
-    subprocess.call(
-        [
-            "qserver",
-            "-c",
-            "add_to_queue",
-            "-p",
-            "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}",
-        ]
-    )
+    assert subprocess.call(["qserver", "-c", "add_to_queue", "-p", plan_3]) == 0
 
     n_plans, is_plan_running = get_reduced_state_info()
     assert n_plans == 1, "Incorrect number of plans in the queue"
 
-    subprocess.call(["qserver", "-c", "process_queue"])
+    assert subprocess.call(["qserver", "-c", "process_queue"]) == 0
     ttime.sleep(1)
-    subprocess.call(["qserver", "-c", "re_pause", "-p", "immediate"])
-    subprocess.call(["qserver", "-c", "re_continue", "-p", "resume"])
+    assert subprocess.call(["qserver", "-c", "re_pause", "-p", "immediate"]) == 0
+    assert subprocess.call(["qserver", "-c", "re_continue", "-p", "resume"]) == 0
     ttime.sleep(1)
-    subprocess.call(["qserver", "-c", "re_pause", "-p", "deferred"])
+    assert subprocess.call(["qserver", "-c", "re_pause", "-p", "deferred"]) == 0
     ttime.sleep(2)  # Need some time to finish the current plan step
-    subprocess.call(["qserver", "-c", "re_continue", "-p", "resume"])
+    assert subprocess.call(["qserver", "-c", "re_continue", "-p", "resume"]) == 0
 
     assert wait_for_condition(
         time=60, condition=condition_queue_processing_finished
     ), "Timeout while waiting for process to finish"
 
-    subprocess.call(["qserver", "-c", "add_to_queue", "-p", "{'name':'count', 'args':[['det1', 'det2']]}"])
-    subprocess.call(["qserver", "-c", "add_to_queue", "-p", "{'name':'count', 'args':[['det1', 'det2']]}"])
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p", plan_1])
+    subprocess.call(["qserver", "-c", "add_to_queue", "-p", plan_1])
 
     n_plans, is_plan_running = get_reduced_state_info()
     assert n_plans == 2, "Incorrect number of plans in the queue"
 
-    subprocess.call(["qserver", "-c", "process_queue"])
+    assert subprocess.call(["qserver", "-c", "process_queue"]) == 0
 
     assert wait_for_condition(
         time=60, condition=condition_queue_processing_finished
@@ -168,28 +170,20 @@ def test_qserver_cli_and_manager(re_manager):
     # Test 'killing' the manager during running plan. Load long plan and two short ones.
     #   The tests checks if execution of the queue is continued uninterrupted after
     #   the manager restart
-    subprocess.call(
-        [
-            "qserver",
-            "-c",
-            "add_to_queue",
-            "-p",
-            "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}",
-        ]
-    )
-    subprocess.call(["qserver", "-c", "add_to_queue", "-p", "{'name':'count', 'args':[['det1', 'det2']]}"])
-    subprocess.call(["qserver", "-c", "add_to_queue", "-p", "{'name':'count', 'args':[['det1', 'det2']]}"])
+    assert subprocess.call(["qserver", "-c", "add_to_queue", "-p", plan_3]) == 0
+    assert subprocess.call(["qserver", "-c", "add_to_queue", "-p", plan_3]) == 0
+    assert subprocess.call(["qserver", "-c", "add_to_queue", "-p", plan_3]) == 0
     n_plans, is_plan_running = get_reduced_state_info()
     assert n_plans == 3, "Incorrect number of plans in the queue"
 
-    subprocess.call(["qserver", "-c", "process_queue"])
+    assert subprocess.call(["qserver", "-c", "process_queue"]) == 0
     ttime.sleep(1)
-    subprocess.call(["qserver", "-c", "kill_manager"])
+    assert subprocess.call(["qserver", "-c", "kill_manager"]) != 0
     assert wait_for_condition(
         time=60, condition=condition_queue_processing_finished
     ), "Timeout while waiting for process to finish"
 
-    subprocess.call(["qserver", "-c", "close_environment"])
+    assert subprocess.call(["qserver", "-c", "close_environment"]) == 0
 
     assert wait_for_condition(
         time=5, condition=condition_environment_closed

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -22,9 +22,9 @@ def pq():
 def test_running_plan_info(pq):
     """
     Basic test for the following methods:
-    ``PlanQueueOperations.is_plan_running()``
-    ``PlanQueueOperations.get_running_plan_info()``
-    ``PlanQueueOperations.delete_pool_entries()``
+    `PlanQueueOperations.is_plan_running()`
+    `PlanQueueOperations.get_running_plan_info()`
+    `PlanQueueOperations.delete_pool_entries()`
     """
 
     async def testing():
@@ -147,7 +147,7 @@ def test_new_plan_uid(pq):
 # fmt: on
 def test_set_new_plan_uuid(pq, plan):
     """
-    Basic test for the method ``set_new_plan_uuid``.
+    Basic test for the method ``set_new_plan_uuid()``.
     """
     uid = plan.get("plan_uid", None)
 
@@ -161,7 +161,7 @@ def test_set_new_plan_uuid(pq, plan):
 
 def test_uid_set(pq):
     """
-    Basic test for functions associated with ``_uid_set``
+    Basic test for functions associated with `_uid_set`
     """
     pq._uid_set_add("a")
     pq._uid_set_add("b")
@@ -181,7 +181,7 @@ def test_uid_set(pq):
 
 def test_uid_set_initialize(pq):
     """
-    Basic test for functions associated with ``_uid_set_initialize``
+    Basic test for functions associated with ``_uid_set_initialize()``
     """
 
     async def testing():
@@ -199,7 +199,7 @@ def test_uid_set_initialize(pq):
 
 def test_remove_plan(pq):
     """
-    Basic test for functions associated with ``_remove_plan``
+    Basic test for functions associated with ``_remove_plan()``
     """
 
     async def testing():

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -446,6 +446,11 @@ def test_plan_to_history_functions(pq):
         assert len(plan_history) == 3
         assert plan_history == plans
 
+        await pq.clear_plan_history()
+
+        plan_history = await pq.get_plan_history()
+        assert plan_history == []
+
     asyncio.run(testing())
 
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -22,9 +22,9 @@ def pq():
 def test_running_plan_info(pq):
     """
     Basic test for the following methods:
-    `PlanQueueOperations.is_plan_running()`
-    `PlanQueueOperations.get_running_plan_info()`
-    `PlanQueueOperations.delete_pool_entries()`
+    ``PlanQueueOperations.is_plan_running()``
+    ``PlanQueueOperations.get_running_plan_info()``
+    ``PlanQueueOperations.delete_pool_entries()``
     """
 
     async def testing():
@@ -62,7 +62,7 @@ def test_running_plan_info(pq):
 # fmt: on
 def test_queue_clean(pq, plan_running, plans, result_running, result_plans):
     """
-    Test for `_queue_clean()` method
+    Test for ``_queue_clean()`` method
     """
 
     async def testing():
@@ -107,7 +107,7 @@ def test_verify_plan_type(pq, plan, result):
 # fmt: on
 def test_verify_plan(pq, plan, result, errmsg):
     """
-    Tests for method `_verify_plan()`.
+    Tests for method ``_verify_plan()``.
     """
     # Set two existiing plans and then set one of them as running
     existing_plans = [{"plan_uid": "two"}, {"plan_uid": "three"}]
@@ -134,7 +134,7 @@ def test_verify_plan(pq, plan, result, errmsg):
 
 def test_new_plan_uid(pq):
     """
-    Smoke test for the method `_new_plan_uid()`
+    Smoke test for the method ``_new_plan_uid()``.
     """
     assert isinstance(pq._new_plan_uid(), str)
 
@@ -147,7 +147,7 @@ def test_new_plan_uid(pq):
 # fmt: on
 def test_set_new_plan_uuid(pq, plan):
     """
-    Basic test for the method `set_new_plan_uuid`
+    Basic test for the method ``set_new_plan_uuid``.
     """
     uid = plan.get("plan_uid", None)
 
@@ -161,7 +161,7 @@ def test_set_new_plan_uuid(pq, plan):
 
 def test_uid_set(pq):
     """
-    Basic test for functions associated with `_uid_set`
+    Basic test for functions associated with ``_uid_set``
     """
     pq._uid_set_add("a")
     pq._uid_set_add("b")
@@ -181,7 +181,7 @@ def test_uid_set(pq):
 
 def test_uid_set_initialize(pq):
     """
-    Basic test for functions associated with `_uid_set_initialize`
+    Basic test for functions associated with ``_uid_set_initialize``
     """
 
     async def testing():
@@ -199,7 +199,7 @@ def test_uid_set_initialize(pq):
 
 def test_remove_plan(pq):
     """
-    Basic test for functions associated with `_remove_plan`
+    Basic test for functions associated with ``_remove_plan``
     """
 
     async def testing():
@@ -259,7 +259,7 @@ def test_remove_plan(pq):
 # fmt: on
 def test_get_plan_1(pq, pos, name):
     """
-    Basic test for the function `PlanQueueOperations.get_plan()`
+    Basic test for the function ``PlanQueueOperations.get_plan()``
     """
 
     async def testing():
@@ -280,7 +280,7 @@ def test_get_plan_1(pq, pos, name):
 
 def test_add_plan_to_queue_1(pq):
     """
-    Basic test for the function `PlanQueueOperations.add_plan_to_queue()`
+    Basic test for the function ``PlanQueueOperations.add_plan_to_queue()``
     """
 
     async def add_plan(plan, n, **kwargs):
@@ -315,7 +315,7 @@ def test_add_plan_to_queue_1(pq):
 
 def test_add_plan_to_queue_2_fail(pq):
     """
-    Failing tests for the function `PlanQueueOperations.add_plan_to_queue()`
+    Failing tests for the function ``PlanQueueOperations.add_plan_to_queue()``
     """
 
     async def testing():
@@ -351,7 +351,7 @@ def test_add_plan_to_queue_2_fail(pq):
 # fmt: on
 def test_pop_plan_from_queue_1(pq, pos, name):
     """
-    Basic test for the function `PlanQueueOperations.pop_plan_from_queue()`
+    Basic test for the function ``PlanQueueOperations.pop_plan_from_queue()``
     """
 
     async def testing():
@@ -378,7 +378,7 @@ def test_pop_plan_from_queue_1(pq, pos, name):
 @pytest.mark.parametrize("pos", ["front", "back", 0, 1, -1])
 def test_pop_plan_from_queue_2(pq, pos):
     """
-    Test for the function `PlanQueueOperations.pop_plan_from_queue()`:
+    Test for the function ``PlanQueueOperations.pop_plan_from_queue()``:
     the case of empty queue.
     """
 
@@ -391,7 +391,7 @@ def test_pop_plan_from_queue_2(pq, pos):
 
 def test_pop_plan_from_queue_3_fail(pq):
     """
-    Failing tests for the function `PlanQueueOperations.pop_plan_from_queue()`
+    Failing tests for the function ``PlanQueueOperations.pop_plan_from_queue()``
     """
 
     async def testing():
@@ -403,7 +403,7 @@ def test_pop_plan_from_queue_3_fail(pq):
 
 def test_clear_plan_queue(pq):
     """
-    Test for `PlanQueueOperations.clear_plan_queue` function
+    Test for ``PlanQueueOperations.clear_plan_queue`` function
     """
 
     async def testing():
@@ -430,7 +430,7 @@ def test_clear_plan_queue(pq):
 
 def test_plan_to_history_functions(pq):
     """
-    Test for `PlanQueueOperations._add_plan_to_history()` method.
+    Test for ``PlanQueueOperations._add_plan_to_history()`` method.
     """
 
     async def testing():
@@ -456,7 +456,7 @@ def test_plan_to_history_functions(pq):
 
 def test_set_next_plan_as_running(pq):
     """
-    Test for `PlanQueueOperations.set_next_plan_as_running()` function
+    Test for ``PlanQueueOperations.set_next_plan_as_running()`` function
     """
 
     async def testing():
@@ -487,7 +487,7 @@ def test_set_next_plan_as_running(pq):
 
 def test_set_processed_plan_as_completed(pq):
     """
-    Test for `PlanQueueOperations.set_processed_plan_as_completed()` function.
+    Test for ``PlanQueueOperations.set_processed_plan_as_completed()`` function.
     The function moves currently running plan to history.
     """
 
@@ -540,7 +540,7 @@ def test_set_processed_plan_as_completed(pq):
 
 def test_set_processed_plan_as_stopped(pq):
     """
-    Test for `PlanQueueOperations.set_processed_plan_as_stopped()` function.
+    Test for ``PlanQueueOperations.set_processed_plan_as_stopped()`` function.
     The function pushes running plan back to the queue and saves it in history as well.
     """
     plans = [{"plan_uid": 1, "name": "a"}, {"plan_uid": 2, "name": "b"}, {"plan_uid": 3, "name": "c"}]

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -110,7 +110,7 @@ class REResumeOptions(str, Enum):
 
 
 @app.get("/")
-async def _hello_handler():
+async def _ping_handler():
     """
     May be called to get response from the server. Returns the number of plans in the queue.
     """

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -110,7 +110,7 @@ class REResumeOptions(str, Enum):
 
 
 @app.get("/")
-async def _ping_handler():
+async def ping_handler():
     """
     May be called to get response from the server. Returns the number of plans in the queue.
     """
@@ -119,7 +119,7 @@ async def _ping_handler():
 
 
 @app.get("/get_queue")
-async def _get_queue_handler():
+async def get_queue_handler():
     """
     Returns the contents of the current queue.
     """
@@ -128,7 +128,7 @@ async def _get_queue_handler():
 
 
 @app.get("/list_allowed_plans_and_devices")
-async def _list_allowed_plans_and_devices_handler():
+async def list_allowed_plans_and_devices_handler():
     """
     Returns the lists of allowed plans and devices.
     """
@@ -137,7 +137,7 @@ async def _list_allowed_plans_and_devices_handler():
 
 
 @app.post("/add_to_queue")
-async def _add_to_queue_handler(payload: dict):
+async def add_to_queue_handler(payload: dict):
     """
     Adds new plan to the end of the queue
     """
@@ -147,7 +147,7 @@ async def _add_to_queue_handler(payload: dict):
 
 
 @app.post("/clear_queue")
-async def _clear_queue_handler():
+async def clear_queue_handler():
     """
     Clear the plan queue.
     """
@@ -156,7 +156,7 @@ async def _clear_queue_handler():
 
 
 @app.post("/pop_from_queue")
-async def _pop_from_queue_handler():
+async def pop_from_queue_handler():
     """
     Pop the last item from back of the queue
     """
@@ -165,7 +165,7 @@ async def _pop_from_queue_handler():
 
 
 @app.get("/get_history")
-async def _get_history_handler():
+async def get_history_handler():
     """
     Returns the plan history (list of dicts).
     """
@@ -174,7 +174,7 @@ async def _get_history_handler():
 
 
 @app.post("/clear_history")
-async def _clear_history_handler():
+async def clear_history_handler():
     """
     Clear plan history.
     """
@@ -183,7 +183,7 @@ async def _clear_history_handler():
 
 
 @app.post("/create_environment")
-async def _create_environment_handler():
+async def create_environment_handler():
     """
     Creates RE environment: creates RE Worker process, starts and configures Run Engine.
     """
@@ -192,7 +192,7 @@ async def _create_environment_handler():
 
 
 @app.post("/close_environment")
-async def _close_environment_handler():
+async def close_environment_handler():
     """
     Deletes RE environment. In the current 'demo' prototype the environment will be deleted
     only after RE completes the current scan.
@@ -202,7 +202,7 @@ async def _close_environment_handler():
 
 
 @app.post("/process_queue")
-async def _process_queue_handler():
+async def process_queue_handler():
     """
     Start execution of the loaded queue. Additional runs can be added to the queue while
     it is executed. If the queue is empty, then nothing will happen.
@@ -212,7 +212,7 @@ async def _process_queue_handler():
 
 
 @app.post("/re_pause")
-async def _re_pause_handler(payload: dict):
+async def re_pause_handler(payload: dict):
     """
     Pause Run Engine
     """
@@ -227,7 +227,7 @@ async def _re_pause_handler(payload: dict):
 
 
 @app.post("/re_continue")
-async def _re_continue_handler(payload: dict):
+async def re_continue_handler(payload: dict):
     """
     Control Run Engine in the paused state
     """
@@ -242,7 +242,7 @@ async def _re_continue_handler(payload: dict):
 
 
 @app.post("/print_db_uids")
-async def _print_db_uids_handler():
+async def print_db_uids_handler():
     """
     Prints the UIDs of the scans in 'temp' database. Just for the demo.
     Not part of future API.

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -118,12 +118,12 @@ async def _hello_handler():
     return msg
 
 
-@app.get("/queue_view")
-async def _queue_view_handler():
+@app.get("/get_queue")
+async def _get_queue_handler():
     """
     Returns the contents of the current queue.
     """
-    msg = await re_server._send_command(command="queue_view")
+    msg = await re_server._send_command(command="get_queue")
     return msg
 
 

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -149,7 +149,7 @@ async def _add_to_queue_handler(payload: dict):
 @app.post("/clear_queue")
 async def _clear_queue_handler():
     """
-    Adds new plan to the end of the queue
+    Clear the plan queue.
     """
     msg = await re_server.send_command(command="clear_queue")
     return msg
@@ -161,6 +161,24 @@ async def _pop_from_queue_handler():
     Pop the last item from back of the queue
     """
     msg = await re_server.send_command(command="pop_from_queue")
+    return msg
+
+
+@app.get("/get_history")
+async def _get_history_handler():
+    """
+    Returns the plan history (list of dict).
+    """
+    msg = await re_server.send_command(command="get_history")
+    return msg
+
+
+@app.post("/clear_history")
+async def _clear_history_handler():
+    """
+    Clear plan history.
+    """
+    msg = await re_server.send_command(command="clear_history")
     return msg
 
 

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -167,7 +167,7 @@ async def _pop_from_queue_handler():
 @app.get("/get_history")
 async def _get_history_handler():
     """
-    Returns the plan history (list of dict).
+    Returns the plan history (list of dicts).
     """
     msg = await re_server.send_command(command="get_history")
     return msg

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -183,3 +183,27 @@ def test_http_server_clear_queue_handler(re_manager, fastapi_server, add_plans_t
 
     resp3 = _request_to_json("get", "/get_queue")
     assert len(resp3["queue"]) == 0
+
+
+def test_http_server_plan_history(re_manager, fastapi_server):  # noqa F811
+    # Select very short plan
+    plan = {"plan": {"name": "count", "args": [["det1", "det2"]]}}
+    _request_to_json("post", "/add_to_queue", json=plan)
+    _request_to_json("post", "/add_to_queue", json=plan)
+    _request_to_json("post", "/add_to_queue", json=plan)
+
+    _request_to_json("post", "/create_environment")
+    ttime.sleep(1)
+
+    _request_to_json("post", "/process_queue")
+    ttime.sleep(5)
+
+    resp1 = _request_to_json("get", "/get_history")
+    assert len(resp1["history"]) == 3
+    assert resp1["history"][0]["name"] == "count"
+
+    resp2 = _request_to_json("post", "/clear_history")
+    assert resp2["success"] is True
+
+    resp3 = _request_to_json("get", "/get_history")
+    assert resp3["history"] == []

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -16,7 +16,7 @@ def _request_to_json(request_type, path, **kwargs):
     return resp
 
 
-def test_http_server_hello_handler(re_manager, fastapi_server):  # noqa F811
+def test_http_server_ping_handler(re_manager, fastapi_server):  # noqa F811
     resp = _request_to_json("get", "/")
     assert resp["msg"] == "RE Manager"
     assert resp["manager_state"] == "idle"

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -173,4 +173,13 @@ def test_http_server_close_print_db_uids_handler(re_manager, fastapi_server, add
     # TODO: can we return the list of UIDs here?
 
 
-# TODO: consider having an entry point for 'qserver -c clear_queue'.
+def test_http_server_clear_queue_handler(re_manager, fastapi_server, add_plans_to_queue):  # noqa F811
+    resp1 = _request_to_json("get", "/get_queue")
+    assert len(resp1["queue"]) == 3
+
+    resp2 = _request_to_json("post", "/clear_queue")
+    assert resp2["success"] is True
+    assert resp2["msg"] == "Plan queue is now empty."
+
+    resp3 = _request_to_json("get", "/get_queue")
+    assert len(resp3["queue"]) == 0

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -25,9 +25,10 @@ def test_http_server_hello_handler(re_manager, fastapi_server):  # noqa F811
     assert resp["worker_environment_exists"] is False
 
 
-def test_http_server_queue_view_handler(re_manager, fastapi_server):  # noqa F811
-    resp = _request_to_json("get", "/queue_view")
+def test_http_server_get_queue_handler(re_manager, fastapi_server):  # noqa F811
+    resp = _request_to_json("get", "/get_queue")
     assert resp["queue"] == []
+    assert resp["running_plan"] == {}
 
 
 def test_http_server_list_allowed_plans_and_devices(re_manager, fastapi_server):  # noqa F811
@@ -44,17 +45,19 @@ def test_http_server_add_to_queue_handler(re_manager, fastapi_server):  # noqa F
     assert resp1["args"] == [["det1", "det2"]]
     assert "plan_uid" in resp1
 
-    resp2 = _request_to_json("get", "/queue_view")
+    resp2 = _request_to_json("get", "/get_queue")
     assert resp2["queue"] != []
     assert len(resp2["queue"]) == 1
     assert resp2["queue"][0] == resp1
+    assert resp2["running_plan"] == {}
 
 
 def test_http_server_pop_from_queue_handler(re_manager, fastapi_server, add_plans_to_queue):  # noqa F811
 
-    resp1 = _request_to_json("get", "/queue_view")
+    resp1 = _request_to_json("get", "/get_queue")
     assert resp1["queue"] != []
     assert len(resp1["queue"]) == 3
+    assert resp1["running_plan"] == {}
 
     resp2 = _request_to_json("post", "/pop_from_queue", json={})
     assert resp2["name"] == "count"
@@ -93,18 +96,26 @@ def test_http_server_process_queue_handler(re_manager, fastapi_server, add_plans
 
     resp2 = _request_to_json("post", "/create_environment")
     assert resp2 == {"success": True, "msg": ""}
-    resp2a = _request_to_json("get", "/queue_view")
+    resp2a = _request_to_json("get", "/get_queue")
     assert len(resp2a["queue"]) == 3
+    assert resp2a["running_plan"] == {}
 
     ttime.sleep(1)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
 
     resp3 = _request_to_json("post", "/process_queue")
     assert resp3 == {"success": True, "msg": ""}
 
+    ttime.sleep(1)
+    # The plan is currently being executed. 'get_queue' is expected to return currently executed plan.
+    resp4 = _request_to_json("get", "/get_queue")
+    assert len(resp4["queue"]) == 2
+    assert resp4["running_plan"]["name"] == "count"  # Check name of the running plan
+
     ttime.sleep(25)  # Wait until all plans are executed
 
-    resp4 = _request_to_json("get", "/queue_view")
+    resp4 = _request_to_json("get", "/get_queue")
     assert len(resp4["queue"]) == 0
+    assert resp2a["running_plan"] == {}
 
 
 def test_http_server_re_pause_continue_handlers(re_manager, fastapi_server):  # noqa F811
@@ -128,16 +139,18 @@ def test_http_server_re_pause_continue_handlers(re_manager, fastapi_server):  # 
     resp3a = _request_to_json("post", "/re_pause", json={"option": "immediate"})
     assert resp3a == {"msg": "", "success": True}
     ttime.sleep(1)  # TODO: API is needed
-    resp3b = _request_to_json("get", "/queue_view")
+    resp3b = _request_to_json("get", "/get_queue")
     assert len(resp3b["queue"]) == 0  # The plan is paused, but it is not in the queue
+    assert resp3b["running_plan"] != {}  # Running plan is set
 
     resp4 = _request_to_json("post", "/re_continue", json={"option": "abort"})
     assert resp4 == {"msg": "", "success": True}
 
     ttime.sleep(15)  # TODO: we need to wait for plan completion
 
-    resp4a = _request_to_json("get", "/queue_view")
+    resp4a = _request_to_json("get", "/get_queue")
     assert len(resp4a["queue"]) == 1  # The plan is back in the queue
+    assert resp4a["running_plan"] == {}
 
 
 def test_http_server_close_print_db_uids_handler(re_manager, fastapi_server, add_plans_to_queue):  # noqa F811
@@ -151,8 +164,9 @@ def test_http_server_close_print_db_uids_handler(re_manager, fastapi_server, add
 
     ttime.sleep(15)
 
-    resp2a = _request_to_json("get", "/queue_view")
+    resp2a = _request_to_json("get", "/get_queue")
     assert len(resp2a["queue"]) == 0
+    assert resp2a["running_plan"] == {}
 
     resp5 = _request_to_json("post", "/print_db_uids")
     assert resp5 == {"msg": "", "success": True}


### PR DESCRIPTION
Changes to RE Manager API:

- renamed `queue_view` to `get_queue`. It now returns a dictionary with two keys: `queue` - list of plans in the queue (represented as dictionaries, first element in the list is the first plan to run), `running_plan` - dictionary that represents currently running plan (running plan is not part of the queue, `{}` is returned if no plan is currently executed).

- `clear_queue` entry point to HTTP server (the operation was available via CLI client). The test is also added.

- `get_history` and `clear_history` API (both CLI and HTTP). The tests are added.
