### PR TITLE
Separate tests for RE Manager ZMQ API (only a few tests for now).

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -701,7 +701,7 @@ class RunEngineManager(Process):
 
         try:
             if "user_group" not in request:
-                raise Exception("Incorrect request format: user group was not found")
+                raise Exception("Incorrect request format: user group is not specified")
 
             user_group = request["user_group"]
 
@@ -728,7 +728,7 @@ class RunEngineManager(Process):
 
         try:
             if "user_group" not in request:
-                raise Exception("Incorrect request format: user group was not found")
+                raise Exception("Incorrect request format: user group is not specified")
 
             user_group = request["user_group"]
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -778,13 +778,13 @@ class RunEngineManager(Process):
         try:
             plan, qsize, msg = {}, None, ""
             if "plan" not in request:
-                raise Exception("Incorrect request format: no plan was found")
+                raise Exception("Incorrect request format: no plan is specified")
 
             if "user_group" not in request:
-                raise Exception("Incorrect request format: user group was not found")
+                raise Exception("Incorrect request format: user group is not specified")
 
             if "user" not in request:
-                raise Exception("Incorrect request format: user name was not found")
+                raise Exception("Incorrect request format: user name is not specified")
 
             user = request["user"]
             user_group = request["user_group"]

--- a/bluesky_queueserver/manager/tests/_common.py
+++ b/bluesky_queueserver/manager/tests/_common.py
@@ -5,10 +5,14 @@ import pytest
 import subprocess
 import asyncio
 import time as ttime
+import zmq
 
 from bluesky_queueserver.manager.profile_ops import get_default_profile_collection_dir
-from bluesky_queueserver.manager.qserver_cli import CliClient
 from bluesky_queueserver.manager.plan_queue_ops import PlanQueueOperations
+
+import logging
+
+logger = logging.Logger(__name__)
 
 
 def copy_default_profile_collection(tmp_path, *, copy_yaml=True):
@@ -83,14 +87,122 @@ def patch_first_startup_file_undo(pc_path):
         os.rename(fln_tmp, fln)
 
 
+class TinyZmqClient:
+    """
+    This is a simplified version of ZMQ Client, which is very similar to the client
+    used in ``qserver_cli``. The server does not perform any verification of input
+    and output data and intended for testing 0MQ API of RE Manager.
+    """
+
+    def __init__(self, *, address=None):
+        # ZeroMQ communication
+        self._ctx = zmq.asyncio.Context()
+        self._zmq_socket = None
+
+        if address is None:
+            self._zmq_server_address = "tcp://localhost:5555"
+        else:
+            self._zmq_server_address = address
+
+        # The attributes for storing output command and received input
+        self._msg_method_out = ""
+        self._msg_params_out = {}
+        self._msg_in = {}
+        self._msg_err_in = ""
+
+    async def _zmq_send(self, msg):
+        await self._zmq_socket.send_json(msg)
+
+    async def _zmq_receive(self):
+        return await self._zmq_socket.recv_json()
+
+    async def _zmq_communicate(self, msg_out):
+        try:
+            await self._zmq_send(msg_out)
+            msg_in = await self._zmq_receive()
+            return msg_in
+        except Exception as ex:
+            raise RuntimeError(f"ZeroMQ communication failed: {str(ex)}")
+
+    async def _zmq_open_connection(self, address):
+        if self._zmq_socket.connect(address):
+            msg_err = f"Failed to connect to the server '{address}'"
+            raise RuntimeError(msg_err)
+
+    async def zmq_single_request(self):
+        self._zmq_socket = self._ctx.socket(zmq.REQ)
+        self._zmq_socket.RCVTIMEO = 2000  # Timeout for 'recv' operation
+        self._zmq_socket.SNDTIMEO = 500  # Timeout for 'send' operation
+        # Clear the buffer quickly after the socket is closed
+        self._zmq_socket.setsockopt(zmq.LINGER, 100)
+
+        try:
+            await self._zmq_open_connection(self._zmq_server_address)
+            logger.info("Connected to ZeroMQ server '%s'", self._zmq_server_address)
+            self._msg_in = await self._send_command(method=self._msg_method_out, params=self._msg_params_out)
+            self._msg_err_in = ""
+        except Exception as ex:
+            self._msg_in = None
+            self._msg_err_in = str(ex)
+            # Close the socket to clear the buffer quickly in case of an error.
+            self._zmq_socket.close()
+
+        if self._msg_err_in:
+            logger.warning("Communication with RE Manager failed: %s", str(self._msg_err_in))
+
+    async def _send_command(self, *, method, params=None):
+        msg_out = self._create_msg(method=method, params=params)
+        msg_in = await self._zmq_communicate(msg_out)
+        return msg_in
+
+    def _create_msg(self, method, params=None):
+        """
+        The function combines 'method' and 'params' to form a request message
+        sent over ZMQ.
+        """
+        params = params or {}
+        return {"method": method, "params": params}
+
+    def set_msg_out(self, method, params):
+        self._msg_method_out = method
+        self._msg_params_out = params
+
+    def get_msg_in(self):
+        return self._msg_in, self._msg_err_in
+
+
+def zmq_communicate(method, params=None):
+    """
+    Communicate with RE Manager.
+
+    Parameters
+    ----------
+    method: str
+        Name of the method called in RE Manager
+    params: dict or None
+        Dictionary of parameters (payload of the message). If ``None`` then
+        the message is sent with empty payload: ``params = {}``.
+
+    Returns
+    -------
+    msg: dict or None
+        Message received from RE Manager in response to the request. None if communication
+        error (timeout) occurred.
+    err_msg: str
+        Contains a message in case communication error (timeout) occurs. Empty string otherwise.
+    """
+    zmq_client = TinyZmqClient()
+    zmq_client.set_msg_out(method, params)
+    asyncio.run(zmq_client.zmq_single_request())
+    msg, err_msg = zmq_client.get_msg_in()
+    return msg, err_msg
+
+
 def get_queue_state():
