### PR TITLE
Load 'Realistic' Beamline Profile Collections into RE Worker environment.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,26 +125,6 @@ There is minimal user protection features implemented that will prevent executio
 the commands that are not supported in current state of the server. Error messages are printed
 in the terminal that is running the server along with output of Run Engine.
 
-There is demo of data collection capability. The instance of the QueueServer is keeping a reference
-to an instance of 'temp' Databroker, which is passed to the RE Worker at the time of creation and
-used to collect documents from Run Engine. Data from all plans executed during QueueServer session
-are accumulated in the 'temp' database. The table that contains Run IDs and UIDs of the runs in
-the databased can be printed on the screen by sending the command::
-
-  http POST http://localhost:8080/print_db_uids
-
-The table will be printed in the RE Manager terminal::
-
-    ===================================================================
-                 The contents of 'temp' database.
-    -------------------------------------------------------------------
-    Run ID: 1   UID: bd621328-ffcf-409f-a668-0c303c0d287f
-    Run ID: 2   UID: e85f2f40-44e9-4097-be50-c27f42c4e201
-    Run ID: 3   UID: 1dec536d-3397-43c1-91a3-2af323452bfe
-    -------------------------------------------------------------------
-      Total of 3 runs were found in 'temp' database.
-    ===================================================================
-
 The 'qserver' CLI tool can be started from a separate shell. Display help options::
 
   qserver -h
@@ -204,9 +184,6 @@ Countinue paused plan::
   qserver -c re_continue -p stop
   qserver -c re_continue -p halt
 
-Print UIDs in 'temp' Databroker::
-
-  qserver -c print_db_uids
 
 Close RE Manager in orderly way. No plans should be running at the moment when the command is issued::
 

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ The number of entries in the queue may be checked as follows::
 
 The contents of the queue can be retrieved as follows::
 
-  http GET http://localhost:8080/queue_view
+  http GET http://localhost:8080/get_queue
 
 Before the queue can be executed, the worker environment must be created and initialized. This operation
 creates a new execution environment for Bluesky Run Engine and used to execute plans until it explicitly
@@ -170,7 +170,7 @@ Add a new plan to the queue::
 
 View the contents of the queue::
 
-  qserver -c queue_view
+  qserver -c get_queue
 
 Pop the last element from queue::
 

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -378,9 +378,9 @@ class PipeJsonRpcSendAsync:
                 if response["id"] != self._expected_msg_id:
                     # Incorrect ID: ignore the message.
                     logger.error(
-                        "Response Watchdog->RE Manager contains incorrect ID: %s. Expected %s.\nMessage: %s",
+                        "Received response with incorrect message ID: %s. Expected %s.\nMessage: %s",
                         response["id"],
-                        self._expected_msg_id["id"],
+                        self._expected_msg_id,
                         pprint.pformat(response),
                     )
                 else:
@@ -388,10 +388,10 @@ class PipeJsonRpcSendAsync:
                     self._fut_comm.set_result(response)
             else:
                 # Missing ID: ignore the message
-                logger.error("Response Watchdog->RE Manager contains no id: %s", pprint.pformat(response))
+                logger.error("Received response with missing message ID: %s", pprint.pformat(response))
         else:
             logger.error(
-                "Unsolicited message received Watchdog->Re Manager: %s. Message is ignored",
+                "Unsolicited message received: %s. Message is ignored",
                 pprint.pformat(response),
             )
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -164,7 +164,7 @@ def load_profile_collection(path, patch_profiles=True):
     # Load the files into the namespace 'nspace'.
     nspace = None
     for file in file_list:
-        logger.info(f"Loading profile collection file '{file}' ...")
+        logger.info(f"Loading startup file '{file}' ...")
         fln_tmp = _patch_profile(file) if patch_profiles else file
         nspace = runpy.run_path(fln_tmp, nspace)
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -26,6 +26,9 @@ def get_default_profile_collection_dir():
 
 _patch1 = """
 
+import logging
+logger_patch = logging.Logger(__name__)
+
 __local_namespace = locals()
 
 try:
@@ -34,10 +37,6 @@ try:
 """
 
 _patch2 = """
-
-    import logging
-    logger_patch = logging.Logger(__name__)
-
 
     class IPDummy:
         def __init__(self, user_ns):

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -8,8 +8,6 @@ import yaml
 import tempfile
 import re
 
-import ophyd
-
 import logging
 
 logger = logging.getLogger(__name__)
@@ -212,6 +210,8 @@ def devices_from_nspace(nspace):
     dict(str: callable)
         Dictionary of devices.
     """
+    import ophyd
+
     devices = {}
     for item in nspace.items():
         if isinstance(item[1], ophyd.Device):

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -73,7 +73,6 @@ class CliClient:
             "process_queue": "process_queue",
             "re_pause": "re_pause",
             "re_continue": "re_continue",
