### PR TITLE
ZMQ client API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_script:
             echo "Not attempting to run doctr due to the docs failed to build"
         else
             pip install doctr
-            doctr deploy --built-docs docs/build/html .
+            doctr deploy --built-docs docs/build/html . --branch-whitelist main
             res=$?
             echo "Docs deployment with 'doctr' finished with the exit code ($res)."
         fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ jobs:
     # As of 2020-10-08, Python 3.9 distribution is not available in TravisCI's repos yet.
     # - python: 3.9
 
+  allow_failures:
+    - name: "Build/deploy docs"
+
 before_install:
   - |
     if [ "${FLAKE_8}" == "true" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,12 +65,14 @@ before_script:
         echo "Docs build finished with the exit code ($res)."
 
         if [ $res -gt 0 ]; then
-            echo "Not attempting to run doctr due to the docs failed to build"
+            echo "Not attempting to run doctr."
         else
-            pip install doctr
-            doctr deploy --built-docs docs/build/html . --branch-whitelist main
-            res=$?
-            echo "Docs deployment with 'doctr' finished with the exit code ($res)."
+            if [ "${TRAVIS_REPO_SLUG}" == "bluesky/bluesky-queueserver" ]; then
+                pip install doctr
+                doctr deploy --built-docs docs/build/html . --branch-whitelist main
+                res=$?
+                echo "Docs deployment with 'doctr' finished with the exit code ($res)."
+            fi
         fi
         exit $res
     fi

--- a/README.rst
+++ b/README.rst
@@ -317,3 +317,4 @@ is to test handling of communication timeouts, since RE Manager does not respond
 
   qserver -c test_manager_kill
   http POST http://localhost:60610/test/manager/kill
+

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -538,7 +538,7 @@ class ZMQCommSendAsync:
             Name of the method to be invoked on the server. The method must be supported
             by the server.
         params: dict or None
-            Dictionary of parameters passed to the method. If ``None`` then empty dictionar
+            Dictionary of parameters passed to the method. If ``None``, then an empty dictionary
             is passed to the server.
 
         Returns

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -105,7 +105,7 @@ def create_msg(command, params=None):
         raise ValueError(f"Command '{command}' is not supported.")
 
 
-def single_zmq_request(zmq_server_address, method, params):
+def single_zmq_request(method, params, *, zmq_server_address=None):
 
     msg_received = None
 
@@ -208,7 +208,7 @@ def qserver():
 
     try:
         while True:
-            msg, msg_err = single_zmq_request(args.address, command, params)
+            msg, msg_err = single_zmq_request(command, params, zmq_server_address=args.address)
 
             now = datetime.now()
             current_time = now.strftime("%H:%M:%S")

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import ast
 import time as ttime
 from datetime import datetime

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -5,11 +5,10 @@ import time as ttime
 from datetime import datetime
 import pprint
 import sys
-import zmq
-import zmq.asyncio
 import argparse
 
 import bluesky_queueserver
+from .comms import ZMQCommSendAsync
 
 import logging
 
@@ -18,163 +17,118 @@ logger = logging.getLogger(__name__)
 qserver_version = bluesky_queueserver.__version__
 
 
-class CliClient:
-    def __init__(self, *, address=None):
-        # ZeroMQ communication
-        self._ctx = zmq.asyncio.Context()
-        self._zmq_socket = None
+def get_supported_commands():
+    """
+    Get the dictionary that maps command names supported by the cli tool to
+    the command names in RE Manager API.
 
-        if address is None:
-            self._zmq_server_address = "tcp://localhost:5555"
-        else:
-            self._zmq_server_address = address
+    Returns
+    -------
+    dict(str, str)
+        Dictionary that maps supported commands to commands from RE Manager API.
+    """
+    command_dict = {
+        "ping": "",
+        "status": "status",
+        "plans_allowed": "plans_allowed",
+        "devices_allowed": "devices_allowed",
+        "history_get": "history_get",
+        "history_clear": "history_clear",
+        "environment_open": "environment_open",
+        "environment_close": "environment_close",
+        "environment_destroy": "environment_destroy",
+        "queue_get": "queue_get",
+        "queue_plan_add": "queue_plan_add",
+        "queue_plan_get": "queue_plan_get",
+        "queue_plan_remove": "queue_plan_remove",
+        "queue_clear": "queue_clear",
+        "queue_start": "queue_start",
+        "queue_stop": "queue_stop",
+        "queue_stop_cancel": "queue_stop_cancel",
+        "re_pause": "re_pause",
+        "re_resume": "re_resume",
+        "re_stop": "re_stop",
+        "re_abort": "re_abort",
+        "re_halt": "re_halt",
+        "manager_stop": "manager_stop",
+        "manager_kill": "manager_kill",
+    }
+    return command_dict
 
-        # The attributes for storing output command and received input
-        self._msg_command_out = ""
-        self._msg_params_out = {}
-        self._msg_in = {}
-        self._msg_err_in = ""
 
-    @staticmethod
-    def get_supported_commands():
-        """
-        Get the dictionary that maps command names supported by the cli tool to
-        the command names in RE Manager API.
+def create_msg(command, params=None):
+    # This function may transform human-friendly command names to API names
+    params = params or []
 
-        Returns
-        -------
-        dict(str, str)
-            Dictionary that maps supported commands to commands from RE Manager API.
-        """
-        command_dict = {
-            "ping": "",
-            "status": "status",
-            "plans_allowed": "plans_allowed",
-            "devices_allowed": "devices_allowed",
-            "history_get": "history_get",
-            "history_clear": "history_clear",
-            "environment_open": "environment_open",
-            "environment_close": "environment_close",
-            "environment_destroy": "environment_destroy",
-            "queue_get": "queue_get",
-            "queue_plan_add": "queue_plan_add",
-            "queue_plan_get": "queue_plan_get",
-            "queue_plan_remove": "queue_plan_remove",
-            "queue_clear": "queue_clear",
-            "queue_start": "queue_start",
-            "queue_stop": "queue_stop",
-            "queue_stop_cancel": "queue_stop_cancel",
-            "re_pause": "re_pause",
-            "re_resume": "re_resume",
-            "re_stop": "re_stop",
-            "re_abort": "re_abort",
-            "re_halt": "re_halt",
-            "manager_stop": "manager_stop",
-            "manager_kill": "manager_kill",
-        }
-        return command_dict
-
-    # ==========================================================================
-    #    Functions that support ZeroMQ communications with RE Manager
-
-    async def _zmq_send(self, msg):
-        await self._zmq_socket.send_json(msg)
-
-    async def _zmq_receive(self):
-        return await self._zmq_socket.recv_json()
-
-    async def _zmq_communicate(self, msg_out):
-        try:
-            await self._zmq_send(msg_out)
-            msg_in = await self._zmq_receive()
-            return msg_in
-        except Exception as ex:
-            raise RuntimeError(f"ZeroMQ communication failed: {str(ex)}")
-
-    async def _zmq_open_connection(self, address):
-        if self._zmq_socket.connect(address):
-            msg_err = f"Failed to connect to the server '{address}'"
-            raise RuntimeError(msg_err)
-
-    async def zmq_single_request(self):
-        self._zmq_socket = self._ctx.socket(zmq.REQ)
-        self._zmq_socket.RCVTIMEO = 2000  # Timeout for 'recv' operation
-        self._zmq_socket.SNDTIMEO = 500  # Timeout for 'send' operation
-        # Clear the buffer quickly after the socket is closed
-        self._zmq_socket.setsockopt(zmq.LINGER, 100)
-
-        try:
-            await self._zmq_open_connection(self._zmq_server_address)
-            logger.info("Connected to ZeroMQ server '%s'", self._zmq_server_address)
-            self._msg_in = await self._send_command(command=self._msg_command_out, params=self._msg_params_out)
-            self._msg_err_in = ""
-        except Exception as ex:
-            self._msg_in = None
-            self._msg_err_in = str(ex)
-            # Close the socket to clear the buffer quickly in case of an error.
-            self._zmq_socket.close()
-
-        if self._msg_err_in:
-            logger.warning("Communication with RE Manager failed: %s", str(self._msg_err_in))
-
-    async def _send_command(self, *, command, params=None):
-        msg_out = self._create_msg(command=command, params=params)
-        msg_in = await self._zmq_communicate(msg_out)
-        return msg_in
-
-    def _create_msg(self, command, params=None):
-        # This function may transform human-friendly command names to API names
-        params = params or []
-
-        command_dict = self.get_supported_commands()
-        try:
-            command = command_dict[command]
-            # Present value in the proper format. This will change as the format is changed.
-            if command == "queue_plan_add":
-                if (len(params) == 1) and isinstance(params[0], dict):
-                    prms = {"plan": params[0]}  # Value is dict
-                elif len(params) == 2:
-                    plan_found, pos_found = False, False
-                    prms = {}
-                    for n in range(2):
-                        if isinstance(params[n], dict):
-                            prms.update({"plan": params[n]})
-                            plan_found = True
-                        else:
-                            prms.update({"pos": params[n]})
-                            pos_found = True
-                    if not plan_found or not pos_found:
-                        raise ValueError("Invalid set of method arguments: '%s'", pprint.pformat(params))
-                else:
-                    raise ValueError("Invalid number of method arguments: '%s'", pprint.pformat(params))
-                prms["user"] = "qserver-cli"
-                prms["user_group"] = "root"
-
-            elif command in ("queue_plan_remove", "queue_plan_get"):
-                if 0 <= len(params) <= 1:
-                    prms = {"pos": params[0]} if len(params) else {}
-                else:
-                    raise ValueError("Invalid number of method arguments: '%s'", pprint.pformat(params))
-
-            elif command in ("plans_allowed", "devices_allowed"):
-                prms = {"user_group": "root"}
-
+    command_dict = get_supported_commands()
+    try:
+        command = command_dict[command]
+        # Present value in the proper format. This will change as the format is changed.
+        if command == "queue_plan_add":
+            if (len(params) == 1) and isinstance(params[0], dict):
+                prms = {"plan": params[0]}  # Value is dict
+            elif len(params) == 2:
+                plan_found, pos_found = False, False
+                prms = {}
+                for n in range(2):
+                    if isinstance(params[n], dict):
+                        prms.update({"plan": params[n]})
+                        plan_found = True
+                    else:
+                        prms.update({"pos": params[n]})
+                        pos_found = True
+                if not plan_found or not pos_found:
+                    raise ValueError("Invalid set of method arguments: '%s'", pprint.pformat(params))
             else:
-                if 0 <= len(params) <= 1:
-                    prms = {"option": params[0]} if len(params) else {}  # Value is str
-                else:
-                    raise ValueError("Invalid number of method arguments: '%s'", pprint.pformat(params))
+                raise ValueError("Invalid number of method arguments: '%s'", pprint.pformat(params))
+            prms["user"] = "qserver-cli"
+            prms["user_group"] = "root"
 
-            return {"method": command, "params": prms}
-        except KeyError:
-            raise ValueError(f"Command '{command}' is not supported.")
+        elif command in ("queue_plan_remove", "queue_plan_get"):
+            if 0 <= len(params) <= 1:
+                prms = {"pos": params[0]} if len(params) else {}
+            else:
+                raise ValueError("Invalid number of method arguments: '%s'", pprint.pformat(params))
 
-    def set_msg_out(self, command, params):
-        self._msg_command_out = command
-        self._msg_params_out = params
+        elif command in ("plans_allowed", "devices_allowed"):
+            prms = {"user_group": "root"}
 
-    def get_msg_in(self):
-        return self._msg_in, self._msg_err_in
+        else:
+            if 0 <= len(params) <= 1:
+                prms = {"option": params[0]} if len(params) else {}  # Value is str
+            else:
+                raise ValueError("Invalid number of method arguments: '%s'", pprint.pformat(params))
+
+        return command, prms
+
+    except KeyError:
+        raise ValueError(f"Command '{command}' is not supported.")
+
+
+def single_zmq_request(zmq_server_address, method, params):
+
+    msg_received = None
+
+    async def send_request(method, params):
+        nonlocal msg_received
+        zmq_to_manager = ZMQCommSendAsync(zmq_server_address=zmq_server_address)
+        msg_received = await zmq_to_manager.send_message(method=method, params=params)
+        del zmq_to_manager  # This will close the socket
+
+    try:
+        method, params_out = create_msg(method, params)
+        asyncio.run(send_request(method, params_out))
+
+        msg = msg_received
+        msg_err = ""
+    except Exception as ex:
+        msg = None
+        msg_err = str(ex)
+
+    if msg_err:
+        logger.warning("Communication with RE Manager failed: %s", str(msg_err))
+
+    return msg, msg_err
 
 
 def qserver():
@@ -182,7 +136,7 @@ def qserver():
     logging.basicConfig(level=logging.WARNING)
     logging.getLogger("bluesky_queueserver").setLevel("CRITICAL")
 
-    supported_commands = list(CliClient.get_supported_commands().keys())
+    supported_commands = list(get_supported_commands().keys())
     # Add the command 'monitor' to the list. This command is not sent to RE Manager.
     supported_commands = ["monitor"] + supported_commands
 
@@ -252,12 +206,9 @@ def qserver():
         command = "ping"
         print("Running QSever monitor. Press Ctrl-C to exit ...")
 
-    re_server = CliClient(address=args.address)
     try:
         while True:
-            re_server.set_msg_out(command, params)
-            asyncio.run(re_server.zmq_single_request())
-            msg, msg_err = re_server.get_msg_in()
+            msg, msg_err = single_zmq_request(args.address, command, params)
 
             now = datetime.now()
             current_time = now.strftime("%H:%M:%S")

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -117,6 +117,7 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "-c", "queue_start"]) == 0
     ttime.sleep(1)
     assert subprocess.call(["qserver", "-c", "manager_kill"]) != 0
