### PR TITLE
ENH: load reference to 'db' into RE namespace

### DIFF
--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -565,6 +565,8 @@ class RunEngineWorker(Process):
                             from databroker import Broker
 
                             self._db = Broker.named(config_name)
+                            self._re_namespace["db"] = self._db
+
                             self._RE.subscribe(self._db.insert)
 
                 if "kafka" in self._config:


### PR DESCRIPTION
Fixes the issue discovered during testing of the QueueServer. In the default mode, QueueServer is removing references to Run Engine (`RE`) and Data Broker (`db`) from RE namespace and generates a new instance of Run Engine. If the name of configuration file is provided as the value of one of CLI parameters (e.g. `start-re-manager --databroker_config "bmm"`), then a new instance of `db` is created and Run Engine is subscribed to it. A simple modification to the code in this PR includes the reference to `db` into RE namespaces so that it becomes accessible from the executed plans. 