-    re_server = CliClient()
-    command, params = "status", None
-    re_server.set_msg_out(command, params)
-    asyncio.run(re_server.zmq_single_request())
-    msg, _ = re_server.get_msg_in()
+    method, params = "status", None
+    msg, _ = zmq_communicate(method, params)
     if msg is None:
-        raise TimeoutError("Timeout occured while monitoring RE Manager state")
+        raise TimeoutError("Timeout occurred while reading RE Manager status.")
     return msg
 
 
@@ -98,13 +210,10 @@ def get_queue():
     """
     Returns current queue.
     """
-    re_server = CliClient()
-    command, params = "queue_get", None
-    re_server.set_msg_out(command, params)
-    asyncio.run(re_server.zmq_single_request())
-    msg, _ = re_server.get_msg_in()
+    method, params = "queue_get", None
+    msg, _ = zmq_communicate(method, params)
     if msg is None:
-        raise TimeoutError("Timeout occured while monitoring RE Manager state")
+        raise TimeoutError("Timeout occurred while loading queue from RE Manager.")
     return msg
 
 
@@ -225,7 +334,7 @@ class ReManager:
         """
         if self._p:
             # Try to stop the manager in a nice way first by sending the command
-            subprocess.call(["qserver", "-c", "manager_stop"])
+            zmq_communicate(method="manager_stop", params=None)
             try:
                 self._p.wait(timeout)
                 clear_redis_pool()

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1,0 +1,148 @@
+import pytest
+
+from ._common import (
+    zmq_communicate,
+)
+
+from ._common import re_manager, re_manager_pc_copy  # noqa: F401
+
+# Plans used in most of the tests: '_plan1' and '_plan2' are quickly executed '_plan3' runs for 5 seconds.
+_plan1 = {"name": "count", "args": [["det1", "det2"]]}
+_plan2 = {"name": "scan", "args": [["det1", "det2"], "motor", -1, 1, 10]}
+_plan3 = {"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 5, "delay": 1}}
+
+# User name and user group name used throughout most of the tests.
+_user, _user_group = "Testing Script", "admin"
+
+# =======================================================================================
+#                             Method 'queue_plan_add'
+
+
+def test_zmq_api_queue_plan_add_1(re_manager):  # noqa F811
+    """
+    Basic test for `queue_plan_add` method.
+    """
+    resp1, _ = zmq_communicate("queue_plan_add", {"plan": _plan1, "user": _user, "user_group": _user_group})
+    assert resp1["success"] is True
+    assert resp1["qsize"] == 1
+    assert resp1["plan"]["name"] == _plan1["name"]
+    assert resp1["plan"]["args"] == _plan1["args"]
+    assert resp1["plan"]["user"] == _user
+    assert resp1["plan"]["user_group"] == _user_group
+    assert "plan_uid" in resp1["plan"]
+
+    resp2, _ = zmq_communicate("queue_get")
+    assert resp2["queue"] != []
+    assert len(resp2["queue"]) == 1
+    assert resp2["queue"][0] == resp1["plan"]
+    assert resp2["running_plan"] == {}
+
+
+# fmt: off
+@pytest.mark.parametrize("pos, pos_result, success", [
+    (None, 2, True),
+    ("back", 2, True),
+    ("front", 0, True),
+    ("some", None, False),
+    (0, 0, True),
+    (1, 1, True),
+    (2, 2, True),
+    (3, 2, True),
+    (100, 2, True),
+    (-1, 1, True),
+    (-2, 0, True),
+    (-3, 0, True),
+    (-100, 0, True),
+])
+# fmt: on
+def test_zmq_api_queue_plan_add_2(re_manager, pos, pos_result, success):  # noqa F811
+
+    plan1 = {"name": "count", "args": [["det1"]]}
+    plan2 = {"name": "count", "args": [["det1", "det2"]]}
+
+    # Create the queue with 2 entries
+    params1 = {"plan": plan1, "user": _user, "user_group": _user_group}
+    zmq_communicate("queue_plan_add", params1)
+    zmq_communicate("queue_plan_add", params1)
+
+    # Add another entry at the specified position
+    params2 = {"plan": plan2, "user": _user, "user_group": _user_group}
+    if pos is not None:
+        params2.update({"pos": pos})
+
+    resp1, _ = zmq_communicate("queue_plan_add", params2)
+
+    assert resp1["success"] is success
+    assert resp1["qsize"] == (3 if success else None)
+    assert resp1["plan"]["name"] == "count"
+    assert resp1["plan"]["args"] == plan2["args"]
+    assert resp1["plan"]["user"] == _user
+    assert resp1["plan"]["user_group"] == _user_group
+    assert "plan_uid" in resp1["plan"]
+
+    resp2, _ = zmq_communicate("queue_get")
+
+    assert len(resp2["queue"]) == (3 if success else 2)
+    assert resp2["running_plan"] == {}
+
+    if success:
+        assert resp2["queue"][pos_result]["args"] == plan2["args"]
+
+
+def test_zmq_api_queue_plan_add_3_fail(re_manager):  # noqa F811
+
+    # Unknown plan name
+    plan1 = {"name": "count_test", "args": [["det1", "det2"]]}
+    params1 = {"plan": plan1, "user": _user, "user_group": _user_group}
+    resp1, _ = zmq_communicate("queue_plan_add", params1)
+    assert resp1["success"] is False
+    assert "Plan 'count_test' is not in the list of allowed plans" in resp1["msg"]
+
+    # Unknown kwarg
+    plan2 = {"name": "count", "args": [["det1", "det2"]], "kwargs": {"abc": 10}}
+    params2 = {"plan": plan2, "user": _user, "user_group": _user_group}
+    resp2, _ = zmq_communicate("queue_plan_add", params2)
+    assert resp2["success"] is False
+    assert "Unexpected kwargs ['abc'] in the plan parameters" in resp2["msg"]
+
+    # User name is not specified
+    params3 = {"plan": plan2, "user_group": _user_group}
+    resp3, _ = zmq_communicate("queue_plan_add", params3)
+    assert resp3["success"] is False
+    assert "user name is not specified" in resp3["msg"]
+
+    # User group is not specified
+    params4 = {"plan": plan2, "user": _user}
+    resp4, _ = zmq_communicate("queue_plan_add", params4)
+    assert resp4["success"] is False
+    assert "user group is not specified" in resp4["msg"]
+
+    # User group is not specified
+    params5 = {"plan": plan2, "user": _user, "user_group": "no_such_group"}
+    resp5, _ = zmq_communicate("queue_plan_add", params5)
+    assert resp5["success"] is False
+    assert "Unknown user group: 'no_such_group'" in resp5["msg"]
+
+    # User group is not specified
+    params6 = {"user": _user, "user_group": "no_such_group"}
+    resp6, _ = zmq_communicate("queue_plan_add", params6)
+    assert resp6["success"] is False
+    assert "no plan is specified" in resp6["msg"]
+
+    # Valid plan
+    plan7 = {"name": "count", "args": [["det1", "det2"]]}
+    params7 = {"plan": plan7, "user": _user, "user_group": _user_group}
+    resp7, _ = zmq_communicate("queue_plan_add", params7)
+    assert resp7["success"] is True
+    assert resp7["qsize"] == 1
+    assert resp7["plan"]["name"] == "count"
+    assert resp7["plan"]["args"] == [["det1", "det2"]]
+    assert resp7["plan"]["user"] == _user
+    assert resp7["plan"]["user_group"] == _user_group
+    assert "plan_uid" in resp7["plan"]
+
+    resp8, _ = zmq_communicate("queue_get")
+    assert resp8["queue"] != []
+    assert len(resp8["queue"]) == 1
+    assert resp8["queue"][0] == resp7["plan"]
+    assert resp8["running_plan"] == {}

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -164,7 +164,7 @@ def test_http_server_queue_plan_add_handler_4_fail(re_manager, fastapi_server): 
     assert resp1["success"] is False
     assert resp1["qsize"] is None
     assert resp1["plan"] == {}
-    assert "no plan was found" in resp1["msg"]
+    assert "no plan is specified" in resp1["msg"]
 
 
 def test_http_server_queue_plan_get_remove_handler_1(re_manager, fastapi_server, add_plans_to_queue):  # noqa F811


### PR DESCRIPTION
Set up framework for direct testing of RE Manager ZMQ API. To this point API were tested indirectly by either calling `qserver` CLI or using REST API. From this point it is likely that CLI commands and REST APIs will start diverging from ZMQ API used for internal communication between the server and RE manager, so it would be beneficial to separate the tests as well. 

Only a few tests are added so far. There are also some minor changes to the code (mostly error messages).