+    ttime.sleep(6)  # Don't request the condition to avoid timeout error TODO: wait for the server
     assert wait_for_condition(
         time=60, condition=condition_queue_processing_finished
     ), "Timeout while waiting for process to finish"

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -1,10 +1,9 @@
-import asyncio
 import logging
 from enum import Enum
 
-import zmq
-import zmq.asyncio
 from fastapi import FastAPI, HTTPException
+
+from ..manager.comms import ZMQCommSendAsync
 
 logger = logging.getLogger(__name__)
 
@@ -13,100 +12,25 @@ logger = logging.getLogger(__name__)
 #   login data. So for now we set up fixed user name and group
 _login_data = {"user": "John Doe", "user_group": "admin"}
 
-
-class ZMQComm:
-    def __init__(self, zmq_host="localhost", zmq_port="5555"):
-        self._loop = asyncio.get_event_loop()
-
-        # ZeroMQ communication
-        self._ctx = zmq.asyncio.Context()
-        self._zmq_socket = None
-        self._zmq_server_address = f"tcp://{zmq_host}:{zmq_port}"
-
-        # Start communication task
-        self._event_zmq_stop = None
-        self._task_zmq_client_conn = asyncio.ensure_future(self._zmq_start_client_conn())
-
-        self._lock_zmq = asyncio.Lock()
-
-    def __del__(self):
-        # Cancel the communication task
-        if not self._task_zmq_client_conn.done():
-            self._task_zmq_client_conn.cancel()
-
-    def get_loop(self):
-        """
-        Returns the asyncio loop.
-        """
-        return self._loop
-
-    # ==========================================================================
-    #    Functions that support ZeroMQ communications with RE Manager
-
-    async def _zmq_send(self, msg):
-        await self._zmq_socket.send_json(msg)
-
-    async def _zmq_receive(self):
-        try:
-            msg = await self._zmq_socket.recv_json()
-        except Exception as ex:
-            # TODO: proper error handling for cases when connection is interrupted.
-            # This is primitive error handling to make sure the server doesn't get stuck
-            #   if there is no reply after timeout. The server still needs to be restarted
-            #   if it was disconnected, since there is not mechanism to reestablish
-            #   connection.
-            logger.exception("ZeroMQ communication failed: %s" % str(ex))
-            msg = {}
-        return msg
-
-    async def _zmq_communicate(self, msg_out):
-        await self._zmq_send(msg_out)
-        msg_in = await self._zmq_receive()
-        return msg_in
-
-    def _zmq_socket_open(self):
-        self._zmq_socket = self._ctx.socket(zmq.REQ)
-        self._zmq_socket.RCVTIMEO = 2000  # Timeout for 'recv' operation
-        self._zmq_socket.SNDTIMEO = 500  # Timeout for 'send' operation
-        # Clear the buffer quickly after the socket is closed
-        self._zmq_socket.setsockopt(zmq.LINGER, 100)
-
-        self._zmq_socket.connect(self._zmq_server_address)
-        logger.info("Connected to ZeroMQ server '%s'" % str(self._zmq_server_address))
-
-    def _zmq_socket_restart(self):
-        self._zmq_socket.close()
-        self._zmq_socket_open()
-
-    async def _zmq_start_client_conn(self):
-        self._event_zmq_stop = asyncio.Event()
-        self._zmq_socket_open()
-        # The event must be set somewhere else
-        await self._event_zmq_stop.wait()
-
-    def _create_msg(self, *, command, params=None):
-        return {"method": command, "params": params}
-
-    async def send_command(self, *, command, params=None):
-        async with self._lock_zmq:
-            try:
-                msg_out = self._create_msg(command=command, params=params)
-                msg_in = await self._zmq_communicate(msg_out)
-                if not msg_in:
-                    raise Exception("Timeout while waiting for response from RE Manager.")
-            except Exception as ex:
-                # This is very likely a timeout (RE Manager is not responding)
-                msg_in = {"success": False, "msg": f"ZMQ communication error: {str(ex)}"}
-                self._zmq_socket_restart()
-            return msg_in
-
-
 logging.basicConfig(level=logging.WARNING)
 logging.getLogger("bluesky_queueserver").setLevel("DEBUG")
 
 # Use FastAPI
 app = FastAPI()
