### PR TITLE
FIX: compatibility with pyzmq v20.0.0.

### DIFF
--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -511,9 +511,8 @@ class ZMQCommSendAsync:
         # Clear the buffer quickly after the socket is closed
         self._zmq_socket.setsockopt(zmq.LINGER, 100)
 
-        if self._zmq_socket.connect(self._zmq_server_address):
-            msg_err = f"Failed to connect to the server '{self._zmq_server_address}'"
-            raise RuntimeError(msg_err)
+        # Successful connection does not mean that the socket exists
+        self._zmq_socket.connect(self._zmq_server_address)
 
         logger.info("Connected to ZeroMQ server '%s'" % str(self._zmq_server_address))
 


### PR DESCRIPTION
Fixed minor bug that prevented the code from running correctly with `pyzmq` v. 20.0.0. In the new version of `pyzmq` the return value of `socket.connect()` is different from `None`. The code was incorrectly using the return value of `socket.connect()` to verify if the connection was established successfully. The changed code does not use the return value of `socket.connect()`.