### PR TITLE
Support for local imports in loaded beamline profiles

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -164,7 +164,12 @@ def load_profile_collection(path, patch_profiles=True):
 
     # Add original path to the profile collection to allow relative imports
     #   from the patched temporary file.
-    sys.path.append(path)
+    if path not in sys.path:
+        # We don't want to add/remove the path if it is already in `sys.path` for some reason.
+        sys.path.append(path)
+        path_is_set = True
+    else:
+        path_is_set = False
 
     # Load the files into the namespace 'nspace'.
     try:
@@ -179,7 +184,8 @@ def load_profile_collection(path, patch_profiles=True):
         nspace.pop("db", None)
     finally:
         try:
-            sys.path.remove(path)
+            if path_is_set:
+                sys.path.remove(path)
         except Exception:
             pass
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -162,7 +162,7 @@ def load_profile_collection(path, patch_profiles=True):
     file_list = glob.glob(file_pattern)
     file_list.sort()  # Sort in alphabetical order
 
-    # Add original path to the profile collection to allow relative imports
+    # Add original path to the profile collection to allow local imports
     #   from the patched temporary file.
     if path not in sys.path:
         # We don't want to add/remove the path if it is already in `sys.path` for some reason.

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -7,6 +7,7 @@ import pkg_resources
 import yaml
 import tempfile
 import re
+import sys
 
 import logging
 
@@ -161,16 +162,26 @@ def load_profile_collection(path, patch_profiles=True):
     file_list = glob.glob(file_pattern)
     file_list.sort()  # Sort in alphabetical order
 
-    # Load the files into the namespace 'nspace'.
-    nspace = None
-    for file in file_list:
-        logger.info(f"Loading startup file '{file}' ...")
-        fln_tmp = _patch_profile(file) if patch_profiles else file
-        nspace = runpy.run_path(fln_tmp, nspace)
+    # Add original path to the profile collection to allow relative imports
+    #   from the patched temporary file.
+    sys.path.append(path)
 
-    # Discard RE and db from the profile namespace (if they exist).
-    nspace.pop("RE", None)
-    nspace.pop("db", None)
+    # Load the files into the namespace 'nspace'.
+    try:
+        nspace = None
+        for file in file_list:
+            logger.info(f"Loading startup file '{file}' ...")
+            fln_tmp = _patch_profile(file) if patch_profiles else file
+            nspace = runpy.run_path(fln_tmp, nspace)
+
+        # Discard RE and db from the profile namespace (if they exist).
+        nspace.pop("RE", None)
+        nspace.pop("db", None)
+    finally:
+        try:
+            sys.path.remove(path)
+        except Exception:
+            pass
 
     return nspace
 

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -67,6 +67,7 @@ code_rel_import = """
 from dir1.dir2.file2 import *
 """
 
+
 def create_rel_imports_dirs(tmp_path):
     path1 = os.path.join(tmp_path, "dir1")
     path2 = os.path.join(path1, "dir2")

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -63,12 +63,12 @@ def test_load_profile_collection_2(tmp_path):
     assert len(nspace) > 0, "Failed to load the profile collection"
 
 
-code_rel_import = """
+code_local_import = """
 from dir1.dir2.file2 import *
 """
 
 
-def create_rel_imports_dirs(tmp_path):
+def create_local_imports_dirs(tmp_path):
     path1 = os.path.join(tmp_path, "dir1")
     path2 = os.path.join(path1, "dir2")
     fln1 = os.path.join(path1, "file1.py")
@@ -96,7 +96,7 @@ def f2():
 
 
 # fmt: off
-@pytest.mark.parametrize("rel_imports", [False, True])
+@pytest.mark.parametrize("local_imports", [False, True])
 @pytest.mark.parametrize("additional_code, success, errmsg", [
     # Patched as expected
     ("""
@@ -137,13 +137,13 @@ raise Exception("Manually raised exception.")
 
 ])
 # fmt: on
-def test_load_profile_collection_3(tmp_path, rel_imports, additional_code, success, errmsg):
+def test_load_profile_collection_3(tmp_path, local_imports, additional_code, success, errmsg):
     """
     Loading a copy of the default profile collection
     """
     pc_path = _copy_default_profile_collection(tmp_path)
 
-    create_rel_imports_dirs(pc_path)
+    create_local_imports_dirs(pc_path)
 
     # Path to the first file (starts with 00)
     file_pattern = os.path.join(pc_path, "[0-9][0-9]*.py")
@@ -155,17 +155,17 @@ def test_load_profile_collection_3(tmp_path, rel_imports, additional_code, succe
         code = file_in.readlines()
 
     with open(fln, "w") as file_out:
-        if rel_imports:
-            file_out.writelines(code_rel_import)
+        if local_imports:
+            file_out.writelines(code_local_import)
         file_out.writelines(additional_code)
         file_out.writelines(code)
 
     if success:
         nspace = load_profile_collection(pc_path)
         assert len(nspace) > 0, "Failed to load the profile collection"
-        if rel_imports:
-            assert "f1" in nspace, "Test for relative imports failed"
-            assert "f2" in nspace, "Test for relative imports failed"
+        if local_imports:
+            assert "f1" in nspace, "Test for local imports failed"
+            assert "f2" in nspace, "Test for local imports failed"
     else:
         with pytest.raises(Exception, match=errmsg):
             load_profile_collection(pc_path)


### PR DESCRIPTION
Added support for relative imports in loaded beamline profiles: path to original location of beamline profile collection is added to `sys.path` before startup files are patched and loaded from a temporary directory. Unit tests are added.