-re_server = ZMQComm()
+zmq_to_manager = None
+
+
+@app.on_event("startup")
+async def startup_event():
+    global zmq_to_manager
+    # ZMQCommSendAsync should be created from the event loop of FastAPI server.
+    zmq_to_manager = ZMQCommSendAsync()
+
+
+@app.on_event("shutdown")
+def shutdown_event():
+    global zmq_to_manager
+    del zmq_to_manager
 
 
 class REPauseOptions(str, Enum):
@@ -169,7 +93,7 @@ async def ping_handler():
     """
     May be called to get some response from the server. Currently returns status of RE Manager.
     """
-    msg = await re_server.send_command(command="")
+    msg = await zmq_to_manager.send_message(method="")
     return msg
 
 
@@ -178,7 +102,7 @@ async def status_handler():
     """
     Returns status of RE Manager.
     """
-    msg = await re_server.send_command(command="status")
+    msg = await zmq_to_manager.send_message(method="status")
     return msg
 
 
@@ -187,7 +111,7 @@ async def queue_get_handler():
     """
     Returns the contents of the current queue.
     """
-    msg = await re_server.send_command(command="queue_get")
+    msg = await zmq_to_manager.send_message(method="queue_get")
     return msg
 
 
@@ -196,7 +120,7 @@ async def queue_clear_handler():
     """
     Clear the plan queue.
     """
