### PR TITLE
CLN: remove outdated examples

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -16,18 +16,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-"""
-#  The following plans that can be used to test the syste
-
-http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
-
-# This is the slowly running plan (convenient to test pausing)
-http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]],
-"kwargs":{"num":10, "delay":1}}'
-
-http POST http://localhost:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
-"""
-
 
 # TODO: this is incomplete set of states. Expect it to be expanded.
 class MState(enum.Enum):

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -17,18 +17,6 @@ logger = logging.getLogger(__name__)
 
 qserver_version = bluesky_queueserver.__version__
 
-"""
-#  The following plans that can be used to test the server
-
-http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
-
-# This is the slowly running plan (convenient to test pausing)
-http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]],
-"kwargs":{"num":10, "delay":1}}'
-
-http POST http://localhost:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
-"""
-
 
 class CliClient:
     def __init__(self, *, address=None):

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -8,18 +8,6 @@ from fastapi import FastAPI, HTTPException
 
 logger = logging.getLogger(__name__)
 
-"""
-#  The following plans that can be used to test the server
-
-http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]]}'
-
-# This is the slowly running plan (convenient to test pausing)
-http POST http://localhost:8080/add_to_queue plan:='{"name":"count", "args":[["det1", "det2"]],
-"kwargs":{"num":10, "delay":1}}'
-
-http POST http://localhost:8080/add_to_queue plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
-"""
-
 
 class ZMQComm:
     def __init__(self, zmq_host="localhost", zmq_port="5555"):


### PR DESCRIPTION
The following examples in the comment blocks in the code are diverging quickly from the "ground-truth" in `README.rst`. I propose we remove them from the `.py` files.