### PR TITLE
DOC: correct typo in flake8 command

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -75,7 +75,7 @@ Ready to contribute? Here's how to set up `bluesky-queueserver` for local develo
 
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
-    $ flake8 bluesky_queueserver/tests
+    $ flake8
     $ python setup.py test
     $ tox
 
@@ -101,4 +101,3 @@ Before you submit a pull request, check that it meets these guidelines:
 3. The pull request should work for Python 2.7, 3.3, 3.4, 3.5 and for PyPy. Check
    https://travis-ci.org/tacaswell/bluesky-queueserver/pull_requests
    and make sure that the tests pass for all supported Python versions.
-

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -75,7 +75,7 @@ Ready to contribute? Here's how to set up `bluesky-queueserver` for local develo
 
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
-    $ flake8 bluesky_queueserver tests
+    $ flake8 bluesky_queueserver/tests
     $ python setup.py test
     $ tox
 


### PR DESCRIPTION
Hey please consider this somewhat of a tentative PR, I'm not sure if the documentation as is would have worked for some setups? But I found when I tried to run it that the slash was needed as I guess it was meant to be a path, so I assumed this was a typo?

**Also I gained a bit of experience in trying to run the unit tests** on my local machine that I felt wasn't really documented in the current README or CONTRIBUTING docs. **I'm happy to add those steps to the documentation** provided I didn't miss it already being documented or mentioned somewhere else already?
It wouldn't be much, just the steps to execute and the prerequisites (**like having a running redis server when running the tests, and http server**)

Regarding my experience having to manually start the redis service and http server, were the tests supposed to do this automatically for me? I wasn't sure but they didn't seem to.