-    msg = await re_server.send_command(command="queue_clear")
+    msg = await zmq_to_manager.send_message(method="queue_clear")
     return msg
 
 
@@ -206,7 +130,7 @@ async def queue_start_handler():
     Start execution of the loaded queue. Additional runs can be added to the queue while
     it is executed. If the queue is empty, then nothing will happen.
     """
-    msg = await re_server.send_command(command="queue_start")
+    msg = await zmq_to_manager.send_message(method="queue_start")
     return msg
 
 
@@ -217,7 +141,7 @@ async def queue_stop():
     but the next plan will not be started. The request will be rejected if no plans are currently
     running
     """
-    msg = await re_server.send_command(command="queue_stop")
+    msg = await zmq_to_manager.send_message(method="queue_stop")
     return msg
 
 
@@ -231,7 +155,7 @@ async def queue_stop_cancel():
     the queue. The command always succeeds, but it has no effect if no queue stop
     requests are pending.
     """
-    msg = await re_server.send_command(command="queue_stop_cancel")
+    msg = await zmq_to_manager.send_message(method="queue_stop_cancel")
     return msg
 
 
@@ -244,7 +168,7 @@ async def queue_plan_add_handler(payload: dict):
     params = payload
     params["user"] = _login_data["user"]
     params["user_group"] = _login_data["user_group"]
-    msg = await re_server.send_command(command="queue_plan_add", params=params)
+    msg = await zmq_to_manager.send_message(method="queue_plan_add", params=params)
     return msg
 
 
@@ -253,7 +177,7 @@ async def queue_plan_remove_handler(payload: dict):
     """
     Remove plan from the queue
     """
-    msg = await re_server.send_command(command="queue_plan_remove", params=payload)
+    msg = await zmq_to_manager.send_message(method="queue_plan_remove", params=payload)
     return msg
 
 
@@ -262,7 +186,7 @@ async def queue_plan_get_handler(payload: dict):
     """
     Get a plan from the queue
     """
-    msg = await re_server.send_command(command="queue_plan_get", params=payload)
+    msg = await zmq_to_manager.send_message(method="queue_plan_get", params=payload)
     return msg
 
 
@@ -271,7 +195,7 @@ async def history_get_handler():
     """
     Returns the plan history (list of dicts).
     """
-    msg = await re_server.send_command(command="history_get")
+    msg = await zmq_to_manager.send_message(method="history_get")
     return msg
 
 
@@ -280,7 +204,7 @@ async def history_clear_handler():
     """
     Clear plan history.
     """
-    msg = await re_server.send_command(command="history_clear")
+    msg = await zmq_to_manager.send_message(method="history_clear")
     return msg
 
 
@@ -289,7 +213,7 @@ async def environment_open_handler():
     """
     Creates RE environment: creates RE Worker process, starts and configures Run Engine.
     """
-    msg = await re_server.send_command(command="environment_open")
+    msg = await zmq_to_manager.send_message(method="environment_open")
     return msg
 
 
@@ -299,7 +223,7 @@ async def environment_close_handler():
     Orderly closes of RE environment. The command returns success only if no plan is running,
     i.e. RE Manager is in the idle state. The command is rejected if a plan is running.
     """
