### PR TITLE
ENH: implementation of an option to add 'queue_stop' instructions to the plan queue

### DIFF
--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -321,7 +321,7 @@ def test_zmq_api_queue_plan_add_5(re_manager):  # noqa: F811
 
 def test_zmq_api_queue_plan_add_6(re_manager):  # noqa: F811
     """
-    Add instruction ('queue_stop') to the queue. Execute the queue.
+    Add instruction ('queue_stop') to the queue.
     """
 
     params1a = {"plan": _plan1, "user": _user, "user_group": _user_group}

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -161,6 +161,30 @@ def test_http_server_queue_plan_add_handler_3(re_manager, fastapi_server):  # no
     assert resp4["running_plan"] == {}
 
 
+def test_http_server_queue_plan_add_handler_4(re_manager, fastapi_server):  # noqa: F811
+    """
+    Add instruction ('queue_stop') to the queue.
+    """
+
+    plan1 = {"name": "count", "args": [["det1"]]}
+    plan2 = {"name": "count", "args": [["det1", "det2"]]}
+    instruction = {"action": "queue_stop"}
+
+    # Create the queue with 2 entries
+    resp1 = _request_to_json("post", "/queue/plan/add", json={"plan": plan1})
+    assert resp1["success"] is True, f"resp={resp1}"
+    resp2 = _request_to_json("post", "/queue/plan/add", json={"instruction": instruction})
+    assert resp2["success"] is True, f"resp={resp2}"
+    resp3 = _request_to_json("post", "/queue/plan/add", json={"plan": plan2})
+    assert resp3["success"] is True, f"resp={resp3}"
+
+    resp4 = _request_to_json("get", "/queue/get")
+    assert len(resp4["queue"]) == 3
+    assert resp4["queue"][0]["item_type"] == "plan"
+    assert resp4["queue"][1]["item_type"] == "instruction"
+    assert resp4["queue"][2]["item_type"] == "plan"
+
+
 def test_http_server_queue_plan_add_handler_6_fail(re_manager, fastapi_server):  # noqa F811
     """
     Failing case: call without sending a plan.

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -168,8 +168,9 @@ def test_http_server_queue_plan_add_handler_6_fail(re_manager, fastapi_server): 
     resp1 = _request_to_json("post", "/queue/plan/add", json={})
     assert resp1["success"] is False
     assert resp1["qsize"] is None
-    assert resp1["plan"] == {}
-    assert "no plan is specified" in resp1["msg"]
+    assert "plan" not in resp1
+    assert "instruction" not in resp1
+    assert "Incorrect request format: request contains no item info." in resp1["msg"]
 
 
 def test_http_server_queue_plan_get_remove_handler_1(re_manager, fastapi_server, add_plans_to_queue):  # noqa F811


### PR DESCRIPTION
The code that implements an option to add `queue_stop` instructions to the plan queue. Once the instruction is encountered during plan execution, the queue execution is stopped. Execution may be resumed by sending `queue_start` request to the manager. The instructions are treated similarly to plans: they can be added to the queue, removed from the queue or moved within the queue. Instructions are assigned `plan_uid` and can be accessed by position and UID (the same way as plans).

Currently an instruction can be added to the queue by sending

```
"instruction": {"action": "queue_stop"}
```
instead of `"plan": {...}` as an argument of `queue_plan_add`. The option of adding instructions is not yet implemented in CLI tool.

The option of adding instructions to the queue makes current naming (e.g. `queue_plan_add`, `queue_plan_remove`, `plan_uid`) misleading. It may be a good idea to rename the API that are used to request operations on the queue and data fields reporting the state of the queue to use the word `item` instead of `plan` (e.g. `queue_item_add`, `queue_item_remove`, `item_uid`). 