### PR TITLE
FIX: reject create/close environment requests if already underway (2nd attempt)

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -230,7 +230,7 @@ class RunEngineManager(Process):
             # Wait for RE Worker to be prepared to close
             self._event_worker_closed = asyncio.Event()
 
-            # self._manager_state = MState.CLOSING_ENVIRONMENT
+            self._manager_state = MState.CLOSING_ENVIRONMENT
             await self._fut_manager_task_completed  # TODO: timeout may be needed here
 
             if not await self._confirm_re_worker_exit():

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -225,7 +225,7 @@ class RunEngineManager(Process):
             self._manager_state = MState.IDLE
             return False, "Environment does not exist"
 
-        if self._manager_state is not MState.IDLE and self._manager_state is not MState.CLOSING_ENVIRONMENT:
+        if self._manager_state not in [MState.IDLE, MState.CLOSING_ENVIRONMENT]:
             return False, f"Manager state was {self._manager_state.value}"
 
         self._fut_manager_task_completed = self._loop.create_future()

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -164,7 +164,7 @@ class RunEngineManager(Process):
         if self._environment_exists:
             return False, "Rejected: RE Worker environment already exists"
 
-        if self._manager_state is not MState.IDLE and self._manager_state is not MState.CREATING_ENVIRONMENT:
+        if self._manager_state not in [MState.IDLE, MState.CREATING_ENVIRONMENT]:
             return False, f"Manager state is {self._manager_state.value}"
 
         self._fut_manager_task_completed = self._loop.create_future()

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -87,7 +87,8 @@ def test_zmq_api_environment_open_close_2(re_manager):  # noqa F811
 
 def test_zmq_api_environment_open_close_3(re_manager):  # noqa F811
     """
-    Basic test for `environment_open` and `environment_close` methods.
+    Test for `environment_open` and `environment_close` methods.
+    Closing the environment while a plan is running.
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -31,6 +31,90 @@ _user, _user_group = "Testing Script", "admin"
 _existing_plans_and_devices_fln = "existing_plans_and_devices.yaml"
 _user_group_permissions_fln = "user_group_permissions.yaml"
 
+
+# =======================================================================================
+#                   Methods 'environment_open', 'environment_close'
+def test_zmq_api_environment_open_close_1(re_manager):  # noqa F811
+    """
+    Basic test for `environment_open` and `environment_close` methods.
+    """
+    resp1, _ = zmq_single_request("environment_open")
+    assert resp1["success"] is True
+    assert resp1["msg"] == ""
+
+    assert wait_for_condition(time=3, condition=condition_environment_created)
+
+    resp2, _ = zmq_single_request("environment_close")
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+
+    assert wait_for_condition(time=3, condition=condition_environment_closed)
+
+
+def test_zmq_api_environment_open_close_2(re_manager):  # noqa F811
+    """
+    Test for `environment_open` and `environment_close` methods.
+    Opening/closing the environment while it is being opened/closed.
+    Opening the environment that already exists.
+    Closing the environment that does not exist.
+    """
+    zmq_single_request("environment_open")
+    # Attempt to open the environment before the previous operation is completed
+    resp1, _ = zmq_single_request("environment_open")
+    assert resp1["success"] is False
+    assert "in the process of creating the RE Worker environment" in resp1["msg"]
+
+    assert wait_for_condition(time=3, condition=condition_environment_created)
+
+    # Attempt to open the environment while it already exists
+    resp2, _ = zmq_single_request("environment_open")
+    assert resp2["success"] is False
+    assert "RE Worker environment already exists" in resp2["msg"]
+
+    zmq_single_request("environment_close")
+    # The environment is being closed.
+    resp3, _ = zmq_single_request("environment_close")
+    assert resp3["success"] is False
+    assert "in the process of closing the RE Worker environment" in resp3["msg"]
+
+    assert wait_for_condition(time=3, condition=condition_environment_closed)
+
+    # The environment is already closed.
+    resp4, _ = zmq_single_request("environment_close")
+    assert resp4["success"] is False
+    assert "RE Worker environment does not exist" in resp4["msg"]
+
+
+def test_zmq_api_environment_open_close_3(re_manager):  # noqa F811
+    """
+    Basic test for `environment_open` and `environment_close` methods.
+    """
+    resp1, _ = zmq_single_request("environment_open")
+    assert resp1["success"] is True
+    assert resp1["msg"] == ""
+
+    assert wait_for_condition(time=3, condition=condition_environment_created)
+
+    # Start a plan
+    resp2, _ = zmq_single_request("queue_plan_add", {"plan": _plan3, "user": _user, "user_group": _user_group})
+    assert resp2["success"] is True
+    resp3, _ = zmq_single_request("queue_start")
+    assert resp3["success"] is True
+
+    # Try to close the environment while the plan is running
+    resp4, _ = zmq_single_request("environment_close")
+    assert resp4["success"] is False
+    assert "Queue execution is in progress" in resp4["msg"]
+
+    assert wait_for_condition(time=20, condition=condition_queue_processing_finished)
+
+    resp2, _ = zmq_single_request("environment_close")
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+
+    assert wait_for_condition(time=3, condition=condition_environment_closed)
+
+
 # =======================================================================================
 #                             Method 'queue_plan_add'
 

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -410,7 +410,7 @@ def test_http_server_open_environment_handler(re_manager, fastapi_server):  # no
     assert wait_for_environment_to_be_created(10), "Timeout"
 
     resp2 = _request_to_json("post", "/environment/open")
-    assert resp2 == {"success": False, "msg": "Environment already exists."}
+    assert resp2 == {"success": False, "msg": "RE Worker environment already exists."}
 
 
 def test_http_server_close_environment_handler(re_manager, fastapi_server):  # noqa F811


### PR DESCRIPTION
Make use of the RE Manager MState enum to indicate when the
manager is already underway in the creation or closing of a
RE Worker environment.

Previously the manager would get into a locked up state if
a request to create an environment was received while it was
already mid-way through the act of creating an environment.