-    msg = await re_server.send_command(command="environment_close")
+    msg = await zmq_to_manager.send_message(method="environment_close")
     return msg
 
 
@@ -309,7 +233,7 @@ async def environment_destroy_handler():
     Destroys RE environment by killing RE Worker process. This is a last resort command which
     should be made available only to expert level users.
     """
-    msg = await re_server.send_command(command="environment_destroy")
+    msg = await zmq_to_manager.send_message(method="environment_destroy")
     return msg
 
 
@@ -328,7 +252,7 @@ async def re_pause_handler(payload: dict):
     except Exception as ex:
         raise HTTPException(status_code=444, detail=str(ex))
 
-    msg = await re_server.send_command(command="re_pause", params=payload)
+    msg = await zmq_to_manager.send_message(method="re_pause", params=payload)
     return msg
 
 
@@ -337,7 +261,7 @@ async def re_resume_handler():
     """
     Run Engine: resume execution of a paused plan
     """
-    msg = await re_server.send_command(command="re_resume")
+    msg = await zmq_to_manager.send_message(method="re_resume")
     return msg
 
 
@@ -346,7 +270,7 @@ async def re_stop_handler():
     """
     Run Engine: stop execution of a paused plan
     """
-    msg = await re_server.send_command(command="re_stop")
+    msg = await zmq_to_manager.send_message(method="re_stop")
     return msg
 
 
@@ -355,7 +279,7 @@ async def re_abort_handler():
     """
     Run Engine: abort execution of a paused plan
     """
-    msg = await re_server.send_command(command="re_abort")
+    msg = await zmq_to_manager.send_message(method="re_abort")
     return msg
 
 
@@ -364,7 +288,7 @@ async def re_halt_handler():
     """
     Run Engine: halt execution of a paused plan
     """
-    msg = await re_server.send_command(command="re_halt")
+    msg = await zmq_to_manager.send_message(method="re_halt")
     return msg
 
 
@@ -374,7 +298,7 @@ async def plans_allowed_handler():
     Returns the lists of allowed plans.
     """
     params = {"user_group": _login_data["user_group"]}