-            "print_db_uids": "print_db_uids",
             "stop_manager": "stop_manager",
             "kill_manager": "kill_manager",
         }

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -488,12 +488,10 @@ class RunEngineWorker(Process):
         asyncio.set_event_loop(loop)
 
         def init_namespace():
-            self._re_namespace, self._existing_plans, self._existing_devices = (
-                {},
-                {},
-                {},
-            )
-
+            self._re_namespace = {}
+            self._existing_plans = {}
+            self._existing_devices = {}
+            
         if "profile_collection_path" not in self._config:
             logger.warning("Path to profile collection was not specified. No profile collection will be loaded.")
             init_namespace()

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -504,7 +504,7 @@ class RunEngineWorker(Process):
                 self._existing_devices = devices_from_nspace(self._re_namespace)
                 logger.info("Loading of the beamline profiles completed successfully")
             except Exception as ex:
-                logger.exception("Error wile loading profile collection: %s", str(ex))
+                logger.exception("Error while loading profile collection: %s", str(ex))
                 init_namespace()
 
         # Load lists of allowed plans and devices
@@ -527,9 +527,11 @@ class RunEngineWorker(Process):
         self._RE.subscribe(self._db.insert)
 
         if "kafka" in self._config:
-            logger.info("Subscribing to Kafka: topic '%s', servers '%s'",
-                        self._config["kafka"]["topic"],
-                        self._config["kafka"]["bootstrap"])
+            logger.info(
+                "Subscribing to Kafka: topic '%s', servers '%s'",
+                self._config["kafka"]["topic"],
+                self._config["kafka"]["bootstrap"],
+            )
             kafka_publisher = kafkaPublisher(
                 topic=self._config["kafka"]["topic"],
                 bootstrap_servers=self._config["kafka"]["bootstrap"],

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -239,13 +239,3 @@ async def re_continue_handler(payload: dict):
         raise HTTPException(status_code=444, detail=msg)
     msg = await re_server.send_command(command="re_continue", params=payload)
     return msg
-
-
-@app.post("/print_db_uids")
-async def print_db_uids_handler():
-    """
-    Prints the UIDs of the scans in 'temp' database. Just for the demo.
-    Not part of future API.
-    """
-    msg = await re_server.send_command(command="print_db_uids")
-    return msg

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -69,7 +69,7 @@ def test_http_server_create_environment_handler(re_manager, fastapi_server):  # 
     resp1 = _request_to_json("post", "/create_environment")
     assert resp1 == {"success": True, "msg": ""}
 
-    ttime.sleep(1)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
+    ttime.sleep(2)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
 
     resp2 = _request_to_json("post", "/create_environment")
     assert resp2 == {"success": False, "msg": "Environment already exists."}
@@ -79,7 +79,7 @@ def test_http_server_close_environment_handler(re_manager, fastapi_server):  # n
     resp1 = _request_to_json("post", "/create_environment")
     assert resp1 == {"success": True, "msg": ""}
 
-    ttime.sleep(1)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
+    ttime.sleep(2)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
 
     resp2 = _request_to_json("post", "/close_environment")
     assert resp2 == {"success": True, "msg": ""}
@@ -100,7 +100,7 @@ def test_http_server_process_queue_handler(re_manager, fastapi_server, add_plans
     assert len(resp2a["queue"]) == 3
     assert resp2a["running_plan"] == {}
 
-    ttime.sleep(1)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
+    ttime.sleep(2)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
 
     resp3 = _request_to_json("post", "/process_queue")
     assert resp3 == {"success": True, "msg": ""}
@@ -122,7 +122,7 @@ def test_http_server_re_pause_continue_handlers(re_manager, fastapi_server):  # 
     resp1 = _request_to_json("post", "/create_environment")
     assert resp1 == {"success": True, "msg": ""}
 
-    ttime.sleep(1)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
+    ttime.sleep(2)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
 
     resp2 = _request_to_json(
         "post",
@@ -157,7 +157,7 @@ def test_http_server_close_print_db_uids_handler(re_manager, fastapi_server, add
     resp1 = _request_to_json("post", "/create_environment")
     assert resp1 == {"success": True, "msg": ""}
 
-    ttime.sleep(1)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
+    ttime.sleep(2)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
 
     resp2 = _request_to_json("post", "/process_queue")
     assert resp2 == {"success": True, "msg": ""}
@@ -167,10 +167,6 @@ def test_http_server_close_print_db_uids_handler(re_manager, fastapi_server, add
     resp2a = _request_to_json("get", "/get_queue")
     assert len(resp2a["queue"]) == 0
     assert resp2a["running_plan"] == {}
-
-    resp5 = _request_to_json("post", "/print_db_uids")
-    assert resp5 == {"msg": "", "success": True}
-    # TODO: can we return the list of UIDs here?
 
 
 def test_http_server_clear_queue_handler(re_manager, fastapi_server, add_plans_to_queue):  # noqa F811
@@ -193,7 +189,7 @@ def test_http_server_plan_history(re_manager, fastapi_server):  # noqa F811
     _request_to_json("post", "/add_to_queue", json=plan)
 
     _request_to_json("post", "/create_environment")
-    ttime.sleep(1)
+    ttime.sleep(2)
 
     _request_to_json("post", "/process_queue")
     ttime.sleep(5)

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -11,6 +11,18 @@ from bluesky_queueserver.server.tests.conftest import (  # noqa F401
 )
 
 
+def wait_for_environment_to_be_created(timeout, polling_period=0.2):
+    """Wait for environment to be created with timeout."""
+    time_start = ttime.time()
+    while ttime.time() < time_start + timeout:
+        ttime.sleep(polling_period)
+        resp = _request_to_json("get", "/")
+        if resp["worker_environment_exists"]:
+            return True
+
+    return False
+
+
 def _request_to_json(request_type, path, **kwargs):
     resp = getattr(requests, request_type)(f"http://{SERVER_ADDRESS}:{SERVER_PORT}{path}", **kwargs).json()
     return resp
@@ -69,7 +81,7 @@ def test_http_server_create_environment_handler(re_manager, fastapi_server):  # 
     resp1 = _request_to_json("post", "/create_environment")
     assert resp1 == {"success": True, "msg": ""}
 
-    ttime.sleep(2)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
+    assert wait_for_environment_to_be_created(10), "Timeout"
 
     resp2 = _request_to_json("post", "/create_environment")
     assert resp2 == {"success": False, "msg": "Environment already exists."}
@@ -79,7 +91,7 @@ def test_http_server_close_environment_handler(re_manager, fastapi_server):  # n
     resp1 = _request_to_json("post", "/create_environment")
     assert resp1 == {"success": True, "msg": ""}
 
-    ttime.sleep(2)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
+    assert wait_for_environment_to_be_created(10), "Timeout"
 
     resp2 = _request_to_json("post", "/close_environment")
     assert resp2 == {"success": True, "msg": ""}
@@ -100,7 +112,7 @@ def test_http_server_process_queue_handler(re_manager, fastapi_server, add_plans
     assert len(resp2a["queue"]) == 3
     assert resp2a["running_plan"] == {}
 
-    ttime.sleep(2)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
+    assert wait_for_environment_to_be_created(10), "Timeout"
 
     resp3 = _request_to_json("post", "/process_queue")
     assert resp3 == {"success": True, "msg": ""}
@@ -122,7 +134,7 @@ def test_http_server_re_pause_continue_handlers(re_manager, fastapi_server):  # 
     resp1 = _request_to_json("post", "/create_environment")
     assert resp1 == {"success": True, "msg": ""}
 
-    ttime.sleep(2)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
+    assert wait_for_environment_to_be_created(10), "Timeout"
 
     resp2 = _request_to_json(
         "post",
@@ -157,7 +169,7 @@ def test_http_server_close_print_db_uids_handler(re_manager, fastapi_server, add
     resp1 = _request_to_json("post", "/create_environment")
     assert resp1 == {"success": True, "msg": ""}
 
-    ttime.sleep(2)  # TODO: API needed to test if environment initialization is finished. Use delay for now.
+    assert wait_for_environment_to_be_created(10), "Timeout"
 
     resp2 = _request_to_json("post", "/process_queue")
     assert resp2 == {"success": True, "msg": ""}
@@ -189,7 +201,7 @@ def test_http_server_plan_history(re_manager, fastapi_server):  # noqa F811
     _request_to_json("post", "/add_to_queue", json=plan)
 
     _request_to_json("post", "/create_environment")
-    ttime.sleep(2)
+    assert wait_for_environment_to_be_created(10), "Timeout"
 
     _request_to_json("post", "/process_queue")
     ttime.sleep(5)


### PR DESCRIPTION
Changes include:

- Support for loading of 'realistic' beamline profile collections that are using `configure_base` function from `nslsii` package. Files from profile collections are patched by replacing `get_ipython()` function with custom function that returns an object with attribute `user_ns` which holds a reference to `locals()` for the patched file. Patched files are saved as temporary files and loaded by using `runpy`. The original files remain unchanged.

- Additional patching of the files in order to capture traceback in case of exception raised while executing the profile collection.

- `temp` databroker can not be used to accumulated data from RE Worker environment. Probably an option of configuring MongoDB-base databroker should be implemented. The command `print_db_uids` is removed: this was a demo command. RE Manager is not expected to read data from databroker. The list of UIDs of the recently executed runs from the queue will be provided as part of the `history`.