-    msg = await re_server.send_command(command="plans_allowed", params=params)
+    msg = await zmq_to_manager.send_message(method="plans_allowed", params=params)
     return msg
 
 
@@ -384,7 +308,7 @@ async def devices_allowed_handler():
     Returns the lists of allowed devices.
     """
     params = {"user_group": _login_data["user_group"]}
-    msg = await re_server.send_command(command="devices_allowed", params=params)
+    msg = await zmq_to_manager.send_message(method="devices_allowed", params=params)
     return msg
 
 
@@ -393,7 +317,7 @@ async def manager_stop_handler(payload: dict):
     """
     Stops of RE Manager. RE Manager will not be restarted after it is stoped.
     """
-    msg = await re_server.send_command(command="manager_stop", params=payload)
+    msg = await zmq_to_manager.send_message(method="manager_stop", params=payload)
     return msg
 
 
@@ -403,5 +327,5 @@ async def test_manager_kill_handler():
     The command stops event loop of RE Manager process. Used for testing of RE Manager
     stability and handling of communication timeouts.
     """
-    msg = await re_server.send_command(command="manager_kill")
+    msg = await zmq_to_manager.send_message(method="manager_kill")
     return msg

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -30,7 +30,7 @@ async def startup_event():
 @app.on_event("shutdown")
 def shutdown_event():
     global zmq_to_manager
-    del zmq_to_manager
+    zmq_to_manager.close()
 
 
 class REPauseOptions(str, Enum):


### PR DESCRIPTION
Contributions: 

- Moved all ZMQ client code to `comms.py`. Class `ZMQCommSendAsync` is used by the web server and function `zmq_single_request` (useful for episodic requests to RE Manager) is used by the CLI tool and unit tests. The API may also be used by third party software if needed.

- Fixed an issue in `server.py` (potentially two event loops).