### PR TITLE
Renaming of API to refer plan queue items as 'items' instead  of 'plans'.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,9 +158,9 @@ Push a new plan to the back of the queue::
   qserver -c queue_item_add -p '{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
   qserver -c queue_item_add -p '{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
 
-  http POST http://localhost:60610/queue/plan/add plan:='{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/plan/add plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
-  http POST http://localhost:60610/queue/plan/add plan:='{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
+  http POST http://localhost:60610/queue/item/add plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+  http POST http://localhost:60610/queue/item/add plan:='{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
 
 It takes 10 second to execute the third plan in the group above, so it is may be the most convenient for testing
 pausing/resuming/stopping of experimental plans.
@@ -171,31 +171,31 @@ The plan to be added at any position of the queue including pushing to the front
   qserver -c queue_item_add -p back '{"name":"count", "args":[["det1", "det2"]]}'
   qserver -c queue_item_add -p 2 '{"name":"count", "args":[["det1", "det2"]]}'  # Inserted at pos #2 (0-based)
 
-  http POST http://localhost:60610/queue/plan/add pos:='"front"' plan:='{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/plan/add pos:='"back"' plan:='{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/plan/add pos:=2 plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add pos:='"front"' plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add pos:='"back"' plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add pos:=2 plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
 The following command will insert the plan in place of the last element and shift the last element to
 the back so that the new element is now previous to last::
 
   qserver -c queue_item_add -p -1 '{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/plan/add pos:=-1 plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add pos:=-1 plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
 The plan can be inserted before or after an existing plan in the queue by specifying the UID of the plan.
 Insert the plan before an existing plan with <uid>::
 
   qserver -c queue_item_add -p before_uid '<uid>' '{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/plan/add before_uid:='<uid>' plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add before_uid:='<uid>' plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
 Insert the plan after an existing plan with <uid>::
 
   qserver -c queue_item_add -p after_uid '<uid>' '{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/plan/add after_uid:='<uid>' plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add after_uid:='<uid>' plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
 If the queue has 5 elements (0..4), then the following command pushes the new plan to the back of the queue::
 
   qserver -c queue_item_add -p 5 '{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/plan/add pos:=5 plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add pos:=5 plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
 The 'queue_item_add' request will accept any index value. If the index is out of range, then the plan will
 be pushed to the front or the back of the queue. If the queue is currently running, then it is recommended
@@ -218,8 +218,8 @@ The last item can be removed (popped) from the back of the queue::
   qserver -c queue_item_remove
   qserver -c queue_item_remove -p back
 
-  echo '{}' | http POST http://localhost:60610/queue/plan/remove
-  http POST http://localhost:60610/queue/plan/remove pos:='"back"'
+  echo '{}' | http POST http://localhost:60610/queue/item/remove
+  http POST http://localhost:60610/queue/item/remove pos:='"back"'
 
 The position of the removed element may be specified similarly to `queue_item_add` request with the difference
 that the position index must point to the existing element, otherwise the request fails (returns 'success==False').
@@ -228,13 +228,13 @@ The following examples remove the plan from the front of the queue and the eleme
   qserver -c queue_item_remove -p front
   qserver -c queue_item_remove -p -2
 
-  http POST http://localhost:60610/queue/plan/remove pos:='"front"'
-  http POST http://localhost:60610/queue/plan/remove pos:=-2
+  http POST http://localhost:60610/queue/item/remove pos:='"front"'
+  http POST http://localhost:60610/queue/item/remove pos:=-2
 
 The plans can also be addressed by UID. Remove the plan with <uid>::
 
   qserver -c queue_item_remove -p '<uid>'
-  http POST http://localhost:60610/queue/plan/remove uid:='<uid>'
+  http POST http://localhost:60610/queue/item/remove uid:='<uid>'
 
 Plans can be read from the queue without changing it. `queue_item_get` requests are formatted identically to
 `queue_item_remove` requests::

--- a/README.rst
+++ b/README.rst
@@ -154,9 +154,9 @@ Get the lists (JSON) of allowed plans and devices::
 
 Push a new plan to the back of the queue::
 
-  qserver -c queue_plan_add -p '{"name":"count", "args":[["det1", "det2"]]}'
-  qserver -c queue_plan_add -p '{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
-  qserver -c queue_plan_add -p '{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
+  qserver -c queue_item_add -p '{"name":"count", "args":[["det1", "det2"]]}'
+  qserver -c queue_item_add -p '{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+  qserver -c queue_item_add -p '{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
 
   http POST http://localhost:60610/queue/plan/add plan:='{"name":"count", "args":[["det1", "det2"]]}'
   http POST http://localhost:60610/queue/plan/add plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
@@ -167,9 +167,9 @@ pausing/resuming/stopping of experimental plans.
 
 The plan to be added at any position of the queue including pushing to the front or back of the queue::
 
-  qserver -c queue_plan_add -p front '{"name":"count", "args":[["det1", "det2"]]}'
-  qserver -c queue_plan_add -p back '{"name":"count", "args":[["det1", "det2"]]}'
-  qserver -c queue_plan_add -p 2 '{"name":"count", "args":[["det1", "det2"]]}'  # Inserted at pos #2 (0-based)
+  qserver -c queue_item_add -p front '{"name":"count", "args":[["det1", "det2"]]}'
+  qserver -c queue_item_add -p back '{"name":"count", "args":[["det1", "det2"]]}'
+  qserver -c queue_item_add -p 2 '{"name":"count", "args":[["det1", "det2"]]}'  # Inserted at pos #2 (0-based)
 
   http POST http://localhost:60610/queue/plan/add pos:='"front"' plan:='{"name":"count", "args":[["det1", "det2"]]}'
   http POST http://localhost:60610/queue/plan/add pos:='"back"' plan:='{"name":"count", "args":[["det1", "det2"]]}'
@@ -178,26 +178,26 @@ The plan to be added at any position of the queue including pushing to the front
 The following command will insert the plan in place of the last element and shift the last element to
 the back so that the new element is now previous to last::
 
-  qserver -c queue_plan_add -p -1 '{"name":"count", "args":[["det1", "det2"]]}'
+  qserver -c queue_item_add -p -1 '{"name":"count", "args":[["det1", "det2"]]}'
   http POST http://localhost:60610/queue/plan/add pos:=-1 plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
 The plan can be inserted before or after an existing plan in the queue by specifying the UID of the plan.
 Insert the plan before an existing plan with <uid>::
 
-  qserver -c queue_plan_add -p before_uid '<uid>' '{"name":"count", "args":[["det1", "det2"]]}'
+  qserver -c queue_item_add -p before_uid '<uid>' '{"name":"count", "args":[["det1", "det2"]]}'
   http POST http://localhost:60610/queue/plan/add before_uid:='<uid>' plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
 Insert the plan after an existing plan with <uid>::
 
-  qserver -c queue_plan_add -p after_uid '<uid>' '{"name":"count", "args":[["det1", "det2"]]}'
+  qserver -c queue_item_add -p after_uid '<uid>' '{"name":"count", "args":[["det1", "det2"]]}'
   http POST http://localhost:60610/queue/plan/add after_uid:='<uid>' plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
 If the queue has 5 elements (0..4), then the following command pushes the new plan to the back of the queue::
 
-  qserver -c queue_plan_add -p 5 '{"name":"count", "args":[["det1", "det2"]]}'
+  qserver -c queue_item_add -p 5 '{"name":"count", "args":[["det1", "det2"]]}'
   http POST http://localhost:60610/queue/plan/add pos:=5 plan:='{"name":"count", "args":[["det1", "det2"]]}'
 
-The 'queue_plan_add' request will accept any index value. If the index is out of range, then the plan will
+The 'queue_item_add' request will accept any index value. If the index is out of range, then the plan will
 be pushed to the front or the back of the queue. If the queue is currently running, then it is recommended
 to access elements using negative indices (counted from the back of the queue).
 
@@ -221,7 +221,7 @@ The last item can be removed (popped) from the back of the queue::
   echo '{}' | http POST http://localhost:60610/queue/plan/remove
   http POST http://localhost:60610/queue/plan/remove pos:='"back"'
 
-The position of the removed element may be specified similarly to `queue_plan_add` request with the difference
+The position of the removed element may be specified similarly to `queue_item_add` request with the difference
 that the position index must point to the existing element, otherwise the request fails (returns 'success==False').
 The following examples remove the plan from the front of the queue and the element previous to last::
 

--- a/README.rst
+++ b/README.rst
@@ -236,14 +236,14 @@ The plans can also be addressed by UID. Remove the plan with <uid>::
   qserver -c queue_plan_remove -p '<uid>'
   http POST http://localhost:60610/queue/plan/remove uid:='<uid>'
 
-Plans can be read from the queue without changing it. `queue_plan_get` requests are formatted identically to
+Plans can be read from the queue without changing it. `queue_item_get` requests are formatted identically to
 `queue_plan_remove` requests::
 
-  qserver -c queue_plan_get
-  qserver -c queue_plan_get -p back
-  qserver -c queue_plan_get -p front
-  qserver -c queue_plan_get -p -2
-  qserver -c queue_plan_get -p '<uid>'
+  qserver -c queue_item_get
+  qserver -c queue_item_get -p back
+  qserver -c queue_item_get -p front
+  qserver -c queue_item_get -p -2
+  qserver -c queue_item_get -p '<uid>'
 
   echo '{}' | http POST http://localhost:60610/queue/plan/get
   http POST http://localhost:60610/queue/plan/get pos:='"back"'

--- a/README.rst
+++ b/README.rst
@@ -260,20 +260,20 @@ the plan with <uid_dest>::
   qserver -c queue_item_move -p <uid_source> before <uid_dest>
   qserver -c queue_item_move -p <uid_source> after <uid_dest>
 
-  http POST http://localhost:60610/queue/plan/move pos:=3 pos_dest:=5
-  http POST http://localhost:60610/queue/plan/move uid:='<uid_source>' before_uid:='<uid_dest>'
-  http POST http://localhost:60610/queue/plan/move uid:='<uid_source>' after_uid:='<uid_dest>'
+  http POST http://localhost:60610/queue/item/move pos:=3 pos_dest:=5
+  http POST http://localhost:60610/queue/item/move uid:='<uid_source>' before_uid:='<uid_dest>'
+  http POST http://localhost:60610/queue/item/move uid:='<uid_source>' after_uid:='<uid_dest>'
 
 Addressing by position and UID may be mixed. The following instruction will move queue item #3
 to the position following an item with <uid_dest>::
 
   qserver -c queue_item_move -p 3 after <uid_dest>
-  http POST http://localhost:60610/queue/plan/move pos:=3 after_uid:='<uid_dest>'
+  http POST http://localhost:60610/queue/item/move pos:=3 after_uid:='<uid_dest>'
 
 The following instruction moves item with <uid_source> to the front of the queue::
 
   qserver -c queue_item_move -p <uid_source> "front"
-  http POST http://localhost:60610/queue/plan/move uid:='<uid_source>' pos_dest:='"front"'
+  http POST http://localhost:60610/queue/item/move uid:='<uid_source>' pos_dest:='"front"'
 
 Remove all entries from the plan queue::
 

--- a/README.rst
+++ b/README.rst
@@ -245,11 +245,11 @@ Plans can be read from the queue without changing it. `queue_item_get` requests 
   qserver -c queue_item_get -p -2
   qserver -c queue_item_get -p '<uid>'
 
-  echo '{}' | http POST http://localhost:60610/queue/plan/get
-  http POST http://localhost:60610/queue/plan/get pos:='"back"'
-  http POST http://localhost:60610/queue/plan/get pos:='"front"'
-  http POST http://localhost:60610/queue/plan/get pos:=-2
-  http POST http://localhost:60610/queue/plan/get uid:='<uid>'
+  echo '{}' | http POST http://localhost:60610/queue/item/get
+  http POST http://localhost:60610/queue/item/get pos:='"back"'
+  http POST http://localhost:60610/queue/item/get pos:='"front"'
+  http POST http://localhost:60610/queue/item/get pos:=-2
+  http POST http://localhost:60610/queue/item/get uid:='<uid>'
 
 Plans can be moved within the queue. Plans can be addressed by position or UID. If plans are
 addressed by position, then the plan is moved from 'source' position to 'destination' position.

--- a/README.rst
+++ b/README.rst
@@ -256,9 +256,9 @@ addressed by position, then the plan is moved from 'source' position to 'destina
 If plans are addressed by UID, then the plan with <uid_source> in inserted before or after
 the plan with <uid_dest>::
 
-  qserver -c queue_plan_move -p 3 5
-  qserver -c queue_plan_move -p <uid_source> before <uid_dest>
-  qserver -c queue_plan_move -p <uid_source> after <uid_dest>
+  qserver -c queue_item_move -p 3 5
+  qserver -c queue_item_move -p <uid_source> before <uid_dest>
+  qserver -c queue_item_move -p <uid_source> after <uid_dest>
 
   http POST http://localhost:60610/queue/plan/move pos:=3 pos_dest:=5
   http POST http://localhost:60610/queue/plan/move uid:='<uid_source>' before_uid:='<uid_dest>'
@@ -267,12 +267,12 @@ the plan with <uid_dest>::
 Addressing by position and UID may be mixed. The following instruction will move queue item #3
 to the position following an item with <uid_dest>::
 
-  qserver -c queue_plan_move -p 3 after <uid_dest>
+  qserver -c queue_item_move -p 3 after <uid_dest>
   http POST http://localhost:60610/queue/plan/move pos:=3 after_uid:='<uid_dest>'
 
 The following instruction moves item with <uid_source> to the front of the queue::
 
-  qserver -c queue_plan_move -p <uid_source> "front"
+  qserver -c queue_item_move -p <uid_source> "front"
   http POST http://localhost:60610/queue/plan/move uid:='<uid_source>' pos_dest:='"front"'
 
 Remove all entries from the plan queue::

--- a/README.rst
+++ b/README.rst
@@ -215,8 +215,8 @@ The contents of the queue may be fetched at any time::
 
 The last item can be removed (popped) from the back of the queue::
 
-  qserver -c queue_plan_remove
-  qserver -c queue_plan_remove -p back
+  qserver -c queue_item_remove
+  qserver -c queue_item_remove -p back
 
   echo '{}' | http POST http://localhost:60610/queue/plan/remove
   http POST http://localhost:60610/queue/plan/remove pos:='"back"'
@@ -225,19 +225,19 @@ The position of the removed element may be specified similarly to `queue_item_ad
 that the position index must point to the existing element, otherwise the request fails (returns 'success==False').
 The following examples remove the plan from the front of the queue and the element previous to last::
 
-  qserver -c queue_plan_remove -p front
-  qserver -c queue_plan_remove -p -2
+  qserver -c queue_item_remove -p front
+  qserver -c queue_item_remove -p -2
 
   http POST http://localhost:60610/queue/plan/remove pos:='"front"'
   http POST http://localhost:60610/queue/plan/remove pos:=-2
 
 The plans can also be addressed by UID. Remove the plan with <uid>::
 
-  qserver -c queue_plan_remove -p '<uid>'
+  qserver -c queue_item_remove -p '<uid>'
   http POST http://localhost:60610/queue/plan/remove uid:='<uid>'
 
 Plans can be read from the queue without changing it. `queue_item_get` requests are formatted identically to
-`queue_plan_remove` requests::
+`queue_item_remove` requests::
 
   qserver -c queue_item_get
   qserver -c queue_item_get -p back

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -477,7 +477,7 @@ class RunEngineManager(Process):
             elif next_item["item_type"] == "instruction":
                 if next_item["action"] == "queue_stop":
                     # Pop the instruction from the queue
-                    await self._plan_queue.pop_plan_from_queue(pos="front")
+                    await self._plan_queue.pop_item_from_queue(pos="front")
                     self._manager_state = MState.EXECUTING_QUEUE
                     self._queue_stop_pending = True
                     asyncio.ensure_future(self._start_plan_task())
@@ -926,7 +926,7 @@ class RunEngineManager(Process):
             plan, qsize, msg = {}, None, ""
             pos = request.get("pos", None)
             uid = request.get("uid", None)
-            plan, qsize = await self._plan_queue.pop_plan_from_queue(pos=pos, uid=uid)
+            plan, qsize = await self._plan_queue.pop_item_from_queue(pos=pos, uid=uid)
             success = True
         except Exception as ex:
             success = False

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -934,7 +934,7 @@ class RunEngineManager(Process):
 
         return {"success": success, "msg": msg, "plan": plan, "qsize": qsize}
 
-    async def _queue_plan_move_handler(self, request):
+    async def _queue_item_move_handler(self, request):
         """
         Moves a plan to a new position in the queue. Source and destination
         for the plan may be specified as position of the plan in the queue
@@ -1158,7 +1158,7 @@ class RunEngineManager(Process):
             "queue_item_add": "_queue_item_add_handler",
             "queue_item_get": "_queue_item_get_handler",
             "queue_item_remove": "_queue_item_remove_handler",
-            "queue_plan_move": "_queue_plan_move_handler",
+            "queue_item_move": "_queue_item_move_handler",
             "queue_clear": "_queue_clear_handler",
             "queue_start": "_queue_start_handler",
             "queue_stop": "_queue_stop_handler",

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -707,14 +707,14 @@ class RunEngineManager(Process):
         logger.info("Processing 'status' request.")
 
         # Computed/retrieved data
-        n_pending_plans = await self._plan_queue.get_queue_size()
-        running_plan_info = await self._plan_queue.get_running_item_info()
-        n_plans_in_history = await self._plan_queue.get_history_size()
+        n_pending_items = await self._plan_queue.get_queue_size()
+        running_item_info = await self._plan_queue.get_running_item_info()
+        n_items_in_history = await self._plan_queue.get_history_size()
 
         # Prepared output data
-        plans_in_queue = n_pending_plans
-        plans_in_history = n_plans_in_history
-        running_plan_uid = running_plan_info["plan_uid"] if running_plan_info else None
+        items_in_queue = n_pending_items
+        items_in_history = n_items_in_history
+        running_item_uid = running_item_info["plan_uid"] if running_item_info else None
         manager_state = self._manager_state.value
         queue_stop_pending = self._queue_stop_pending
         worker_environment_exists = self._environment_exists
@@ -724,9 +724,9 @@ class RunEngineManager(Process):
         #       retrieve detailed status.
         msg = {
             "msg": "RE Manager",
-            "plans_in_queue": plans_in_queue,
-            "plans_in_history": plans_in_history,
-            "running_plan_uid": running_plan_uid,
+            "items_in_queue": items_in_queue,
+            "items_in_history": items_in_history,
+            "running_item_uid": running_item_uid,
             "manager_state": manager_state,
             "queue_stop_pending": queue_stop_pending,
             "worker_environment_exists": worker_environment_exists,
@@ -886,7 +886,7 @@ class RunEngineManager(Process):
 
         except Exception as ex:
             success = False
-            msg = f"Failed to add a plan: {str(ex)}"
+            msg = f"Failed to add an item: {str(ex)}"
 
         rdict = {"success": success, "msg": msg, "qsize": qsize}
         if item_type:
@@ -909,7 +909,7 @@ class RunEngineManager(Process):
             success = True
         except Exception as ex:
             success = False
-            msg = f"Failed to get a plan: {str(ex)}"
+            msg = f"Failed to get an item: {str(ex)}"
 
         return {"success": success, "msg": msg, "plan": plan}
 
@@ -930,7 +930,7 @@ class RunEngineManager(Process):
             success = True
         except Exception as ex:
             success = False
-            msg = f"Failed to remove a plan: {str(ex)}"
+            msg = f"Failed to remove an item: {str(ex)}"
 
         return {"success": success, "msg": msg, "plan": plan, "qsize": qsize}
 
@@ -956,7 +956,7 @@ class RunEngineManager(Process):
             success = True
         except Exception as ex:
             success = False
-            msg = f"Failed to move the plan: {str(ex)}"
+            msg = f"Failed to move the item: {str(ex)}"
 
         return {"success": success, "msg": msg, "plan": plan, "qsize": qsize}
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -879,7 +879,7 @@ class RunEngineManager(Process):
             item["plan_uid"] = PlanQueueOperations.new_plan_uid()
 
             # Adding plan to queue may raise an exception
-            item, qsize = await self._plan_queue.add_plan_to_queue(
+            item, qsize = await self._plan_queue.add_item_to_queue(
                 item, pos=pos, before_uid=before_uid, after_uid=after_uid
             )
             success = True

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -708,7 +708,7 @@ class RunEngineManager(Process):
 
         # Computed/retrieved data
         n_pending_plans = await self._plan_queue.get_queue_size()
-        running_plan_info = await self._plan_queue.get_running_plan_info()
+        running_plan_info = await self._plan_queue.get_running_item_info()
         n_plans_in_history = await self._plan_queue.get_plan_history_size()
 
         # Prepared output data
@@ -794,7 +794,7 @@ class RunEngineManager(Process):
         """
         logger.info("Returning current queue and running plan.")
         plan_queue = await self._plan_queue.get_queue()
-        running_plan = await self._plan_queue.get_running_plan_info()
+        running_plan = await self._plan_queue.get_running_item_info()
 
         return {"queue": plan_queue, "running_plan": running_plan}
 
@@ -1244,7 +1244,7 @@ class RunEngineManager(Process):
                 re_state = self._worker_state_info["re_state"]
                 if plan_uid_running:
                     # Plan is running. Check if it is the same plan as in redis.
-                    plan_stored = await self._plan_queue.get_running_plan_info()
+                    plan_stored = await self._plan_queue.get_running_item_info()
                     if "plan_uid" in plan_stored:
                         plan_uid_stored = plan_stored["plan_uid"]
                         if re_state in ("paused", "pausing"):

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -894,7 +894,7 @@ class RunEngineManager(Process):
 
         return rdict
 
-    async def _queue_plan_get_handler(self, request):
+    async def _queue_item_get_handler(self, request):
         """
         Returns an item from the queue. The position of the item
         may be specified as an index (positive or negative) or a string
@@ -1156,7 +1156,7 @@ class RunEngineManager(Process):
             "environment_close": "_environment_close_handler",
             "environment_destroy": "_environment_destroy_handler",
             "queue_item_add": "_queue_item_add_handler",
-            "queue_plan_get": "_queue_plan_get_handler",
+            "queue_item_get": "_queue_item_get_handler",
             "queue_plan_remove": "_queue_plan_remove_handler",
             "queue_plan_move": "_queue_plan_move_handler",
             "queue_clear": "_queue_clear_handler",

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -798,7 +798,7 @@ class RunEngineManager(Process):
 
         return {"queue": plan_queue, "running_plan": running_plan}
 
-    async def _queue_plan_add_handler(self, request):
+    async def _queue_item_add_handler(self, request):
         """
         Adds new item to the the queue. Item may be a plan or an instruction. Request must
         include the element with the key ``plan`` if the added item is a plan or ``instruction``
@@ -1155,7 +1155,7 @@ class RunEngineManager(Process):
             "environment_open": "_environment_open_handler",
             "environment_close": "_environment_close_handler",
             "environment_destroy": "_environment_destroy_handler",
-            "queue_plan_add": "_queue_plan_add_handler",
+            "queue_item_add": "_queue_item_add_handler",
             "queue_plan_get": "_queue_plan_get_handler",
             "queue_plan_remove": "_queue_plan_remove_handler",
             "queue_plan_move": "_queue_plan_move_handler",

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -449,7 +449,7 @@ class RunEngineManager(Process):
 
                 self._manager_state = MState.EXECUTING_QUEUE
 
-                new_plan = await self._plan_queue.set_next_plan_as_running()
+                new_plan = await self._plan_queue.set_next_item_as_running()
 
                 plan_name = new_plan["name"]
                 args = new_plan["args"] if "args" in new_plan else []

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -876,7 +876,7 @@ class RunEngineManager(Process):
             item["user_group"] = user_group
 
             # Always generate a new UID for the added plan!!!
-            item["plan_uid"] = PlanQueueOperations.new_plan_uid()
+            item["plan_uid"] = PlanQueueOperations.new_item_uid()
 
             # Adding plan to queue may raise an exception
             item, qsize = await self._plan_queue.add_item_to_queue(

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -950,7 +950,7 @@ class RunEngineManager(Process):
             pos_dest = request.get("pos_dest", None)
             before_uid = request.get("before_uid", None)
             after_uid = request.get("after_uid", None)
-            plan, qsize = await self._plan_queue.move_plan(
+            plan, qsize = await self._plan_queue.move_item(
                 pos=pos, uid=uid, pos_dest=pos_dest, before_uid=before_uid, after_uid=after_uid
             )
             success = True

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -793,7 +793,7 @@ class RunEngineManager(Process):
         Returns the contents of the current queue.
         """
         logger.info("Returning current queue and running plan.")
-        plan_queue = await self._plan_queue.get_plan_queue()
+        plan_queue = await self._plan_queue.get_queue()
         running_plan = await self._plan_queue.get_running_plan_info()
 
         return {"queue": plan_queue, "running_plan": running_plan}

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -913,7 +913,7 @@ class RunEngineManager(Process):
 
         return {"success": success, "msg": msg, "plan": plan}
 
-    async def _queue_plan_remove_handler(self, request):
+    async def _queue_item_remove_handler(self, request):
         """
         Removes (pops) item from the queue. The position of the item
         may be specified as an index (positive or negative) or a string
@@ -1157,7 +1157,7 @@ class RunEngineManager(Process):
             "environment_destroy": "_environment_destroy_handler",
             "queue_item_add": "_queue_item_add_handler",
             "queue_item_get": "_queue_item_get_handler",
-            "queue_plan_remove": "_queue_plan_remove_handler",
+            "queue_item_remove": "_queue_item_remove_handler",
             "queue_plan_move": "_queue_plan_move_handler",
             "queue_clear": "_queue_clear_handler",
             "queue_start": "_queue_start_handler",

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -420,7 +420,7 @@ class RunEngineManager(Process):
         "args" (list of args), "kwargs" (list of kwargs). Only the plan name is mandatory.
         Names of plans and devices are strings.
         """
-        n_pending_plans = await self._plan_queue.get_plan_queue_size()
+        n_pending_plans = await self._plan_queue.get_queue_size()
         logger.info("Starting a new plan: %d plans are left in the queue", n_pending_plans)
 
         if not n_pending_plans:
@@ -707,7 +707,7 @@ class RunEngineManager(Process):
         logger.info("Processing 'status' request.")
 
         # Computed/retrieved data
-        n_pending_plans = await self._plan_queue.get_plan_queue_size()
+        n_pending_plans = await self._plan_queue.get_queue_size()
         running_plan_info = await self._plan_queue.get_running_plan_info()
         n_plans_in_history = await self._plan_queue.get_plan_history_size()
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -965,7 +965,7 @@ class RunEngineManager(Process):
         Remove all entries from the plan queue (does not affect currently executed run)
         """
         logger.info("Clearing the queue")
-        await self._plan_queue.clear_plan_queue()
+        await self._plan_queue.clear_queue()
         return {"success": True, "msg": "Plan queue is now empty."}
 
     async def _history_get_handler(self, request):

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -434,7 +434,7 @@ class RunEngineManager(Process):
             logger.info(err_msg)
 
         else:
-            next_item = await self._plan_queue.get_plan(pos="front")
+            next_item = await self._plan_queue.get_item(pos="front")
 
             # The next items is PLAN
             if next_item["item_type"] == "plan":
@@ -905,7 +905,7 @@ class RunEngineManager(Process):
             plan, msg = {}, ""
             pos = request.get("pos", None)
             uid = request.get("uid", None)
-            plan = await self._plan_queue.get_plan(pos=pos, uid=uid)
+            plan = await self._plan_queue.get_item(pos=pos, uid=uid)
             success = True
         except Exception as ex:
             success = False

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -32,7 +32,7 @@ class PlanQueueOperations:
         qsize = await pq.get_queue_size()
 
         # Read the queue (as a list)
-        queue = await pq.get_plan_queue()
+        queue = await pq.get_queue()
 
         # Start the first plan (This doesn't actually execute the plan. It is just for bookkeeping.)
         plan = await pq.set_next_plan_as_running()
@@ -81,7 +81,7 @@ class PlanQueueOperations:
         """
         Delete all the invalid queue entries (there could be some entries from failed unit tests).
         """
-        pq = await self._get_plan_queue()
+        pq = await self._get_queue()
 
         def verify_plan(plan):
             # The criteria may be changed.
@@ -182,7 +182,7 @@ class PlanQueueOperations:
         IndexError
             No plan is found.
         """
-        queue = await self._get_plan_queue()
+        queue = await self._get_queue()
         for n, plan in enumerate(queue):
             if plan["plan_uid"] == uid:
                 return n
@@ -238,7 +238,7 @@ class PlanQueueOperations:
         """
         Initialize ``self._uid_dict`` with UIDs extracted from the plans in the queue.
         """
-        pq = await self._get_plan_queue()
+        pq = await self._get_queue()
         self._uid_dict_clear()
         # Go over all plans in the queue
         for plan in pq:
@@ -327,26 +327,26 @@ class PlanQueueOperations:
         async with self._lock:
             return await self._get_queue_size()
 
-    async def _get_plan_queue(self):
+    async def _get_queue(self):
         """
-        See ``self.get_plan_queue()`` method.
+        See ``self.get_queue()`` method.
         """
         all_plans_json = await self._r_pool.lrange(self._name_plan_queue, 0, -1)
         return [json.loads(_) for _ in all_plans_json]
 
-    async def get_plan_queue(self):
+    async def get_queue(self):
         """
-        Get the list of all plans in the queue. The first element of the list is the first
-        plan in the queue.
+        Get the list of all items in the queue. The first element of the list is the first
+        item in the queue.
 
         Returns
         -------
         list(dict)
-            The list of plans in the queue. Each plan is represented as a dictionary.
+            The list of items in the queue. Each item is represented as a dictionary.
             Empty list is returned if the queue is empty.
         """
         async with self._lock:
-            return await self._get_plan_queue()
+            return await self._get_queue()
 
     async def _get_plan(self, *, pos=None, uid=None):
         """

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -809,7 +809,7 @@ class PlanQueueOperations:
 
     async def clear_history(self):
         """
-        Remove all entries from the plan queue. Does not touch the running plan.
+        Remove all entries from the plan queue. Does not touch the running item.
         The plan may be pushed back into the queue if it is stopped.
         """
         async with self._lock:

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -535,8 +535,8 @@ class PlanQueueOperations:
 
             if not self._is_uid_in_dict(uid):
                 raise IndexError(f"Plan with UID '{uid}' is not in the queue.")
-            running_plan = await self._get_running_item_info()
-            if running_plan and (uid == running_plan["plan_uid"]):
+            running_item = await self._get_running_item_info()
+            if running_item and (uid == running_item["plan_uid"]):
                 if before:
                     raise IndexError("Can not insert a plan in the queue before a currently running plan.")
                 else:

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -810,7 +810,7 @@ class PlanQueueOperations:
     async def clear_history(self):
         """
         Remove all entries from the plan queue. Does not touch the running item.
-        The plan may be pushed back into the queue if it is stopped.
+        The item (plan) may be pushed back into the queue if it is stopped.
         """
         async with self._lock:
             await self._clear_history()

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -452,7 +452,7 @@ class PlanQueueOperations:
                 raise IndexError(f"Plan with UID '{uid}' is not in the queue.")
             running_item = await self._get_running_item_info()
             if running_item and (uid == running_item["item_uid"]):
-                raise IndexError("Can not remove a plan which is currently running.")
+                raise IndexError("Can not remove an item which is currently running.")
             item = self._uid_dict_get_item(uid)
             await self._remove_item(item)
         elif pos == "back":

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -435,9 +435,7 @@ class PlanQueueOperations:
         """
         n_rem_items = await self._r_pool.lrem(self._name_plan_queue, 0, json.dumps(item))
         if (n_rem_items != 1) and single:
-            raise RuntimeError(
-                f"The number of removed items is {n_rem_items}. One item is expected."
-            )
+            raise RuntimeError(f"The number of removed items is {n_rem_items}. One item is expected.")
 
     async def _pop_item_from_queue(self, *, pos=None, uid=None):
         """

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -29,7 +29,7 @@ class PlanQueueOperations:
         await pq.add_item_to_queue(<plan3>)
 
         # Number of plans in the queue
-        qsize = await pq.get_plan_queue_size()
+        qsize = await pq.get_queue_size()
 
         # Read the queue (as a list)
         queue = await pq.get_plan_queue()
@@ -309,13 +309,13 @@ class PlanQueueOperations:
     # -------------------------------------------------------------
     #                       Plan Queue
 
-    async def _get_plan_queue_size(self):
+    async def _get_queue_size(self):
         """
-        See ``self.get_plan_queue_size()`` method.
+        See ``self.get_queue_size()`` method.
         """
         return await self._r_pool.llen(self._name_plan_queue)
 
-    async def get_plan_queue_size(self):
+    async def get_queue_size(self):
         """
         Get the number of plans in the queue.
 
@@ -325,7 +325,7 @@ class PlanQueueOperations:
             The number of plans in the queue.
         """
         async with self._lock:
-            return await self._get_plan_queue_size()
+            return await self._get_queue_size()
 
     async def _get_plan_queue(self):
         """
@@ -477,7 +477,7 @@ class PlanQueueOperations:
         if plan:
             self._uid_dict_remove(plan["plan_uid"])
 
-        qsize = await self._get_plan_queue_size()
+        qsize = await self._get_queue_size()
 
         return plan, qsize
 
@@ -528,7 +528,7 @@ class PlanQueueOperations:
         else:
             self._verify_plan(item)
 
-        qsize0 = await self._get_plan_queue_size()
+        qsize0 = await self._get_queue_size()
         if (before_uid is not None) or (after_uid is not None):
             uid = before_uid if before_uid is not None else after_uid
             before = uid == before_uid
@@ -626,7 +626,7 @@ class PlanQueueOperations:
         if (before_uid is not None) and (after_uid is not None):
             raise ValueError("Ambiguous parameters: source should be moved 'before' and 'after' the destination.")
 
-        queue_size = await self._get_plan_queue_size()
+        queue_size = await self._get_queue_size()
 
         # Find the source plan
         src_txt = ""
@@ -690,7 +690,7 @@ class PlanQueueOperations:
             item, qsize = await self._add_item_to_queue(**kw)
         else:
             item = item_dest
-            qsize = await self._get_plan_queue_size()
+            qsize = await self._get_queue_size()
         return item, qsize
 
     async def move_item(self, *, pos=None, uid=None, pos_dest=None, before_uid=None, after_uid=None):
@@ -731,7 +731,7 @@ class PlanQueueOperations:
         """
         See ``self.clear_plan_queue()`` method.
         """
-        while await self._get_plan_queue_size():
+        while await self._get_queue_size():
             await self._pop_plan_from_queue()
 
     async def clear_plan_queue(self):

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -35,7 +35,7 @@ class PlanQueueOperations:
         queue = await pq.get_queue()
 
         # Start the first plan (This doesn't actually execute the plan. It is just for bookkeeping.)
-        plan = await pq.set_next_plan_as_running()
+        plan = await pq.set_next_item_as_running()
         # ...
         # Here place the code for executing the plan in dictionary `plan`
 
@@ -48,7 +48,7 @@ class PlanQueueOperations:
         plan = await pq.set_processed_plan_as_completed(exit_status="completed")
 
         # We are ready to start the next plan
-        plan = await pq.set_next_plan_as_running()
+        plan = await pq.set_next_item_as_running()
 
         # Assume that we paused and then stopped the plan. Clear the running plan and
         #   push it back to the queue. Also create the respective history entry.
@@ -820,9 +820,9 @@ class PlanQueueOperations:
     # ----------------------------------------------------------------------
     #          Standard plan operations during queue execution
 
-    async def _set_next_plan_as_running(self):
+    async def _set_next_item_as_running(self):
         """
-        See ``self.set_next_plan_as_running()`` method.
+        See ``self.set_next_item_as_running()`` method.
         """
         # UID remains in the `self._uid_dict` after this operation.
         if not await self._is_plan_running():
@@ -836,20 +836,20 @@ class PlanQueueOperations:
             plan = {}
         return plan
 
-    async def set_next_plan_as_running(self):
+    async def set_next_item_as_running(self):
         """
-        Sets the next plan from the queue as a running plan. The plan is removed
-        from the queue. UID remains in ``self._uid_dict``, i.e. plan with the same UID
+        Sets the next item from the queue as 'running'. The item is removed
+        from the queue. UID remains in ``self._uid_dict``, i.e. item with the same UID
         may not be added to the queue while it is being executed.
 
         Returns
         -------
         dict
-            The plan that was set as currently running. If another plan is currently
-            running or the queue is empty, then ``{}`` is returned.
+            The item that was set as currently running. If another item is currently
+            set as 'running' or the queue is empty, then ``{}`` is returned.
         """
         async with self._lock:
-            return await self._set_next_plan_as_running()
+            return await self._set_next_item_as_running()
 
     async def _set_processed_plan_as_completed(self, exit_status):
         """

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -289,9 +289,9 @@ class PlanQueueOperations:
         async with self._lock:
             return await self._get_running_item_info()
 
-    async def _set_running_plan_info(self, plan):
+    async def _set_running_item_info(self, plan):
         """
-        Write info on the currently running plan to Redis
+        Write info on the currently running item (plan) to Redis
 
         Parameters
         ----------
@@ -304,7 +304,7 @@ class PlanQueueOperations:
         """
         Clear info on the currently running plan in Redis.
         """
-        await self._set_running_plan_info({})
+        await self._set_running_item_info({})
 
     # -------------------------------------------------------------
     #                       Plan Queue
@@ -829,7 +829,7 @@ class PlanQueueOperations:
             plan_json = await self._r_pool.lpop(self._name_plan_queue)
             if plan_json:
                 plan = json.loads(plan_json)
-                await self._set_running_plan_info(plan)
+                await self._set_running_item_info(plan)
             else:
                 plan = {}
         else:

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -85,7 +85,7 @@ class PlanQueueOperations:
 
         def verify_item(item):
             # The criteria may be changed.
-            return "plan_uid" in item
+            return "item_uid" in item
 
         items_to_remove = []
         for item in pq:
@@ -127,15 +127,15 @@ class PlanQueueOperations:
     def _verify_item(self, item):
         """
         Verify that item (plan) structure is valid enough to be put in the queue.
-        Current checks: item is a dictionary, ``plan_uid`` key is present, Plan with the UID is not in
+        Current checks: item is a dictionary, ``item_uid`` key is present, Plan with the UID is not in
         the queue or currently running.
         """
         self._verify_item_type(item)
         # Verify plan UID
-        if "plan_uid" not in item:
+        if "item_uid" not in item:
             raise ValueError("Item does not have UID.")
-        if self._is_uid_in_dict(item["plan_uid"]):
-            raise RuntimeError(f"Item with UID {item['plan_uid']} is already in the queue")
+        if self._is_uid_in_dict(item["item_uid"]):
+            raise RuntimeError(f"Item with UID {item['item_uid']} is already in the queue")
 
     @staticmethod
     def new_item_uid():
@@ -151,7 +151,7 @@ class PlanQueueOperations:
         Parameters
         ----------
         item: dict
-            Dictionary of item parameters. The dictionary may or may not have the key ``plan_uid``.
+            Dictionary of item parameters. The dictionary may or may not have the key ``item_uid``.
 
         Returns
         -------
@@ -159,7 +159,7 @@ class PlanQueueOperations:
             Plan with new UID.
         """
         self._verify_item_type(item)
-        item["plan_uid"] = self.new_item_uid()
+        item["item_uid"] = self.new_item_uid()
         return item
 
     async def _get_index_by_uid(self, *, uid):
@@ -184,7 +184,7 @@ class PlanQueueOperations:
         """
         queue = await self._get_queue()
         for n, plan in enumerate(queue):
-            if plan["plan_uid"] == uid:
+            if plan["item_uid"] == uid:
                 return n
         raise IndexError(f"No plan with UID '{uid}' was found in the list.")
 
@@ -206,7 +206,7 @@ class PlanQueueOperations:
         """
         Add UID to ``self._uid_dict``.
         """
-        uid = plan["plan_uid"]
+        uid = plan["item_uid"]
         if self._is_uid_in_dict(uid):
             raise RuntimeError(f"Trying to add plan with UID '{uid}', which is already in the queue")
         self._uid_dict.update({uid: plan})
@@ -223,7 +223,7 @@ class PlanQueueOperations:
         """
         Update a plan with UID that is already in the dictionary.
         """
-        uid = plan["plan_uid"]
+        uid = plan["item_uid"]
         if not self._is_uid_in_dict(uid):
             raise RuntimeError(f"Trying to update plan with UID '{uid}', which is not in the queue")
         self._uid_dict.update({uid: plan})
@@ -359,7 +359,7 @@ class PlanQueueOperations:
             if not self._is_uid_in_dict(uid):
                 raise IndexError(f"Item with UID '{uid}' is not in the queue.")
             running_item = await self._get_running_item_info()
-            if running_item and (uid == running_item["plan_uid"]):
+            if running_item and (uid == running_item["item_uid"]):
                 raise IndexError("The item with UID '{uid}' is currently running.")
             item = self._uid_dict_get_item(uid)
 
@@ -451,7 +451,7 @@ class PlanQueueOperations:
             if not self._is_uid_in_dict(uid):
                 raise IndexError(f"Plan with UID '{uid}' is not in the queue.")
             running_item = await self._get_running_item_info()
-            if running_item and (uid == running_item["plan_uid"]):
+            if running_item and (uid == running_item["item_uid"]):
                 raise IndexError("Can not remove a plan which is currently running.")
             item = self._uid_dict_get_item(uid)
             await self._remove_item(item)
@@ -473,7 +473,7 @@ class PlanQueueOperations:
             raise ValueError(f"Parameter 'pos' has incorrect value: pos={str(pos)} (type={type(pos)})")
 
         if item:
-            self._uid_dict_remove(item["plan_uid"])
+            self._uid_dict_remove(item["item_uid"])
 
         qsize = await self._get_queue_size()
 
@@ -521,7 +521,7 @@ class PlanQueueOperations:
 
         pos = pos if pos is not None else "back"
 
-        if "plan_uid" not in item:
+        if "item_uid" not in item:
             item = self.set_new_item_uuid(item)
         else:
             self._verify_item(item)
@@ -534,7 +534,7 @@ class PlanQueueOperations:
             if not self._is_uid_in_dict(uid):
                 raise IndexError(f"Plan with UID '{uid}' is not in the queue.")
             running_item = await self._get_running_item_info()
-            if running_item and (uid == running_item["plan_uid"]):
+            if running_item and (uid == running_item["item_uid"]):
                 if before:
                     raise IndexError("Can not insert a plan in the queue before a currently running plan.")
                 else:
@@ -640,7 +640,7 @@ class PlanQueueOperations:
         except Exception as ex:
             raise IndexError(f"Source plan ({src_txt}) was not found: {str(ex)}.")
 
-        uid_source = item_source["plan_uid"]
+        uid_source = item_source["item_uid"]
 
         # Find the destination plan
         dest_txt, before = "", True
@@ -677,7 +677,7 @@ class PlanQueueOperations:
         #   so we convert it to UID, but we can do it for the case of UID addressing as well)
         #   In case of positional addressing 'before' is True, so the source is going to be
         #   inserted in place of destination.
-        uid_dest = item_dest["plan_uid"]
+        uid_dest = item_dest["item_uid"]
 
         # If source and destination point to the same plan, then do nothing,
         #   but consider it a valid operation.
@@ -858,7 +858,7 @@ class PlanQueueOperations:
             item = await self._get_running_item_info()
             item["exit_status"] = exit_status
             await self._clear_running_item_info()
-            self._uid_dict_remove(item["plan_uid"])
+            self._uid_dict_remove(item["item_uid"])
             await self._add_to_history(item)
         else:
             item = {}

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -228,7 +228,7 @@ class PlanQueueOperations:
             raise RuntimeError(f"Trying to update plan with UID '{uid}', which is not in the queue")
         self._uid_dict.update({uid: plan})
 
-    def _uid_dict_get_plan(self, uid):
+    def _uid_dict_get_item(self, uid):
         """
         Returns a plan with the given UID.
         """
@@ -241,12 +241,12 @@ class PlanQueueOperations:
         pq = await self._get_queue()
         self._uid_dict_clear()
         # Go over all plans in the queue
-        for plan in pq:
-            self._uid_dict_add(plan)
+        for item in pq:
+            self._uid_dict_add(item)
         # If plan is currently running
-        plan = await self._get_running_item_info()
-        if plan:
-            self._uid_dict_add(plan)
+        item = await self._get_running_item_info()
+        if item:
+            self._uid_dict_add(item)
 
     # -------------------------------------------------------------
     #                   Currently Running Plan
@@ -361,7 +361,7 @@ class PlanQueueOperations:
             running_item = await self._get_running_item_info()
             if running_item and (uid == running_item["plan_uid"]):
                 raise IndexError("The item with UID '{uid}' is currently running.")
-            item = self._uid_dict_get_plan(uid)
+            item = self._uid_dict_get_item(uid)
 
         else:
             pos = pos if pos is not None else "back"
@@ -455,7 +455,7 @@ class PlanQueueOperations:
             running_item = await self._get_running_item_info()
             if running_item and (uid == running_item["plan_uid"]):
                 raise IndexError("Can not remove a plan which is currently running.")
-            item = self._uid_dict_get_plan(uid)
+            item = self._uid_dict_get_item(uid)
             await self._remove_item(item)
         elif pos == "back":
             item_json = await self._r_pool.rpop(self._name_plan_queue)
@@ -543,7 +543,7 @@ class PlanQueueOperations:
                     # Push to the plan front of the queue (after the running plan).
                     qsize = await self._r_pool.lpush(self._name_plan_queue, json.dumps(item))
             else:
-                item_to_displace = self._uid_dict_get_plan(uid)
+                item_to_displace = self._uid_dict_get_item(uid)
                 before = uid == before_uid
                 qsize = await self._r_pool.linsert(
                     self._name_plan_queue, json.dumps(item_to_displace), json.dumps(item), before=before

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -914,7 +914,7 @@ class PlanQueueOperations:
         Returns
         -------
         dict
-            The plan added to the history including ``exit_status``. If another item (plan)
+            The item (plan) added to the history including ``exit_status``. If another item (plan)
             is currently running, then ``{}`` is returned.
         """
         async with self._lock:

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -610,7 +610,7 @@ class PlanQueueOperations:
         async with self._lock:
             return await self._add_item_to_queue(item, pos=pos, before_uid=before_uid, after_uid=after_uid)
 
-    async def _move_plan(self, *, pos=None, uid=None, pos_dest=None, before_uid=None, after_uid=None):
+    async def _move_item(self, *, pos=None, uid=None, pos_dest=None, before_uid=None, after_uid=None):
         """
         See ``self.move_plan()`` method.
         """
@@ -693,29 +693,29 @@ class PlanQueueOperations:
             qsize = await self._get_plan_queue_size()
         return item, qsize
 
-    async def move_plan(self, *, pos=None, uid=None, pos_dest=None, before_uid=None, after_uid=None):
+    async def move_item(self, *, pos=None, uid=None, pos_dest=None, before_uid=None, after_uid=None):
         """
-        Move existing plan within the queue.
+        Move existing item within the queue.
 
         Parameters
         ----------
         pos: str or int
-            Position of the source plan: positive or negative integer that specifieds the index
-            of the plan in the queue or a string from the set {"back", "front"}.
+            Position of the source item: positive or negative integer that specifieds the index
+            of the item in the queue or a string from the set {"back", "front"}.
         uid: str
-            UID of the source plan. UID overrides the position
+            UID of the source item. UID overrides the position
         pos_dext: str or int
-            Index of the new position of the plan in the queue: positive or negative integer that
-            specifieds the index of the plan in the queue or a string from the set {"back", "front"}.
+            Index of the new position of the item in the queue: positive or negative integer that
+            specifieds the index of the item in the queue or a string from the set {"back", "front"}.
         before_uid: str
-            Insert the plan before the plan with the given UID.
+            Insert the item before the item with the given UID.
         after_uid: str
-            Insert the plan after the plan with the given UID.
+            Insert the item after the item with the given UID.
 
         Returns
         -------
         dict, int
-            The dictionary that contains a plan that was moved and the size of the queue.
+            The dictionary that contains a item that was moved and the size of the queue.
 
         Raises
         ------
@@ -723,7 +723,7 @@ class PlanQueueOperations:
             Error in specification of source or destination.
         """
         async with self._lock:
-            return await self._move_plan(
+            return await self._move_item(
                 pos=pos, uid=uid, pos_dest=pos_dest, before_uid=before_uid, after_uid=after_uid
             )
 

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -727,20 +727,20 @@ class PlanQueueOperations:
                 pos=pos, uid=uid, pos_dest=pos_dest, before_uid=before_uid, after_uid=after_uid
             )
 
-    async def _clear_plan_queue(self):
+    async def _clear_queue(self):
         """
-        See ``self.clear_plan_queue()`` method.
+        See ``self.clear_queue()`` method.
         """
         while await self._get_queue_size():
             await self._pop_plan_from_queue()
 
-    async def clear_plan_queue(self):
+    async def clear_queue(self):
         """
-        Remove all entries from the plan queue. Does not touch the running plan.
-        The plan may be pushed back into the queue if it is stopped.
+        Remove all entries from the plan queue. Does not touch the running item (plan).
+        The item may be pushed back into the queue if it is stopped.
         """
         async with self._lock:
-            await self._clear_plan_queue()
+            await self._clear_queue()
 
     # -----------------------------------------------------------------------
     #                          Plan History

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -750,7 +750,7 @@ class PlanQueueOperations:
         Parameters
         ----------
         item: dict
-            Plan represented as a dictionary of parameters. No verifications are performed
+            Item (plan) represented as a dictionary of parameters. No verifications are performed
             on the plan. The function is not intended to be used outside of this class.
 
         Returns

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -38,7 +38,7 @@ def get_supported_commands():
         "queue_get": "queue_get",
         "queue_item_add": "queue_item_add",
         "queue_item_get": "queue_item_get",
-        "queue_plan_remove": "queue_plan_remove",
+        "queue_item_remove": "queue_item_remove",
         "queue_plan_move": "queue_plan_move",
         "queue_clear": "queue_clear",
         "queue_start": "queue_start",
@@ -96,7 +96,7 @@ def create_msg(command, params=None):
             prms["user"] = "qserver-cli"
             prms["user_group"] = "root"
 
-        elif command in ("queue_plan_remove", "queue_item_get"):
+        elif command in ("queue_item_remove", "queue_item_get"):
             if len(params) == 0:
                 prms = {}
             elif len(params) == 1:

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -37,7 +37,7 @@ def get_supported_commands():
         "environment_destroy": "environment_destroy",
         "queue_get": "queue_get",
         "queue_item_add": "queue_item_add",
-        "queue_plan_get": "queue_plan_get",
+        "queue_item_get": "queue_item_get",
         "queue_plan_remove": "queue_plan_remove",
         "queue_plan_move": "queue_plan_move",
         "queue_clear": "queue_clear",
@@ -96,7 +96,7 @@ def create_msg(command, params=None):
             prms["user"] = "qserver-cli"
             prms["user_group"] = "root"
 
-        elif command in ("queue_plan_remove", "queue_plan_get"):
+        elif command in ("queue_plan_remove", "queue_item_get"):
             if len(params) == 0:
                 prms = {}
             elif len(params) == 1:

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -36,7 +36,7 @@ def get_supported_commands():
         "environment_close": "environment_close",
         "environment_destroy": "environment_destroy",
         "queue_get": "queue_get",
-        "queue_plan_add": "queue_plan_add",
+        "queue_item_add": "queue_item_add",
         "queue_plan_get": "queue_plan_get",
         "queue_plan_remove": "queue_plan_remove",
         "queue_plan_move": "queue_plan_move",
@@ -72,7 +72,7 @@ def create_msg(command, params=None):
     try:
         command = command_dict[command]
         # Present value in the proper format. This will change as the format is changed.
-        if command == "queue_plan_add":
+        if command == "queue_item_add":
             if (len(params) == 1) and isinstance(params[0], dict):
                 # Arguments: <plan>
                 prms = {"plan": params[0]}  # Value is dict

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -39,7 +39,7 @@ def get_supported_commands():
         "queue_item_add": "queue_item_add",
         "queue_item_get": "queue_item_get",
         "queue_item_remove": "queue_item_remove",
-        "queue_plan_move": "queue_plan_move",
+        "queue_item_move": "queue_item_move",
         "queue_clear": "queue_clear",
         "queue_start": "queue_start",
         "queue_stop": "queue_stop",
@@ -104,7 +104,7 @@ def create_msg(command, params=None):
             else:
                 raise ValueError(f"Invalid number of method arguments: '{pprint.pformat(params)}'")
 
-        elif command == "queue_plan_move":
+        elif command == "queue_item_move":
             if len(params) == 2:
                 # Argument order: [<pos_source>, <uid_source>] <pos_dest>
                 prms = _pos_or_uid(params[0])

--- a/bluesky_queueserver/manager/tests/_common.py
+++ b/bluesky_queueserver/manager/tests/_common.py
@@ -108,10 +108,10 @@ def get_queue():
 
 def get_reduced_state_info():
     msg = get_queue_state()
-    plans_in_queue = msg["plans_in_queue"]
+    items_in_queue = msg["items_in_queue"]
     queue_is_running = msg["manager_state"] == "executing_queue"
-    plans_in_history = msg["plans_in_history"]
-    return plans_in_queue, queue_is_running, plans_in_history
+    items_in_history = msg["items_in_history"]
+    return items_in_queue, queue_is_running, items_in_history
 
 
 def condition_manager_idle(msg):
@@ -131,9 +131,9 @@ def condition_environment_closed(msg):
 
 
 def condition_queue_processing_finished(msg):
-    plans_in_queue = msg["plans_in_queue"]
+    items_in_queue = msg["items_in_queue"]
     queue_is_running = msg["manager_state"] == "executing_queue"
-    return (plans_in_queue == 0) and not queue_is_running
+    return (items_in_queue == 0) and not queue_is_running
 
 
 def wait_for_condition(time, condition):

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -145,14 +145,14 @@ def test_new_item_uid(pq):
     {"plan_uid": "some_uid", "name": "a"},
 ])
 # fmt: on
-def test_set_new_plan_uuid(pq, plan):
+def test_set_new_item_uuid(pq, plan):
     """
-    Basic test for the method ``set_new_plan_uuid()``.
+    Basic test for the method ``set_new_item_uuid()``.
     """
     uid = plan.get("plan_uid", None)
 
     # The function is supposed to create or replace UID
-    new_plan = pq.set_new_plan_uuid(plan)
+    new_plan = pq.set_new_item_uuid(plan)
 
     assert "plan_uid" in new_plan
     assert isinstance(new_plan["plan_uid"], str)
@@ -320,9 +320,9 @@ def test_remove_item(pq):
     ({"uid": "nonexistent"}, None),
 ])
 # fmt: on
-def test_get_plan_1(pq, params, name):
+def test_get_item_1(pq, params, name):
     """
-    Basic test for the function ``PlanQueueOperations.get_plan()``
+    Basic test for the function ``PlanQueueOperations.get_item()``
     """
 
     async def testing():
@@ -333,19 +333,19 @@ def test_get_plan_1(pq, params, name):
         assert await pq.get_queue_size() == 3
 
         if name is not None:
-            plan = await pq.get_plan(**params)
+            plan = await pq.get_item(**params)
             assert plan["name"] == name
         else:
             msg = "Index .* is out of range" if "pos" in params else "is not in the queue"
             with pytest.raises(IndexError, match=msg):
-                await pq.get_plan(**params)
+                await pq.get_item(**params)
 
     asyncio.run(testing())
 
 
-def test_get_plan_2_fail(pq):
+def test_get_item_2_fail(pq):
     """
-    Basic test for the function ``PlanQueueOperations.get_plan()``.
+    Basic test for the function ``PlanQueueOperations.get_item()``.
     Attempt to retrieve a running plan.
     """
 
@@ -360,11 +360,11 @@ def test_get_plan_2_fail(pq):
         assert await pq.get_queue_size() == 2
 
         with pytest.raises(IndexError, match="is currently running"):
-            await pq.get_plan(uid="one")
+            await pq.get_item(uid="one")
 
         # Ambiguous parameters (position and UID is passed)
         with pytest.raises(ValueError, match="Ambiguous parameters"):
-            await pq.get_plan(pos=5, uid="abc")
+            await pq.get_item(pos=5, uid="abc")
 
     asyncio.run(testing())
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -33,7 +33,7 @@ def test_running_plan_info(pq):
         assert await pq.is_item_running() is False
 
         some_plan = {"some_key": "some_value"}
-        await pq._set_running_plan_info(some_plan)
+        await pq._set_running_item_info(some_plan)
         assert await pq.get_running_item_info() == some_plan
 
         assert await pq.is_item_running() is True
@@ -42,7 +42,7 @@ def test_running_plan_info(pq):
         assert await pq.get_running_item_info() == {}
         assert await pq.is_item_running() is False
 
-        await pq._set_running_plan_info(some_plan)
+        await pq._set_running_item_info(some_plan)
         await pq.delete_pool_entries()
         assert await pq.get_running_item_info() == {}
         assert await pq.is_item_running() is False
@@ -66,7 +66,7 @@ def test_queue_clean(pq, plan_running, plans, result_running, result_plans):
     """
 
     async def testing():
-        await pq._set_running_plan_info(plan_running)
+        await pq._set_running_item_info(plan_running)
         for plan in plans:
             await pq._r_pool.rpush(pq._name_plan_queue, json.dumps(plan))
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -22,30 +22,30 @@ def pq():
 def test_running_plan_info(pq):
     """
     Basic test for the following methods:
-    `PlanQueueOperations.is_plan_running()`
-    `PlanQueueOperations.get_running_plan_info()`
+    `PlanQueueOperations.is_item_running()`
+    `PlanQueueOperations.get_running_item_info()`
     `PlanQueueOperations.delete_pool_entries()`
     """
 
     async def testing():
 
-        assert await pq.get_running_plan_info() == {}
-        assert await pq.is_plan_running() is False
+        assert await pq.get_running_item_info() == {}
+        assert await pq.is_item_running() is False
 
         some_plan = {"some_key": "some_value"}
         await pq._set_running_plan_info(some_plan)
-        assert await pq.get_running_plan_info() == some_plan
+        assert await pq.get_running_item_info() == some_plan
 
-        assert await pq.is_plan_running() is True
+        assert await pq.is_item_running() is True
 
         await pq._clear_running_plan_info()
-        assert await pq.get_running_plan_info() == {}
-        assert await pq.is_plan_running() is False
+        assert await pq.get_running_item_info() == {}
+        assert await pq.is_item_running() is False
 
         await pq._set_running_plan_info(some_plan)
         await pq.delete_pool_entries()
-        assert await pq.get_running_plan_info() == {}
-        assert await pq.is_plan_running() is False
+        assert await pq.get_running_item_info() == {}
+        assert await pq.is_item_running() is False
 
     asyncio.run(testing())
 
@@ -70,12 +70,12 @@ def test_queue_clean(pq, plan_running, plans, result_running, result_plans):
         for plan in plans:
             await pq._r_pool.rpush(pq._name_plan_queue, json.dumps(plan))
 
-        assert await pq.get_running_plan_info() == plan_running
+        assert await pq.get_running_item_info() == plan_running
         assert await pq.get_queue() == plans
 
         await pq._queue_clean()
 
-        assert await pq.get_running_plan_info() == result_running
+        assert await pq.get_running_item_info() == result_running
         assert await pq.get_queue() == result_plans
 
     asyncio.run(testing())
@@ -120,7 +120,7 @@ def test_verify_plan(pq, plan, result, errmsg):
         await pq.set_next_item_as_running()
 
         # Verify that setup is correct
-        assert await pq.is_plan_running() is True
+        assert await pq.is_item_running() is True
         assert await pq.get_queue_size() == 1
 
     asyncio.run(set_plans())
@@ -724,10 +724,10 @@ def test_set_next_item_as_running(pq):
     async def testing():
         # Apply to empty queue
         assert await pq.get_queue_size() == 0
-        assert await pq.is_plan_running() is False
+        assert await pq.is_item_running() is False
         assert await pq.set_next_item_as_running() == {}
         assert await pq.get_queue_size() == 0
-        assert await pq.is_plan_running() is False
+        assert await pq.is_item_running() is False
 
         # Apply to a queue with several plans
         await pq.add_item_to_queue({"name": "a"})

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -196,9 +196,9 @@ def test_uid_dict_1(pq):
     assert pq._is_uid_in_dict(plan_b["plan_uid"]) is True
     assert pq._is_uid_in_dict(plan_c["plan_uid"]) is False
 
-    assert pq._uid_dict_get_plan(plan_b["plan_uid"]) == plan_b
+    assert pq._uid_dict_get_item(plan_b["plan_uid"]) == plan_b
     pq._uid_dict_update(plan_b_updated)
-    assert pq._uid_dict_get_plan(plan_b["plan_uid"]) == plan_b_updated
+    assert pq._uid_dict_get_item(plan_b["plan_uid"]) == plan_b_updated
 
     pq._uid_dict_remove(plan_a["plan_uid"])
     assert pq._is_uid_in_dict(plan_a["plan_uid"]) is False

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -115,7 +115,7 @@ def test_verify_plan(pq, plan, result, errmsg):
     async def set_plans():
         # Add plan to queue
         for plan in existing_plans:
-            await pq.add_plan_to_queue(plan)
+            await pq.add_item_to_queue(plan)
         # Set one plan as currently running
         await pq.set_next_plan_as_running()
 
@@ -171,7 +171,7 @@ def test_get_index_by_uid(pq):
 
     async def testing():
         for plan in plans:
-            await pq.add_plan_to_queue(plan)
+            await pq.add_item_to_queue(plan)
 
         assert await pq._get_index_by_uid("b") == 1
 
@@ -215,9 +215,9 @@ def test_uid_dict_2_initialize(pq):
     """
 
     async def testing():
-        await pq.add_plan_to_queue({"name": "a"})
-        await pq.add_plan_to_queue({"name": "b"})
-        await pq.add_plan_to_queue({"name": "c"})
+        await pq.add_item_to_queue({"name": "a"})
+        await pq.add_item_to_queue({"name": "b"})
+        await pq.add_item_to_queue({"name": "c"})
         plans = await pq.get_plan_queue()
         uid_dict = {_["plan_uid"]: _ for _ in plans}
 
@@ -265,7 +265,7 @@ def test_remove_plan(pq):
     async def testing():
         plan_list = [{"name": "a"}, {"name": "b"}, {"name": "c"}]
         for plan in plan_list:
-            await pq.add_plan_to_queue(plan)
+            await pq.add_item_to_queue(plan)
 
         plans = await pq.get_plan_queue()
         plan_to_remove = [_ for _ in plans if _["name"] == "b"][0]
@@ -327,9 +327,9 @@ def test_get_plan_1(pq, params, name):
 
     async def testing():
 
-        await pq.add_plan_to_queue({"plan_uid": "one", "name": "a"})
-        await pq.add_plan_to_queue({"plan_uid": "two", "name": "b"})
-        await pq.add_plan_to_queue({"plan_uid": "three", "name": "c"})
+        await pq.add_item_to_queue({"plan_uid": "one", "name": "a"})
+        await pq.add_item_to_queue({"plan_uid": "two", "name": "b"})
+        await pq.add_item_to_queue({"plan_uid": "three", "name": "c"})
         assert await pq.get_plan_queue_size() == 3
 
         if name is not None:
@@ -351,9 +351,9 @@ def test_get_plan_2_fail(pq):
 
     async def testing():
 
-        await pq.add_plan_to_queue({"plan_uid": "one", "name": "a"})
-        await pq.add_plan_to_queue({"plan_uid": "two", "name": "b"})
-        await pq.add_plan_to_queue({"plan_uid": "three", "name": "c"})
+        await pq.add_item_to_queue({"plan_uid": "one", "name": "a"})
+        await pq.add_item_to_queue({"plan_uid": "two", "name": "b"})
+        await pq.add_item_to_queue({"plan_uid": "three", "name": "c"})
         assert await pq.get_plan_queue_size() == 3
 
         await pq.set_next_plan_as_running()
@@ -369,13 +369,13 @@ def test_get_plan_2_fail(pq):
     asyncio.run(testing())
 
 
-def test_add_plan_to_queue_1(pq):
+def test_add_item_to_queue_1(pq):
     """
-    Basic test for the function ``PlanQueueOperations.add_plan_to_queue()``
+    Basic test for the function ``PlanQueueOperations.add_item_to_queue()``
     """
 
     async def add_plan(plan, n, **kwargs):
-        plan_added, qsize = await pq.add_plan_to_queue(plan, **kwargs)
+        plan_added, qsize = await pq.add_item_to_queue(plan, **kwargs)
         assert plan_added["name"] == plan["name"], f"plan: {plan}"
         assert qsize == n, f"plan: {plan}"
 
@@ -404,13 +404,13 @@ def test_add_plan_to_queue_1(pq):
     asyncio.run(testing())
 
 
-def test_add_plan_to_queue_2(pq):
+def test_add_item_to_queue_2(pq):
     """
-    Basic test for the function ``PlanQueueOperations.add_plan_to_queue()``
+    Basic test for the function ``PlanQueueOperations.add_item_to_queue()``
     """
 
     async def add_plan(plan, n, **kwargs):
-        plan_added, qsize = await pq.add_plan_to_queue(plan, **kwargs)
+        plan_added, qsize = await pq.add_item_to_queue(plan, **kwargs)
         assert plan_added["name"] == plan["name"], f"plan: {plan}"
         assert qsize == n, f"plan: {plan}"
 
@@ -448,32 +448,32 @@ def test_add_plan_to_queue_2(pq):
     asyncio.run(testing())
 
 
-def test_add_plan_to_queue_3_fail(pq):
+def test_add_item_to_queue_3_fail(pq):
     """
-    Failing tests for the function ``PlanQueueOperations.add_plan_to_queue()``
+    Failing tests for the function ``PlanQueueOperations.add_item_to_queue()``
     """
 
     async def testing():
 
         with pytest.raises(ValueError, match="Parameter 'pos' has incorrect value"):
-            await pq.add_plan_to_queue({"name": "a"}, pos="something")
+            await pq.add_item_to_queue({"name": "a"}, pos="something")
 
         with pytest.raises(TypeError, match=errmsg_wrong_plan_type):
-            await pq.add_plan_to_queue("plan_is_not_string")
+            await pq.add_item_to_queue("plan_is_not_string")
 
         # Duplicate plan UID
         plan = {"plan_uid": "abc", "name": "a"}
-        await pq.add_plan_to_queue(plan)
+        await pq.add_item_to_queue(plan)
         with pytest.raises(RuntimeError, match="Plan with UID .+ is already in the queue"):
-            await pq.add_plan_to_queue(plan)
+            await pq.add_item_to_queue(plan)
 
         # Ambiguous parameters (position and UID is passed)
         with pytest.raises(ValueError, match="Ambiguous parameters"):
-            await pq.add_plan_to_queue({"name": "abc"}, pos=5, before_uid="abc")
+            await pq.add_item_to_queue({"name": "abc"}, pos=5, before_uid="abc")
 
         # Ambiguous parameters ('before_uid' and 'after_uid' is specified)
         with pytest.raises(ValueError, match="Ambiguous parameters"):
-            await pq.add_plan_to_queue({"name": "abc"}, before_uid="abc", after_uid="abc")
+            await pq.add_item_to_queue({"name": "abc"}, before_uid="abc", after_uid="abc")
 
     asyncio.run(testing())
 
@@ -534,7 +534,7 @@ def test_move_plan_1(pq, params, src, order, success, msg):
         ]
 
         for plan in plans:
-            await pq.add_plan_to_queue(plan)
+            await pq.add_item_to_queue(plan)
 
         assert await pq.get_plan_queue_size() == len(plans)
 
@@ -576,9 +576,9 @@ def test_pop_plan_from_queue_1(pq, pos, name):
 
     async def testing():
 
-        await pq.add_plan_to_queue({"name": "a"})
-        await pq.add_plan_to_queue({"name": "b"})
-        await pq.add_plan_to_queue({"name": "c"})
+        await pq.add_item_to_queue({"name": "a"})
+        await pq.add_item_to_queue({"name": "b"})
+        await pq.add_item_to_queue({"name": "c"})
         assert await pq.get_plan_queue_size() == 3
 
         if name is not None:
@@ -587,7 +587,7 @@ def test_pop_plan_from_queue_1(pq, pos, name):
             assert qsize == 2
             assert await pq.get_plan_queue_size() == 2
             # Push the plan back to the queue (proves that UID is removed from '_uid_dict')
-            await pq.add_plan_to_queue(plan)
+            await pq.add_item_to_queue(plan)
             assert await pq.get_plan_queue_size() == 3
         else:
             with pytest.raises(IndexError, match="Index .* is out of range"):
@@ -617,9 +617,9 @@ def test_pop_plan_from_queue_3(pq):
     """
 
     async def testing():
-        await pq.add_plan_to_queue({"name": "a"})
-        await pq.add_plan_to_queue({"name": "b"})
-        await pq.add_plan_to_queue({"name": "c"})
+        await pq.add_item_to_queue({"name": "a"})
+        await pq.add_item_to_queue({"name": "b"})
+        await pq.add_item_to_queue({"name": "c"})
         assert await pq.get_plan_queue_size() == 3
 
         plans = await pq.get_plan_queue()
@@ -669,9 +669,9 @@ def test_clear_plan_queue(pq):
     """
 
     async def testing():
-        await pq.add_plan_to_queue({"name": "a"})
-        await pq.add_plan_to_queue({"name": "b"})
-        await pq.add_plan_to_queue({"name": "c"})
+        await pq.add_item_to_queue({"name": "a"})
+        await pq.add_item_to_queue({"name": "b"})
+        await pq.add_item_to_queue({"name": "c"})
         # Set one of 3 plans as running (removes it from the queue)
         await pq.set_next_plan_as_running()
 
@@ -730,9 +730,9 @@ def test_set_next_plan_as_running(pq):
         assert await pq.is_plan_running() is False
 
         # Apply to a queue with several plans
-        await pq.add_plan_to_queue({"name": "a"})
-        await pq.add_plan_to_queue({"name": "b"})
-        await pq.add_plan_to_queue({"name": "c"})
+        await pq.add_item_to_queue({"name": "a"})
+        await pq.add_item_to_queue({"name": "b"})
+        await pq.add_item_to_queue({"name": "c"})
         # Set one of 3 plans as running (removes it from the queue)
         assert await pq.set_next_plan_as_running() != {}
 
@@ -765,7 +765,7 @@ def test_set_processed_plan_as_completed(pq):
 
     async def testing():
         for plan in plans:
-            await pq.add_plan_to_queue(plan)
+            await pq.add_item_to_queue(plan)
 
         # No plan is running
         plan = await pq.set_processed_plan_as_completed(exit_status="completed")
@@ -817,7 +817,7 @@ def test_set_processed_plan_as_stopped(pq):
 
     async def testing():
         for plan in plans:
-            await pq.add_plan_to_queue(plan)
+            await pq.add_item_to_queue(plan)
 
         # No plan is running
         plan = await pq.set_processed_plan_as_stopped(exit_status="stopped")

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -5,7 +5,7 @@ import copy
 from bluesky_queueserver.manager.plan_queue_ops import PlanQueueOperations
 
 
-errmsg_wrong_plan_type = "Parameter 'plan' should be a dictionary"
+errmsg_wrong_plan_type = "Parameter 'item' should be a dictionary"
 
 
 @pytest.fixture
@@ -38,7 +38,7 @@ def test_running_plan_info(pq):
 
         assert await pq.is_item_running() is True
 
-        await pq._clear_running_plan_info()
+        await pq._clear_running_item_info()
         assert await pq.get_running_item_info() == {}
         assert await pq.is_item_running() is False
 
@@ -88,26 +88,26 @@ def test_queue_clean(pq, plan_running, plans, result_running, result_plans):
                           (50, False),
                           ("abc", False)])
 # fmt: on
-def test_verify_plan_type(pq, plan, result):
+def test_verify_item_type(pq, plan, result):
     if result:
-        pq._verify_plan_type(plan)
+        pq._verify_item_type(plan)
     else:
         with pytest.raises(TypeError, match=errmsg_wrong_plan_type):
-            pq._verify_plan_type(plan)
+            pq._verify_item_type(plan)
 
 
 # fmt: off
 @pytest.mark.parametrize(
     "plan, result, errmsg",
-    [({"a": 10}, False, "Plan does not have UID"),
+    [({"a": 10}, False, "Item does not have UID"),
      ([10, 20], False, errmsg_wrong_plan_type),
      ({"plan_uid": "one"}, True, ""),
-     ({"plan_uid": "two"}, False, "Plan with UID .+ is already in the queue"),
-     ({"plan_uid": "three"}, False, "Plan with UID .+ is already in the queue")])
+     ({"plan_uid": "two"}, False, "Item with UID .+ is already in the queue"),
+     ({"plan_uid": "three"}, False, "Item with UID .+ is already in the queue")])
 # fmt: on
-def test_verify_plan(pq, plan, result, errmsg):
+def test_verify_item(pq, plan, result, errmsg):
     """
-    Tests for method ``_verify_plan()``.
+    Tests for method ``_verify_item()``.
     """
     # Set two existiing plans and then set one of them as running
     existing_plans = [{"plan_uid": "two"}, {"plan_uid": "three"}]
@@ -126,17 +126,17 @@ def test_verify_plan(pq, plan, result, errmsg):
     asyncio.run(set_plans())
 
     if result:
-        pq._verify_plan(plan)
+        pq._verify_item(plan)
     else:
         with pytest.raises(Exception, match=errmsg):
-            pq._verify_plan(plan)
+            pq._verify_item(plan)
 
 
-def test_new_plan_uid(pq):
+def test_new_item_uid(pq):
     """
-    Smoke test for the method ``_new_plan_uid()``.
+    Smoke test for the method ``new_item_uid()``.
     """
-    assert isinstance(pq.new_plan_uid(), str)
+    assert isinstance(pq.new_item_uid(), str)
 
 
 # fmt: off
@@ -464,7 +464,7 @@ def test_add_item_to_queue_3_fail(pq):
         # Duplicate plan UID
         plan = {"plan_uid": "abc", "name": "a"}
         await pq.add_item_to_queue(plan)
-        with pytest.raises(RuntimeError, match="Plan with UID .+ is already in the queue"):
+        with pytest.raises(RuntimeError, match="Item with UID .+ is already in the queue"):
             await pq.add_item_to_queue(plan)
 
         # Ambiguous parameters (position and UID is passed)

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -52,12 +52,12 @@ def test_running_plan_info(pq):
 
 # fmt: off
 @pytest.mark.parametrize("plan_running, plans, result_running, result_plans", [
-    ({"testing": 1}, [{"testing": 2}, {"plan_uid": "ab", "name": "nm"}, {"testing": 2}],
-     {}, [{"plan_uid": "ab", "name": "nm"}]),
-    ({"testing": 1}, [{"testing": 2}, {"plan_uid": "ab", "name": "nm"}, {"testing": 3}],
-     {}, [{"plan_uid": "ab", "name": "nm"}]),
-    ({"plan_uid": "a"}, [{"plan_uid": "a1"}, {"plan_uid": "a2"}, {"plan_uid": "a3"}],
-     {"plan_uid": "a"}, [{"plan_uid": "a1"}, {"plan_uid": "a2"}, {"plan_uid": "a3"}]),
+    ({"testing": 1}, [{"testing": 2}, {"item_uid": "ab", "name": "nm"}, {"testing": 2}],
+     {}, [{"item_uid": "ab", "name": "nm"}]),
+    ({"testing": 1}, [{"testing": 2}, {"item_uid": "ab", "name": "nm"}, {"testing": 3}],
+     {}, [{"item_uid": "ab", "name": "nm"}]),
+    ({"item_uid": "a"}, [{"item_uid": "a1"}, {"item_uid": "a2"}, {"item_uid": "a3"}],
+     {"item_uid": "a"}, [{"item_uid": "a1"}, {"item_uid": "a2"}, {"item_uid": "a3"}]),
 ])
 # fmt: on
 def test_queue_clean(pq, plan_running, plans, result_running, result_plans):
@@ -101,16 +101,16 @@ def test_verify_item_type(pq, plan, result):
     "plan, result, errmsg",
     [({"a": 10}, False, "Item does not have UID"),
      ([10, 20], False, errmsg_wrong_plan_type),
-     ({"plan_uid": "one"}, True, ""),
-     ({"plan_uid": "two"}, False, "Item with UID .+ is already in the queue"),
-     ({"plan_uid": "three"}, False, "Item with UID .+ is already in the queue")])
+     ({"item_uid": "one"}, True, ""),
+     ({"item_uid": "two"}, False, "Item with UID .+ is already in the queue"),
+     ({"item_uid": "three"}, False, "Item with UID .+ is already in the queue")])
 # fmt: on
 def test_verify_item(pq, plan, result, errmsg):
     """
     Tests for method ``_verify_item()``.
     """
     # Set two existiing plans and then set one of them as running
-    existing_plans = [{"plan_uid": "two"}, {"plan_uid": "three"}]
+    existing_plans = [{"item_uid": "two"}, {"item_uid": "three"}]
 
     async def set_plans():
         # Add plan to queue
@@ -142,21 +142,21 @@ def test_new_item_uid(pq):
 # fmt: off
 @pytest.mark.parametrize("plan", [
     {"name": "a"},
-    {"plan_uid": "some_uid", "name": "a"},
+    {"item_uid": "some_uid", "name": "a"},
 ])
 # fmt: on
 def test_set_new_item_uuid(pq, plan):
     """
     Basic test for the method ``set_new_item_uuid()``.
     """
-    uid = plan.get("plan_uid", None)
+    uid = plan.get("item_uid", None)
 
     # The function is supposed to create or replace UID
     new_plan = pq.set_new_item_uuid(plan)
 
-    assert "plan_uid" in new_plan
-    assert isinstance(new_plan["plan_uid"], str)
-    assert new_plan["plan_uid"] != uid
+    assert "item_uid" in new_plan
+    assert isinstance(new_plan["item_uid"], str)
+    assert new_plan["item_uid"] != uid
 
 
 def test_get_index_by_uid(pq):
@@ -164,9 +164,9 @@ def test_get_index_by_uid(pq):
     Test for ``_get_index_by_uid()``
     """
     plans = [
-        {"plan_uid": "a", "name": "name_a"},
-        {"plan_uid": "b", "name": "name_b"},
-        {"plan_uid": "c", "name": "name_c"},
+        {"item_uid": "a", "name": "name_a"},
+        {"item_uid": "b", "name": "name_b"},
+        {"item_uid": "c", "name": "name_c"},
     ]
 
     async def testing():
@@ -183,30 +183,30 @@ def test_uid_dict_1(pq):
     """
     Basic test for functions associated with `_uid_dict`
     """
-    plan_a = {"plan_uid": "a", "name": "name_a"}
-    plan_b = {"plan_uid": "b", "name": "name_b"}
-    plan_c = {"plan_uid": "c", "name": "name_c"}
+    plan_a = {"item_uid": "a", "name": "name_a"}
+    plan_b = {"item_uid": "b", "name": "name_b"}
+    plan_c = {"item_uid": "c", "name": "name_c"}
 
-    plan_b_updated = {"plan_uid": "b", "name": "name_b_updated"}
+    plan_b_updated = {"item_uid": "b", "name": "name_b_updated"}
 
     pq._uid_dict_add(plan_a)
     pq._uid_dict_add(plan_b)
 
-    assert pq._is_uid_in_dict(plan_a["plan_uid"]) is True
-    assert pq._is_uid_in_dict(plan_b["plan_uid"]) is True
-    assert pq._is_uid_in_dict(plan_c["plan_uid"]) is False
+    assert pq._is_uid_in_dict(plan_a["item_uid"]) is True
+    assert pq._is_uid_in_dict(plan_b["item_uid"]) is True
+    assert pq._is_uid_in_dict(plan_c["item_uid"]) is False
 
-    assert pq._uid_dict_get_item(plan_b["plan_uid"]) == plan_b
+    assert pq._uid_dict_get_item(plan_b["item_uid"]) == plan_b
     pq._uid_dict_update(plan_b_updated)
-    assert pq._uid_dict_get_item(plan_b["plan_uid"]) == plan_b_updated
+    assert pq._uid_dict_get_item(plan_b["item_uid"]) == plan_b_updated
 
-    pq._uid_dict_remove(plan_a["plan_uid"])
-    assert pq._is_uid_in_dict(plan_a["plan_uid"]) is False
-    assert pq._is_uid_in_dict(plan_b["plan_uid"]) is True
+    pq._uid_dict_remove(plan_a["item_uid"])
+    assert pq._is_uid_in_dict(plan_a["item_uid"]) is False
+    assert pq._is_uid_in_dict(plan_b["item_uid"]) is True
 
     pq._uid_dict_clear()
-    assert pq._is_uid_in_dict(plan_a["plan_uid"]) is False
-    assert pq._is_uid_in_dict(plan_b["plan_uid"]) is False
+    assert pq._is_uid_in_dict(plan_a["item_uid"]) is False
+    assert pq._is_uid_in_dict(plan_b["item_uid"]) is False
 
 
 def test_uid_dict_2_initialize(pq):
@@ -219,7 +219,7 @@ def test_uid_dict_2_initialize(pq):
         await pq.add_item_to_queue({"name": "b"})
         await pq.add_item_to_queue({"name": "c"})
         plans = await pq.get_queue()
-        uid_dict = {_["plan_uid"]: _ for _ in plans}
+        uid_dict = {_["item_uid"]: _ for _ in plans}
 
         await pq._uid_dict_initialize()
         assert pq._uid_dict == uid_dict
@@ -231,27 +231,27 @@ def test_uid_dict_3_failing(pq):
     """
     Failing cases for functions associated with `_uid_dict`
     """
-    plan_a = {"plan_uid": "a", "name": "name_a"}
-    plan_b = {"plan_uid": "b", "name": "name_b"}
-    plan_c = {"plan_uid": "c", "name": "name_c"}
+    plan_a = {"item_uid": "a", "name": "name_a"}
+    plan_b = {"item_uid": "b", "name": "name_b"}
+    plan_c = {"item_uid": "c", "name": "name_c"}
 
     pq._uid_dict_add(plan_a)
     pq._uid_dict_add(plan_b)
 
     # Add plan with UID that already exists
-    with pytest.raises(RuntimeError, match=f"'{plan_a['plan_uid']}', which is already in the queue"):
+    with pytest.raises(RuntimeError, match=f"'{plan_a['item_uid']}', which is already in the queue"):
         pq._uid_dict_add(plan_a)
 
     assert len(pq._uid_dict) == 2
 
     # Remove plan with UID does not exist exists
-    with pytest.raises(RuntimeError, match=f"'{plan_c['plan_uid']}', which is not in the queue"):
-        pq._uid_dict_remove(plan_c["plan_uid"])
+    with pytest.raises(RuntimeError, match=f"'{plan_c['item_uid']}', which is not in the queue"):
+        pq._uid_dict_remove(plan_c["item_uid"])
 
     assert len(pq._uid_dict) == 2
 
     # Update plan with UID does not exist exists
-    with pytest.raises(RuntimeError, match=f"'{plan_c['plan_uid']}', which is not in the queue"):
+    with pytest.raises(RuntimeError, match=f"'{plan_c['item_uid']}', which is not in the queue"):
         pq._uid_dict_update(plan_c)
 
     assert len(pq._uid_dict) == 2
@@ -327,9 +327,9 @@ def test_get_item_1(pq, params, name):
 
     async def testing():
 
-        await pq.add_item_to_queue({"plan_uid": "one", "name": "a"})
-        await pq.add_item_to_queue({"plan_uid": "two", "name": "b"})
-        await pq.add_item_to_queue({"plan_uid": "three", "name": "c"})
+        await pq.add_item_to_queue({"item_uid": "one", "name": "a"})
+        await pq.add_item_to_queue({"item_uid": "two", "name": "b"})
+        await pq.add_item_to_queue({"item_uid": "three", "name": "c"})
         assert await pq.get_queue_size() == 3
 
         if name is not None:
@@ -351,9 +351,9 @@ def test_get_item_2_fail(pq):
 
     async def testing():
 
-        await pq.add_item_to_queue({"plan_uid": "one", "name": "a"})
-        await pq.add_item_to_queue({"plan_uid": "two", "name": "b"})
-        await pq.add_item_to_queue({"plan_uid": "three", "name": "c"})
+        await pq.add_item_to_queue({"item_uid": "one", "name": "a"})
+        await pq.add_item_to_queue({"item_uid": "two", "name": "b"})
+        await pq.add_item_to_queue({"item_uid": "three", "name": "c"})
         assert await pq.get_queue_size() == 3
 
         await pq.set_next_item_as_running()
@@ -420,7 +420,7 @@ def test_add_item_to_queue_2(pq):
         await add_plan({"name": "c"}, 3, pos="back")
 
         plan_queue = await pq.get_queue()
-        displaced_uid = plan_queue[1]["plan_uid"]
+        displaced_uid = plan_queue[1]["item_uid"]
 
         await add_plan({"name": "d"}, 4, before_uid=displaced_uid)
         await add_plan({"name": "e"}, 5, after_uid=displaced_uid)
@@ -428,7 +428,7 @@ def test_add_item_to_queue_2(pq):
         # This reduces the number of elements in the queue by one
         await pq.set_next_item_as_running()
 
-        displaced_uid = plan_queue[0]["plan_uid"]
+        displaced_uid = plan_queue[0]["item_uid"]
         await add_plan({"name": "f"}, 5, after_uid=displaced_uid)
 
         with pytest.raises(IndexError, match="Can not insert a plan in the queue before a currently running plan"):
@@ -462,7 +462,7 @@ def test_add_item_to_queue_3_fail(pq):
             await pq.add_item_to_queue("plan_is_not_string")
 
         # Duplicate plan UID
-        plan = {"plan_uid": "abc", "name": "a"}
+        plan = {"item_uid": "abc", "name": "a"}
         await pq.add_item_to_queue(plan)
         with pytest.raises(RuntimeError, match="Item with UID .+ is already in the queue"):
             await pq.add_item_to_queue(plan)
@@ -526,11 +526,11 @@ def test_move_item_1(pq, params, src, order, success, msg):
 
     async def testing():
         plans = [
-            {"plan_uid": "p1", "name": "a"},
-            {"plan_uid": "p2", "name": "b"},
-            {"plan_uid": "p3", "name": "c"},
-            {"plan_uid": "p4", "name": "d"},
-            {"plan_uid": "p5", "name": "e"},
+            {"item_uid": "p1", "name": "a"},
+            {"item_uid": "p2", "name": "b"},
+            {"item_uid": "p3", "name": "c"},
+            {"item_uid": "p4", "name": "d"},
+            {"item_uid": "p5", "name": "e"},
         ]
 
         for plan in plans:
@@ -627,21 +627,21 @@ def test_pop_item_from_queue_3(pq):
         plan_to_remove = [_ for _ in plans if _["name"] == "b"][0]
 
         # Remove one plan
-        await pq.pop_item_from_queue(uid=plan_to_remove["plan_uid"])
+        await pq.pop_item_from_queue(uid=plan_to_remove["item_uid"])
         assert await pq.get_queue_size() == 2
 
         # Attempt to remove the plan again. This should raise an exception.
         with pytest.raises(
-            IndexError, match=f"Plan with UID '{plan_to_remove['plan_uid']}' " f"is not in the queue"
+            IndexError, match=f"Plan with UID '{plan_to_remove['item_uid']}' " f"is not in the queue"
         ):
-            await pq.pop_item_from_queue(uid=plan_to_remove["plan_uid"])
+            await pq.pop_item_from_queue(uid=plan_to_remove["item_uid"])
         assert await pq.get_queue_size() == 2
 
         # Attempt to remove the plan that is running. This should raise an exception.
         await pq.set_next_item_as_running()
         assert await pq.get_queue_size() == 1
         with pytest.raises(IndexError, match="Can not remove a plan which is currently running"):
-            await pq.pop_item_from_queue(uid=plans[0]["plan_uid"])
+            await pq.pop_item_from_queue(uid=plans[0]["item_uid"])
         assert await pq.get_queue_size() == 1
 
     asyncio.run(testing())
@@ -753,7 +753,7 @@ def test_set_processed_item_as_completed(pq):
     The function moves currently running plan to history.
     """
 
-    plans = [{"plan_uid": 1, "name": "a"}, {"plan_uid": 2, "name": "b"}, {"plan_uid": 3, "name": "c"}]
+    plans = [{"item_uid": 1, "name": "a"}, {"item_uid": 2, "name": "b"}, {"item_uid": 3, "name": "c"}]
 
     def add_status_to_plans(plans, exit_status):
         plans = copy.deepcopy(plans)
@@ -805,7 +805,7 @@ def test_set_processed_item_as_stopped(pq):
     Test for ``PlanQueueOperations.set_processed_item_as_stopped()`` function.
     The function pushes running plan back to the queue and saves it in history as well.
     """
-    plans = [{"plan_uid": 1, "name": "a"}, {"plan_uid": 2, "name": "b"}, {"plan_uid": 3, "name": "c"}]
+    plans = [{"item_uid": 1, "name": "a"}, {"item_uid": 2, "name": "b"}, {"item_uid": 3, "name": "c"}]
 
     def add_status_to_plans(plans, exit_status):
         plans = copy.deepcopy(plans)

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -71,12 +71,12 @@ def test_queue_clean(pq, plan_running, plans, result_running, result_plans):
             await pq._r_pool.rpush(pq._name_plan_queue, json.dumps(plan))
 
         assert await pq.get_running_plan_info() == plan_running
-        assert await pq.get_plan_queue() == plans
+        assert await pq.get_queue() == plans
 
         await pq._queue_clean()
 
         assert await pq.get_running_plan_info() == result_running
-        assert await pq.get_plan_queue() == result_plans
+        assert await pq.get_queue() == result_plans
 
     asyncio.run(testing())
 
@@ -218,7 +218,7 @@ def test_uid_dict_2_initialize(pq):
         await pq.add_item_to_queue({"name": "a"})
         await pq.add_item_to_queue({"name": "b"})
         await pq.add_item_to_queue({"name": "c"})
-        plans = await pq.get_plan_queue()
+        plans = await pq.get_queue()
         uid_dict = {_["plan_uid"]: _ for _ in plans}
 
         await pq._uid_dict_initialize()
@@ -267,12 +267,12 @@ def test_remove_plan(pq):
         for plan in plan_list:
             await pq.add_item_to_queue(plan)
 
-        plans = await pq.get_plan_queue()
+        plans = await pq.get_queue()
         plan_to_remove = [_ for _ in plans if _["name"] == "b"][0]
 
         # Remove one plan
         await pq._remove_plan(plan_to_remove)
-        plans = await pq.get_plan_queue()
+        plans = await pq.get_queue()
         assert len(plans) == 2
 
         # Add a copy of a plan (queue is not supposed to have copies in real life)
@@ -395,7 +395,7 @@ def test_add_item_to_queue_1(pq):
 
         assert await pq.get_queue_size() == 12
 
-        plans = await pq.get_plan_queue()
+        plans = await pq.get_queue()
         name_sequence = [_["name"] for _ in plans]
         assert name_sequence == ["l", "k", "e", "d", "a", "i", "b", "c", "g", "h", "f", "j"]
 
@@ -419,7 +419,7 @@ def test_add_item_to_queue_2(pq):
         await add_plan({"name": "b"}, 2)
         await add_plan({"name": "c"}, 3, pos="back")
 
-        plan_queue = await pq.get_plan_queue()
+        plan_queue = await pq.get_queue()
         displaced_uid = plan_queue[1]["plan_uid"]
 
         await add_plan({"name": "d"}, 4, before_uid=displaced_uid)
@@ -439,7 +439,7 @@ def test_add_item_to_queue_2(pq):
 
         assert await pq.get_queue_size() == 5
 
-        plans = await pq.get_plan_queue()
+        plans = await pq.get_queue()
         name_sequence = [_["name"] for _ in plans]
         assert name_sequence == ["f", "d", "b", "e", "c"]
 
@@ -543,7 +543,7 @@ def test_move_item_1(pq, params, src, order, success, msg):
             assert qsize == len(plans)
             assert plan["name"] == plans[src]["name"]
 
-            queue = await pq.get_plan_queue()
+            queue = await pq.get_queue()
             names = [_["name"] for _ in queue]
             names = "".join(names)
             assert names == order
@@ -622,7 +622,7 @@ def test_pop_plan_from_queue_3(pq):
         await pq.add_item_to_queue({"name": "c"})
         assert await pq.get_queue_size() == 3
 
-        plans = await pq.get_plan_queue()
+        plans = await pq.get_queue()
         assert len(plans) == 3
         plan_to_remove = [_ for _ in plans if _["name"] == "b"][0]
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -257,7 +257,7 @@ def test_uid_dict_3_failing(pq):
     assert len(pq._uid_dict) == 2
 
 
-def test_remove_plan(pq):
+def test_remove_item(pq):
     """
     Basic test for functions associated with ``_remove_plan()``
     """
@@ -271,7 +271,7 @@ def test_remove_plan(pq):
         plan_to_remove = [_ for _ in plans if _["name"] == "b"][0]
 
         # Remove one plan
-        await pq._remove_plan(plan_to_remove)
+        await pq._remove_item(plan_to_remove)
         plans = await pq.get_queue()
         assert len(plans) == 2
 
@@ -279,15 +279,15 @@ def test_remove_plan(pq):
         plan_to_add = plans[0]
         await pq._r_pool.lpush(pq._name_plan_queue, json.dumps(plan_to_add))
         # Now remove both plans
-        await pq._remove_plan(plan_to_add, single=False)  # Allow deleting multiple or no plans
+        await pq._remove_item(plan_to_add, single=False)  # Allow deleting multiple or no plans
         assert await pq.get_queue_size() == 1
 
         # Delete the plan again (the plan is not in the queue, but it shouldn't raise an exception)
-        await pq._remove_plan(plan_to_add, single=False)  # Allow deleting multiple or no plans
+        await pq._remove_item(plan_to_add, single=False)  # Allow deleting multiple or no plans
         assert await pq.get_queue_size() == 1
 
-        with pytest.raises(RuntimeError, match="One plans is expected to be removed"):
-            await pq._remove_plan(plan_to_add)
+        with pytest.raises(RuntimeError, match="One item is expected"):
+            await pq._remove_item(plan_to_add)
         assert await pq.get_queue_size() == 1
 
         # Now add 'plan_to_add' twice (create two copies)
@@ -295,8 +295,8 @@ def test_remove_plan(pq):
         await pq._r_pool.lpush(pq._name_plan_queue, json.dumps(plan_to_add))
         assert await pq.get_queue_size() == 3
         # Attempt to delete two copies
-        with pytest.raises(RuntimeError, match="One plans is expected to be removed"):
-            await pq._remove_plan(plan_to_add)
+        with pytest.raises(RuntimeError, match="One item is expected"):
+            await pq._remove_item(plan_to_add)
         # Exception is raised, but both copies are deleted
         assert await pq.get_queue_size() == 1
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -640,7 +640,7 @@ def test_pop_item_from_queue_3(pq):
         # Attempt to remove the plan that is running. This should raise an exception.
         await pq.set_next_item_as_running()
         assert await pq.get_queue_size() == 1
-        with pytest.raises(IndexError, match="Can not remove a plan which is currently running"):
+        with pytest.raises(IndexError, match="Can not remove an item which is currently running"):
             await pq.pop_item_from_queue(uid=plans[0]["item_uid"])
         assert await pq.get_queue_size() == 1
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -399,7 +399,7 @@ def test_add_item_to_queue_1(pq):
         name_sequence = [_["name"] for _ in plans]
         assert name_sequence == ["l", "k", "e", "d", "a", "i", "b", "c", "g", "h", "f", "j"]
 
-        await pq.clear_plan_queue()
+        await pq.clear_queue()
 
     asyncio.run(testing())
 
@@ -443,7 +443,7 @@ def test_add_item_to_queue_2(pq):
         name_sequence = [_["name"] for _ in plans]
         assert name_sequence == ["f", "d", "b", "e", "c"]
 
-        await pq.clear_plan_queue()
+        await pq.clear_queue()
 
     asyncio.run(testing())
 
@@ -663,9 +663,9 @@ def test_pop_plan_from_queue_4_fail(pq):
     asyncio.run(testing())
 
 
-def test_clear_plan_queue(pq):
+def test_clear_queue(pq):
     """
-    Test for ``PlanQueueOperations.clear_plan_queue`` function
+    Test for ``PlanQueueOperations.clear_queue`` function
     """
 
     async def testing():
@@ -679,7 +679,7 @@ def test_clear_plan_queue(pq):
         assert len(pq._uid_dict) == 3
 
         # Clears the queue only (doesn't touch the running plan)
-        await pq.clear_plan_queue()
+        await pq.clear_queue()
 
         assert await pq.get_queue_size() == 0
         assert len(pq._uid_dict) == 1

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -117,7 +117,7 @@ def test_verify_plan(pq, plan, result, errmsg):
         for plan in existing_plans:
             await pq.add_item_to_queue(plan)
         # Set one plan as currently running
-        await pq.set_next_plan_as_running()
+        await pq.set_next_item_as_running()
 
         # Verify that setup is correct
         assert await pq.is_plan_running() is True
@@ -356,7 +356,7 @@ def test_get_plan_2_fail(pq):
         await pq.add_item_to_queue({"plan_uid": "three", "name": "c"})
         assert await pq.get_queue_size() == 3
 
-        await pq.set_next_plan_as_running()
+        await pq.set_next_item_as_running()
         assert await pq.get_queue_size() == 2
 
         with pytest.raises(IndexError, match="is currently running"):
@@ -426,7 +426,7 @@ def test_add_item_to_queue_2(pq):
         await add_plan({"name": "e"}, 5, after_uid=displaced_uid)
 
         # This reduces the number of elements in the queue by one
-        await pq.set_next_plan_as_running()
+        await pq.set_next_item_as_running()
 
         displaced_uid = plan_queue[0]["plan_uid"]
         await add_plan({"name": "f"}, 5, after_uid=displaced_uid)
@@ -638,7 +638,7 @@ def test_pop_plan_from_queue_3(pq):
         assert await pq.get_queue_size() == 2
 
         # Attempt to remove the plan that is running. This should raise an exception.
-        await pq.set_next_plan_as_running()
+        await pq.set_next_item_as_running()
         assert await pq.get_queue_size() == 1
         with pytest.raises(IndexError, match="Can not remove a plan which is currently running"):
             await pq.pop_plan_from_queue(uid=plans[0]["plan_uid"])
@@ -673,7 +673,7 @@ def test_clear_plan_queue(pq):
         await pq.add_item_to_queue({"name": "b"})
         await pq.add_item_to_queue({"name": "c"})
         # Set one of 3 plans as running (removes it from the queue)
-        await pq.set_next_plan_as_running()
+        await pq.set_next_item_as_running()
 
         assert await pq.get_queue_size() == 2
         assert len(pq._uid_dict) == 3
@@ -716,16 +716,16 @@ def test_plan_to_history_functions(pq):
     asyncio.run(testing())
 
 
-def test_set_next_plan_as_running(pq):
+def test_set_next_item_as_running(pq):
     """
-    Test for ``PlanQueueOperations.set_next_plan_as_running()`` function
+    Test for ``PlanQueueOperations.set_next_item_as_running()`` function
     """
 
     async def testing():
         # Apply to empty queue
         assert await pq.get_queue_size() == 0
         assert await pq.is_plan_running() is False
-        assert await pq.set_next_plan_as_running() == {}
+        assert await pq.set_next_item_as_running() == {}
         assert await pq.get_queue_size() == 0
         assert await pq.is_plan_running() is False
 
@@ -734,13 +734,13 @@ def test_set_next_plan_as_running(pq):
         await pq.add_item_to_queue({"name": "b"})
         await pq.add_item_to_queue({"name": "c"})
         # Set one of 3 plans as running (removes it from the queue)
-        assert await pq.set_next_plan_as_running() != {}
+        assert await pq.set_next_item_as_running() != {}
 
         assert await pq.get_queue_size() == 2
         assert len(pq._uid_dict) == 3
 
         # Apply if a plan is already running
-        assert await pq.set_next_plan_as_running() == {}
+        assert await pq.set_next_item_as_running() == {}
         assert await pq.get_queue_size() == 2
         assert len(pq._uid_dict) == 3
 
@@ -772,7 +772,7 @@ def test_set_processed_plan_as_completed(pq):
         assert plan == {}
 
         # Execute the first plan
-        await pq.set_next_plan_as_running()
+        await pq.set_next_item_as_running()
         plan = await pq.set_processed_plan_as_completed(exit_status="completed")
 
         assert await pq.get_queue_size() == 2
@@ -785,7 +785,7 @@ def test_set_processed_plan_as_completed(pq):
         assert plan_history == plan_history_expected
 
         # Execute the second plan
-        await pq.set_next_plan_as_running()
+        await pq.set_next_item_as_running()
         plan = await pq.set_processed_plan_as_completed(exit_status="completed")
 
         assert await pq.get_queue_size() == 1
@@ -824,7 +824,7 @@ def test_set_processed_plan_as_stopped(pq):
         assert plan == {}
 
         # Execute the first plan
-        await pq.set_next_plan_as_running()
+        await pq.set_next_item_as_running()
         plan = await pq.set_processed_plan_as_stopped(exit_status="stopped")
 
         assert await pq.get_queue_size() == 3
@@ -837,7 +837,7 @@ def test_set_processed_plan_as_stopped(pq):
         assert plan_history == plan_history_expected
 
         # Execute the second plan
-        await pq.set_next_plan_as_running()
+        await pq.set_next_item_as_running()
         plan = await pq.set_processed_plan_as_stopped(exit_status="stopped")
 
         assert await pq.get_queue_size() == 3

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -690,27 +690,27 @@ def test_clear_queue(pq):
     asyncio.run(testing())
 
 
-def test_plan_to_history_functions(pq):
+def test_add_to_history_functions(pq):
     """
-    Test for ``PlanQueueOperations._add_plan_to_history()`` method.
+    Test for ``PlanQueueOperations._add_to_history()`` method.
     """
 
     async def testing():
-        assert await pq.get_plan_history_size() == 0
+        assert await pq.get_history_size() == 0
 
         plans = [{"name": "a"}, {"name": "b"}, {"name": "c"}]
         for plan in plans:
-            await pq._add_plan_to_history(plan)
-        assert await pq.get_plan_history_size() == 3
+            await pq._add_to_history(plan)
+        assert await pq.get_history_size() == 3
 
-        plan_history = await pq.get_plan_history()
+        plan_history = await pq.get_history()
 
         assert len(plan_history) == 3
         assert plan_history == plans
 
-        await pq.clear_plan_history()
+        await pq.clear_history()
 
-        plan_history = await pq.get_plan_history()
+        plan_history = await pq.get_history()
         assert plan_history == []
 
     asyncio.run(testing())
@@ -747,9 +747,9 @@ def test_set_next_item_as_running(pq):
     asyncio.run(testing())
 
 
-def test_set_processed_plan_as_completed(pq):
+def test_set_processed_item_as_completed(pq):
     """
-    Test for ``PlanQueueOperations.set_processed_plan_as_completed()`` function.
+    Test for ``PlanQueueOperations.set_processed_item_as_completed()`` function.
     The function moves currently running plan to history.
     """
 
@@ -768,41 +768,41 @@ def test_set_processed_plan_as_completed(pq):
             await pq.add_item_to_queue(plan)
 
         # No plan is running
-        plan = await pq.set_processed_plan_as_completed(exit_status="completed")
+        plan = await pq.set_processed_item_as_completed(exit_status="completed")
         assert plan == {}
 
         # Execute the first plan
         await pq.set_next_item_as_running()
-        plan = await pq.set_processed_plan_as_completed(exit_status="completed")
+        plan = await pq.set_processed_item_as_completed(exit_status="completed")
 
         assert await pq.get_queue_size() == 2
-        assert await pq.get_plan_history_size() == 1
+        assert await pq.get_history_size() == 1
         assert plan["name"] == plans[0]["name"]
         assert plan["exit_status"] == "completed"
 
-        plan_history = await pq.get_plan_history()
+        plan_history = await pq.get_history()
         plan_history_expected = add_status_to_plans(plans[0:1], "completed")
         assert plan_history == plan_history_expected
 
         # Execute the second plan
         await pq.set_next_item_as_running()
-        plan = await pq.set_processed_plan_as_completed(exit_status="completed")
+        plan = await pq.set_processed_item_as_completed(exit_status="completed")
 
         assert await pq.get_queue_size() == 1
-        assert await pq.get_plan_history_size() == 2
+        assert await pq.get_history_size() == 2
         assert plan["name"] == plans[1]["name"]
         assert plan["exit_status"] == "completed"
 
-        plan_history = await pq.get_plan_history()
+        plan_history = await pq.get_history()
         plan_history_expected = add_status_to_plans(plans[0:2], "completed")
         assert plan_history == plan_history_expected
 
     asyncio.run(testing())
 
 
-def test_set_processed_plan_as_stopped(pq):
+def test_set_processed_item_as_stopped(pq):
     """
-    Test for ``PlanQueueOperations.set_processed_plan_as_stopped()`` function.
+    Test for ``PlanQueueOperations.set_processed_item_as_stopped()`` function.
     The function pushes running plan back to the queue and saves it in history as well.
     """
     plans = [{"plan_uid": 1, "name": "a"}, {"plan_uid": 2, "name": "b"}, {"plan_uid": 3, "name": "c"}]
@@ -820,32 +820,32 @@ def test_set_processed_plan_as_stopped(pq):
             await pq.add_item_to_queue(plan)
 
         # No plan is running
-        plan = await pq.set_processed_plan_as_stopped(exit_status="stopped")
+        plan = await pq.set_processed_item_as_stopped(exit_status="stopped")
         assert plan == {}
 
         # Execute the first plan
         await pq.set_next_item_as_running()
-        plan = await pq.set_processed_plan_as_stopped(exit_status="stopped")
+        plan = await pq.set_processed_item_as_stopped(exit_status="stopped")
 
         assert await pq.get_queue_size() == 3
-        assert await pq.get_plan_history_size() == 1
+        assert await pq.get_history_size() == 1
         assert plan["name"] == plans[0]["name"]
         assert plan["exit_status"] == "stopped"
 
-        plan_history = await pq.get_plan_history()
+        plan_history = await pq.get_history()
         plan_history_expected = add_status_to_plans([plans[0]], "stopped")
         assert plan_history == plan_history_expected
 
         # Execute the second plan
         await pq.set_next_item_as_running()
-        plan = await pq.set_processed_plan_as_stopped(exit_status="stopped")
+        plan = await pq.set_processed_item_as_stopped(exit_status="stopped")
 
         assert await pq.get_queue_size() == 3
-        assert await pq.get_plan_history_size() == 2
+        assert await pq.get_history_size() == 2
         assert plan["name"] == plans[0]["name"]
         assert plan["exit_status"] == "stopped"
 
-        plan_history = await pq.get_plan_history()
+        plan_history = await pq.get_history()
         plan_history_expected = add_status_to_plans([plans[0], plans[0]], "stopped")
         assert plan_history == plan_history_expected
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -569,9 +569,9 @@ def test_move_item_1(pq, params, src, order, success, msg):
     (-4, None)  # Index out of range
 ])
 # fmt: on
-def test_pop_plan_from_queue_1(pq, pos, name):
+def test_pop_item_from_queue_1(pq, pos, name):
     """
-    Basic test for the function ``PlanQueueOperations.pop_plan_from_queue()``
+    Basic test for the function ``PlanQueueOperations.pop_item_from_queue()``
     """
 
     async def testing():
@@ -582,7 +582,7 @@ def test_pop_plan_from_queue_1(pq, pos, name):
         assert await pq.get_queue_size() == 3
 
         if name is not None:
-            plan, qsize = await pq.pop_plan_from_queue(pos=pos)
+            plan, qsize = await pq.pop_item_from_queue(pos=pos)
             assert plan["name"] == name
             assert qsize == 2
             assert await pq.get_queue_size() == 2
@@ -591,27 +591,27 @@ def test_pop_plan_from_queue_1(pq, pos, name):
             assert await pq.get_queue_size() == 3
         else:
             with pytest.raises(IndexError, match="Index .* is out of range"):
-                await pq.pop_plan_from_queue(pos=pos)
+                await pq.pop_item_from_queue(pos=pos)
 
     asyncio.run(testing())
 
 
 @pytest.mark.parametrize("pos", ["front", "back", 0, 1, -1])
-def test_pop_plan_from_queue_2(pq, pos):
+def test_pop_item_from_queue_2(pq, pos):
     """
-    Test for the function ``PlanQueueOperations.pop_plan_from_queue()``:
+    Test for the function ``PlanQueueOperations.pop_item_from_queue()``:
     the case of empty queue.
     """
 
     async def testing():
         assert await pq.get_queue_size() == 0
         with pytest.raises(IndexError, match="Index .* is out of range|Queue is empty"):
-            await pq.pop_plan_from_queue(pos=pos)
+            await pq.pop_item_from_queue(pos=pos)
 
     asyncio.run(testing())
 
 
-def test_pop_plan_from_queue_3(pq):
+def test_pop_item_from_queue_3(pq):
     """
     Pop plans by UID.
     """
@@ -627,38 +627,38 @@ def test_pop_plan_from_queue_3(pq):
         plan_to_remove = [_ for _ in plans if _["name"] == "b"][0]
 
         # Remove one plan
-        await pq.pop_plan_from_queue(uid=plan_to_remove["plan_uid"])
+        await pq.pop_item_from_queue(uid=plan_to_remove["plan_uid"])
         assert await pq.get_queue_size() == 2
 
         # Attempt to remove the plan again. This should raise an exception.
         with pytest.raises(
             IndexError, match=f"Plan with UID '{plan_to_remove['plan_uid']}' " f"is not in the queue"
         ):
-            await pq.pop_plan_from_queue(uid=plan_to_remove["plan_uid"])
+            await pq.pop_item_from_queue(uid=plan_to_remove["plan_uid"])
         assert await pq.get_queue_size() == 2
 
         # Attempt to remove the plan that is running. This should raise an exception.
         await pq.set_next_item_as_running()
         assert await pq.get_queue_size() == 1
         with pytest.raises(IndexError, match="Can not remove a plan which is currently running"):
-            await pq.pop_plan_from_queue(uid=plans[0]["plan_uid"])
+            await pq.pop_item_from_queue(uid=plans[0]["plan_uid"])
         assert await pq.get_queue_size() == 1
 
     asyncio.run(testing())
 
 
-def test_pop_plan_from_queue_4_fail(pq):
+def test_pop_item_from_queue_4_fail(pq):
     """
-    Failing tests for the function ``PlanQueueOperations.pop_plan_from_queue()``
+    Failing tests for the function ``PlanQueueOperations.pop_item_from_queue()``
     """
 
     async def testing():
         with pytest.raises(ValueError, match="Parameter 'pos' has incorrect value"):
-            await pq.pop_plan_from_queue(pos="something")
+            await pq.pop_item_from_queue(pos="something")
 
         # Ambiguous parameters (position and UID is passed)
         with pytest.raises(ValueError, match="Ambiguous parameters"):
-            await pq.pop_plan_from_queue(pos=5, uid="abc")
+            await pq.pop_item_from_queue(pos=5, uid="abc")
 
     asyncio.run(testing())
 
@@ -685,7 +685,7 @@ def test_clear_queue(pq):
         assert len(pq._uid_dict) == 1
 
         with pytest.raises(ValueError, match="Parameter 'pos' has incorrect value"):
-            await pq.pop_plan_from_queue(pos="something")
+            await pq.pop_item_from_queue(pos="something")
 
     asyncio.run(testing())
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -519,9 +519,9 @@ def test_add_item_to_queue_3_fail(pq):
     ({"pos": 1, "after_uid": "p4", "before_uid": "p4"}, 1, "", False, "Ambiguous parameters"),
 ])
 # fmt: on
-def test_move_plan_1(pq, params, src, order, success, msg):
+def test_move_item_1(pq, params, src, order, success, msg):
     """
-    Basic tests for ``move_plans()``.
+    Basic tests for ``move_item()``.
     """
 
     async def testing():
@@ -539,7 +539,7 @@ def test_move_plan_1(pq, params, src, order, success, msg):
         assert await pq.get_plan_queue_size() == len(plans)
 
         if success:
-            plan, qsize = await pq.move_plan(**params)
+            plan, qsize = await pq.move_item(**params)
             assert qsize == len(plans)
             assert plan["name"] == plans[src]["name"]
 
@@ -550,7 +550,7 @@ def test_move_plan_1(pq, params, src, order, success, msg):
 
         else:
             with pytest.raises(Exception, match=msg):
-                await pq.move_plan(**params)
+                await pq.move_item(**params)
 
     asyncio.run(testing())
 

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -735,9 +735,9 @@ def test_queue_item_add_6_fail(re_manager, params, exit_code):  # noqa F811
     (None, 3, 2, False),
 ])
 # fmt: on
-def test_queue_plan_get_remove(re_manager, pos, uid_ind, pos_result, success):  # noqa F811
+def test_queue_item_get_remove(re_manager, pos, uid_ind, pos_result, success):  # noqa F811
     """
-    Tests for ``queue_plan_get`` and ``queue_plan_remove`` requests.
+    Tests for ``queue_item_get`` and ``queue_plan_remove`` requests.
     """
     plans = [
         "{'name':'count', 'args':[['det1']]}",
@@ -761,8 +761,8 @@ def test_queue_plan_get_remove(re_manager, pos, uid_ind, pos_result, success):  
         uid = uids_1[uid_ind]
         args = ["-p", uid]
 
-    # Testing 'queue_plan_get'. ONLY THE RETURN CODE IS TESTED.
-    res = subprocess.call(["qserver", "-c", "queue_plan_get", *args])
+    # Testing 'queue_item_get'. ONLY THE RETURN CODE IS TESTED.
+    res = subprocess.call(["qserver", "-c", "queue_item_get", *args])
     if success:
         assert res == 0
     else:
@@ -808,9 +808,9 @@ def test_queue_plan_get_remove(re_manager, pos, uid_ind, pos_result, success):  
 
 ])
 # fmt: on
-def test_queue_plan_get_move(re_manager, params, result_order, exit_code):  # noqa F811
+def test_queue_item_get_move(re_manager, params, result_order, exit_code):  # noqa F811
     """
-    Tests for ``queue_plan_get`` and ``queue_plan_remove`` requests.
+    Tests for ``queue_item_get`` and ``queue_plan_remove`` requests.
     """
     plans = [
         "{'name':'count', 'args':[['det1']]}",
@@ -832,7 +832,7 @@ def test_queue_plan_get_move(re_manager, params, result_order, exit_code):  # no
         if isinstance(p, int):
             params[n] = uids_1[p]
 
-    # Testing 'queue_plan_get'. ONLY THE RETURN CODE IS TESTED.
+    # Testing 'queue_item_get'. ONLY THE RETURN CODE IS TESTED.
     assert subprocess.call(["qserver", "-c", "queue_plan_move", "-p", *params]) == exit_code
 
     queue_2 = get_queue()["queue"]

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -47,7 +47,7 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     assert not is_plan_running, "Plan is executed while it shouldn't"
 
     assert subprocess.call(["qserver", "-c", "queue_get"]) == 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_remove"]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_remove"]) == 0
 
     n_plans, is_plan_running, _ = get_reduced_state_info()
     assert n_plans == 2, "Incorrect number of plans in the queue"
@@ -737,7 +737,7 @@ def test_queue_item_add_6_fail(re_manager, params, exit_code):  # noqa F811
 # fmt: on
 def test_queue_item_get_remove(re_manager, pos, uid_ind, pos_result, success):  # noqa F811
     """
-    Tests for ``queue_item_get`` and ``queue_plan_remove`` requests.
+    Tests for ``queue_item_get`` and ``queue_item_remove`` requests.
     """
     plans = [
         "{'name':'count', 'args':[['det1']]}",
@@ -768,8 +768,8 @@ def test_queue_item_get_remove(re_manager, pos, uid_ind, pos_result, success):  
     else:
         assert res != 0
 
-    # Testing 'queue_plan_remove'.
-    res = subprocess.call(["qserver", "-c", "queue_plan_remove", *args])
+    # Testing 'queue_item_remove'.
+    res = subprocess.call(["qserver", "-c", "queue_item_remove", *args])
     if success:
         assert res == 0
     else:
@@ -810,7 +810,7 @@ def test_queue_item_get_remove(re_manager, pos, uid_ind, pos_result, success):  
 # fmt: on
 def test_queue_item_get_move(re_manager, params, result_order, exit_code):  # noqa F811
     """
-    Tests for ``queue_item_get`` and ``queue_plan_remove`` requests.
+    Tests for ``queue_item_get`` and ``queue_item_remove`` requests.
     """
     plans = [
         "{'name':'count', 'args':[['det1']]}",

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -598,7 +598,7 @@ def test_queue_item_add_1(re_manager, pos, pos_result, success):  # noqa F811
 
     if success:
         assert resp["queue"][pos_result]["args"] == [["det1", "det2"]]
-        assert "plan_uid" in resp["queue"][pos_result]
+        assert "item_uid" in resp["queue"][pos_result]
 
 
 def test_queue_item_add_2(re_manager):  # noqa F811
@@ -643,7 +643,7 @@ def test_queue_item_add_3(re_manager, before, target_pos, result_order):  # noqa
     # Read queue.
     queue_1 = get_queue()["queue"]
     assert len(queue_1) == 2
-    uids_1 = [_["plan_uid"] for _ in queue_1]
+    uids_1 = [_["item_uid"] for _ in queue_1]
 
     params = ["before_uid" if before else "after_uid", uids_1[target_pos], plan3]
     assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", *params]) == 0
@@ -651,7 +651,7 @@ def test_queue_item_add_3(re_manager, before, target_pos, result_order):  # noqa
     # Check if the element was inserted in the right plance
     queue_2 = get_queue()["queue"]
     assert len(queue_2) == 3
-    uids_2 = [_["plan_uid"] for _ in queue_2]
+    uids_2 = [_["item_uid"] for _ in queue_2]
     for n, uid in enumerate(uids_2):
         n_res = result_order[n]
         if (n_res < 2) and (uid != uids_1[n_res]):
@@ -751,7 +751,7 @@ def test_queue_item_get_remove(re_manager, pos, uid_ind, pos_result, success):  
 
     queue_1 = get_queue()["queue"]
     assert len(queue_1) == 3
-    uids_1 = [_["plan_uid"] for _ in queue_1]
+    uids_1 = [_["item_uid"] for _ in queue_1]
     uids_1.append("unknown_uid")  # Extra element (for one of the tests)
 
     if uid_ind is None:
@@ -823,7 +823,7 @@ def test_queue_item_get_move(re_manager, params, result_order, exit_code):  # no
 
     queue_1 = get_queue()["queue"]
     assert len(queue_1) == 3
-    uids_1 = [_["plan_uid"] for _ in queue_1]
+    uids_1 = [_["item_uid"] for _ in queue_1]
     uids_1.append("unknown_uid")  # Extra element (for one of the tests)
 
     # Replace ints with UIDs (positions are represented as strings)
@@ -837,7 +837,7 @@ def test_queue_item_get_move(re_manager, params, result_order, exit_code):  # no
 
     queue_2 = get_queue()["queue"]
     assert len(queue_2) == 3
-    uids_2 = [_["plan_uid"] for _ in queue_2]
+    uids_2 = [_["item_uid"] for _ in queue_2]
 
     # Compare the order of UIDs before and after moving the element
     uids_1_reordered = [uids_1[_] for _ in result_order]

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -38,9 +38,9 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     plan_1 = "{'name':'count', 'args':[['det1', 'det2']]}"
     plan_2 = "{'name':'scan', 'args':[['det1', 'det2'], 'motor', -1, 1, 10]}"
     plan_3 = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}"
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan_1]) == 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan_2]) == 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan_3]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan_1]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan_2]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan_3]) == 0
 
     n_plans, is_plan_running, _ = get_reduced_state_info()
     assert n_plans == 3, "Incorrect number of plans in the queue"
@@ -68,7 +68,7 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "-c", "history_clear"]) == 0
 
     # Queue is expected to be empty (processed). Load one more plan.
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan_3]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan_3]) == 0
 
     n_plans, is_plan_running, _ = get_reduced_state_info()
     assert n_plans == 1, "Incorrect number of plans in the queue"
@@ -93,8 +93,8 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
         time=60, condition=condition_queue_processing_finished
     ), "Timeout while waiting for process to finish"
 
-    subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan_1])
-    subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan_1])
+    subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan_1])
+    subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan_1])
 
     n_plans, is_plan_running, _ = get_reduced_state_info()
     assert n_plans == 2, "Incorrect number of plans in the queue"
@@ -108,9 +108,9 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     # Test 'killing' the manager during running plan. Load long plan and two short ones.
     #   The tests checks if execution of the queue is continued uninterrupted after
     #   the manager restart
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan_3]) == 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan_3]) == 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan_3]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan_3]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan_3]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan_3]) == 0
     n_plans, is_plan_running, _ = get_reduced_state_info()
     assert n_plans == 3, "Incorrect number of plans in the queue"
 
@@ -140,7 +140,7 @@ def test_qserver_environment_close(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "-c", "queue_clear"]) == 0
 
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':5, 'delay':1}}"
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
 
     n_plans, is_plan_running, _ = get_reduced_state_info()
     assert n_plans == 1, "Incorrect number of plans in the queue"
@@ -188,7 +188,7 @@ def test_qserver_environment_destroy(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "-c", "queue_clear"]) == 0
 
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':5, 'delay':1}}"
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
 
     n_plans, is_plan_running, _ = get_reduced_state_info()
     assert n_plans == 1, "Incorrect number of plans in the queue"
@@ -267,8 +267,8 @@ def test_qserver_re_pause_continue(re_manager, option_pause, option_continue):  
     assert subprocess.call(["qserver", "-c", "queue_clear"]) == 0
 
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num': 10, 'delay': 1}}"
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
 
     n_plans, is_plan_running, _ = get_reduced_state_info()
     assert n_plans == 2, "Incorrect number of plans in the queue"
@@ -366,8 +366,8 @@ def test_qserver_manager_kill(re_manager, time_kill):  # noqa: F811
     assert subprocess.call(["qserver", "-c", "queue_clear"]) == 0
 
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num': 10, 'delay': 1}}"
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
 
     assert subprocess.call(["qserver", "-c", "environment_open"]) == 0
     assert wait_for_condition(
@@ -468,7 +468,7 @@ def test_qserver_env_open_various_cases(re_manager_pc_copy, additional_code, suc
 
     # Run a plan to make sure RE Manager is functional after the startup.
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num': 10, 'delay': 1}}"
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
 
     # Start queue processing
     assert subprocess.call(["qserver", "-c", "queue_start"]) == 0
@@ -525,8 +525,8 @@ def test_qserver_manager_stop_2(re_manager, option):  # noqa: F811
     assert wait_for_condition(time=30, condition=condition_manager_idle)
 
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num': 10, 'delay': 1}}"
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
 
     assert subprocess.call(["qserver", "-c", "queue_start"]) == 0
     ttime.sleep(2)
@@ -570,7 +570,7 @@ def test_qserver_manager_stop_2(re_manager, option):  # noqa: F811
     (-100, 0, True),
 ])
 # fmt: on
-def test_queue_plan_add_1(re_manager, pos, pos_result, success):  # noqa F811
+def test_queue_item_add_1(re_manager, pos, pos_result, success):  # noqa F811
 
     # Wait until RE Manager is started
     assert wait_for_condition(time=10, condition=condition_manager_idle)
@@ -579,15 +579,15 @@ def test_queue_plan_add_1(re_manager, pos, pos_result, success):  # noqa F811
     plan2 = "{'name':'count', 'args':[['det1', 'det2']]}"
 
     # Create the queue with 2 entries
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan1]) == 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan1]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan1]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan1]) == 0
 
     # Add another entry at the specified position
     params = [plan2]
     if pos is not None:
         params.insert(0, str(pos))
 
-    res = subprocess.call(["qserver", "-c", "queue_plan_add", "-p", *params])
+    res = subprocess.call(["qserver", "-c", "queue_item_add", "-p", *params])
     if success:
         assert res == 0
     else:
@@ -601,7 +601,7 @@ def test_queue_plan_add_1(re_manager, pos, pos_result, success):  # noqa F811
         assert "plan_uid" in resp["queue"][pos_result]
 
 
-def test_queue_plan_add_2(re_manager):  # noqa F811
+def test_queue_item_add_2(re_manager):  # noqa F811
     """
     Failing cases: adding the plans that are expected to fail validation.
     """
@@ -614,8 +614,8 @@ def test_queue_plan_add_2(re_manager):  # noqa F811
     plan2 = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'abc': 10}}"
 
     # Both calls are expected to fail
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan1]) != 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan2]) != 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan1]) != 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan2]) != 0
 
 
 # fmt: off
@@ -626,7 +626,7 @@ def test_queue_plan_add_2(re_manager):  # noqa F811
     (False, 1, [0, 1, 2]),
 ])
 # fmt: on
-def test_queue_plan_add_3(re_manager, before, target_pos, result_order):  # noqa F811
+def test_queue_item_add_3(re_manager, before, target_pos, result_order):  # noqa F811
     """
     Insert an item before or after the element with a given UID
     """
@@ -637,8 +637,8 @@ def test_queue_plan_add_3(re_manager, before, target_pos, result_order):  # noqa
     plan2 = "{'name':'count', 'args':[['det1', 'det2']]}"
     plan3 = "{'name':'count', 'args':[['det2']]}"
 
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan1]) == 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan2]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan1]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan2]) == 0
 
     # Read queue.
     queue_1 = get_queue()["queue"]
@@ -646,7 +646,7 @@ def test_queue_plan_add_3(re_manager, before, target_pos, result_order):  # noqa
     uids_1 = [_["plan_uid"] for _ in queue_1]
 
     params = ["before_uid" if before else "after_uid", uids_1[target_pos], plan3]
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", *params]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", *params]) == 0
 
     # Check if the element was inserted in the right plance
     queue_2 = get_queue()["queue"]
@@ -661,7 +661,7 @@ def test_queue_plan_add_3(re_manager, before, target_pos, result_order):  # noqa
 # fmt: off
 @pytest.mark.parametrize("pos", [None, "back"])
 # fmt: on
-def test_queue_plan_add_4_fail(re_manager, pos):  # noqa F811
+def test_queue_item_add_4_fail(re_manager, pos):  # noqa F811
     """
     No plan is supplied.
     """
@@ -669,15 +669,15 @@ def test_queue_plan_add_4_fail(re_manager, pos):  # noqa F811
     assert wait_for_condition(time=10, condition=condition_manager_idle)
 
     if pos:
-        assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", pos]) != 0
+        assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", pos]) != 0
     else:
-        assert subprocess.call(["qserver", "-c", "queue_plan_add"]) != 0
+        assert subprocess.call(["qserver", "-c", "queue_item_add"]) != 0
 
 
 # fmt: off
 @pytest.mark.parametrize("pos", [10, "front", "back"])
 # fmt: on
-def test_queue_plan_add_5_fail(re_manager, pos):  # noqa F811
+def test_queue_item_add_5_fail(re_manager, pos):  # noqa F811
     """
     Incorrect order of arguments (position is specified).
     """
@@ -686,7 +686,7 @@ def test_queue_plan_add_5_fail(re_manager, pos):  # noqa F811
 
     pos, plan = 10, "{'name':'count', 'args':[['det1']]}"
     params = [plan, str(pos)]
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", *params]) != 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", *params]) != 0
 
 
 # fmt: off
@@ -701,7 +701,7 @@ def test_queue_plan_add_5_fail(re_manager, pos):  # noqa F811
     (["some_uid", "plan", "before_uid"], 4),
 ])
 # fmt: on
-def test_queue_plan_add_6_fail(re_manager, params, exit_code):  # noqa F811
+def test_queue_item_add_6_fail(re_manager, params, exit_code):  # noqa F811
     """
     Incorrect order of arguments (position is specified).
     """
@@ -710,7 +710,7 @@ def test_queue_plan_add_6_fail(re_manager, params, exit_code):  # noqa F811
 
     plan = "{'name':'count', 'args':[['det1']]}"
     params = [_ if _ != "plan" else plan for _ in params]
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", *params]) == exit_code
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", *params]) == exit_code
 
 
 # fmt: off
@@ -747,7 +747,7 @@ def test_queue_plan_get_remove(re_manager, pos, uid_ind, pos_result, success):  
     plans_args = [[["det1"]], [["det2"]], [["det1", "det2"]]]
 
     for plan in plans:
-        assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
+        assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
 
     queue_1 = get_queue()["queue"]
     assert len(queue_1) == 3
@@ -819,7 +819,7 @@ def test_queue_plan_get_move(re_manager, params, result_order, exit_code):  # no
     ]
 
     for plan in plans:
-        assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
+        assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
 
     queue_1 = get_queue()["queue"]
     assert len(queue_1) == 3
@@ -859,8 +859,8 @@ def test_qserver_queue_stop(re_manager, deactivate):  # noqa: F811
     assert wait_for_condition(time=10, condition=condition_manager_idle)
 
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num': 10, 'delay': 1}}"
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
-    assert subprocess.call(["qserver", "-c", "queue_plan_add", "-p", plan]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
+    assert subprocess.call(["qserver", "-c", "queue_item_add", "-p", plan]) == 0
 
     # Queue is not running, so the request is expected to fail
     assert subprocess.call(["qserver", "-c", "queue_stop"]) != 0

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -833,7 +833,7 @@ def test_queue_item_get_move(re_manager, params, result_order, exit_code):  # no
             params[n] = uids_1[p]
 
     # Testing 'queue_item_get'. ONLY THE RETURN CODE IS TESTED.
-    assert subprocess.call(["qserver", "-c", "queue_plan_move", "-p", *params]) == exit_code
+    assert subprocess.call(["qserver", "-c", "queue_item_move", "-p", *params]) == exit_code
 
     queue_2 = get_queue()["queue"]
     assert len(queue_2) == 3

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -359,7 +359,9 @@ def test_zmq_api_queue_item_add_7_fail(re_manager):  # noqa F811
     params2 = {"plan": plan2, "user": _user, "user_group": _user_group}
     resp2, _ = zmq_single_request("queue_item_add", params2)
     assert resp2["success"] is False
-    assert "Failed to add an item: Plan validation failed: got an unexpected keyword argument 'abc'" in resp2["msg"]
+    assert (
+        "Failed to add an item: Plan validation failed: got an unexpected keyword argument 'abc'" in resp2["msg"]
+    )
 
     # User name is not specified
     params3 = {"plan": plan2, "user_group": _user_group}

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -483,10 +483,10 @@ def test_zmq_api_plans_allowed_and_devices_allowed_3_fail(re_manager, params, me
 
 
 # =======================================================================================
-#                      Method 'queue_plan_get', 'queue_plan_remove'
+#                      Method 'queue_item_get', 'queue_plan_remove'
 
 
-def test_zmq_api_queue_plan_get_remove_1(re_manager):  # noqa F811
+def test_zmq_api_queue_item_get_remove_1(re_manager):  # noqa F811
     """
     Get and remove a plan from the back of the queue
     """
@@ -501,7 +501,7 @@ def test_zmq_api_queue_plan_get_remove_1(re_manager):  # noqa F811
     assert resp1["running_plan"] == {}
 
     # Get the last plan from the queue
-    resp2, _ = zmq_single_request("queue_plan_get")
+    resp2, _ = zmq_single_request("queue_item_get")
     assert resp2["success"] is True
     assert resp2["plan"]["name"] == _plan3["name"]
     assert resp2["plan"]["args"] == _plan3["args"]
@@ -536,7 +536,7 @@ def test_zmq_api_queue_plan_get_remove_1(re_manager):  # noqa F811
     (-100, 0, False),
 ])
 # fmt: on
-def test_zmq_api_queue_plan_get_remove_2(re_manager, pos, pos_result, success):  # noqa F811
+def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success):  # noqa F811
     """
     Get and remove elements using element position in the queue.
     """
@@ -554,7 +554,7 @@ def test_zmq_api_queue_plan_get_remove_2(re_manager, pos, pos_result, success): 
     params = {} if pos is None else {"pos": pos}
 
     # Testing '/queue/plan/get'
-    resp1, _ = zmq_single_request("queue_plan_get", params)
+    resp1, _ = zmq_single_request("queue_item_get", params)
     assert resp1["success"] is success
     if success:
         assert resp1["plan"]["args"] == plans[pos_result]["args"]
@@ -581,7 +581,7 @@ def test_zmq_api_queue_plan_get_remove_2(re_manager, pos, pos_result, success): 
     assert resp3["running_plan"] == {}
 
 
-def test_zmq_api_queue_plan_get_remove_3(re_manager):  # noqa F811
+def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     """
     Get and remove elements using plan UID. Successful and failing cases.
     """
@@ -596,7 +596,7 @@ def test_zmq_api_queue_plan_get_remove_3(re_manager):  # noqa F811
 
     # Get and then remove plan 2 from the queue
     uid = plans_in_queue[1]["plan_uid"]
-    resp2a, _ = zmq_single_request("queue_plan_get", {"uid": uid})
+    resp2a, _ = zmq_single_request("queue_item_get", {"uid": uid})
     assert resp2a["plan"]["plan_uid"] == plans_in_queue[1]["plan_uid"]
     assert resp2a["plan"]["name"] == plans_in_queue[1]["name"]
     assert resp2a["plan"]["args"] == plans_in_queue[1]["args"]
@@ -618,7 +618,7 @@ def test_zmq_api_queue_plan_get_remove_3(re_manager):  # noqa F811
 
     ttime.sleep(1)
     uid = plans_in_queue[0]["plan_uid"]
-    resp5a, _ = zmq_single_request("queue_plan_get", {"uid": uid})
+    resp5a, _ = zmq_single_request("queue_item_get", {"uid": uid})
     assert resp5a["success"] is False
     assert "is currently running" in resp5a["msg"]
     resp5b, _ = zmq_single_request("queue_plan_remove", {"uid": uid})
@@ -626,7 +626,7 @@ def test_zmq_api_queue_plan_get_remove_3(re_manager):  # noqa F811
     assert "Can not remove a plan which is currently running" in resp5b["msg"]
 
     uid = "nonexistent"
-    resp6a, _ = zmq_single_request("queue_plan_get", {"uid": uid})
+    resp6a, _ = zmq_single_request("queue_item_get", {"uid": uid})
     assert resp6a["success"] is False
     assert "not in the queue" in resp6a["msg"]
     resp6b, _ = zmq_single_request("queue_plan_remove", {"uid": uid})
@@ -635,7 +635,7 @@ def test_zmq_api_queue_plan_get_remove_3(re_manager):  # noqa F811
 
     # Remove the last entry
     uid = plans_in_queue[2]["plan_uid"]
-    resp7a, _ = zmq_single_request("queue_plan_get", {"uid": uid})
+    resp7a, _ = zmq_single_request("queue_item_get", {"uid": uid})
     assert resp7a["success"] is True
     resp7b, _ = zmq_single_request("queue_plan_remove", {"uid": uid})
     assert resp7b["success"] is True
@@ -654,12 +654,12 @@ def test_zmq_api_queue_plan_get_remove_3(re_manager):  # noqa F811
     assert wait_for_condition(time=5, condition=condition_environment_closed)
 
 
-def test_zmq_api_queue_plan_get_remove_4_failing(re_manager):  # noqa F811
+def test_zmq_api_queue_item_get_remove_4_failing(re_manager):  # noqa F811
     """
     Failing cases that are not tested in other places.
     """
     # Ambiguous parameters
-    resp1, _ = zmq_single_request("queue_plan_get", {"pos": 5, "uid": "some_uid"})
+    resp1, _ = zmq_single_request("queue_item_get", {"pos": 5, "uid": "some_uid"})
     assert resp1["success"] is False
     assert "Ambiguous parameters" in resp1["msg"]
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -723,7 +723,7 @@ def test_zmq_api_move_plan_1(re_manager, params, src, order, success, msg):  # n
     if "after_uid" in params:
         params["after_uid"] = plan_uids[params["after_uid"]]
 
-    resp2, _ = zmq_single_request("queue_plan_move", params)
+    resp2, _ = zmq_single_request("queue_item_move", params)
     if success:
         assert resp2["success"] is True
         assert resp2["plan"] == queue[src]

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -310,7 +310,7 @@ def test_zmq_api_queue_plan_add_5(re_manager):  # noqa: F811
     plan1 = {"name": "count", "args": [["det1", "det2"]]}
 
     # Set plan UID. This UID is expected to be replaced when the plan is added
-    plan1["plan_uid"] = PlanQueueOperations.new_plan_uid()
+    plan1["plan_uid"] = PlanQueueOperations.new_item_uid()
 
     params1 = {"plan": plan1, "user": _user, "user_group": _user_group}
     resp1, _ = zmq_single_request("queue_plan_add", params1)

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -135,7 +135,7 @@ def test_zmq_api_queue_item_add_1(re_manager):  # noqa F811
     assert resp1["plan"]["args"] == _plan1["args"]
     assert resp1["plan"]["user"] == _user
     assert resp1["plan"]["user_group"] == _user_group
-    assert "plan_uid" in resp1["plan"]
+    assert "item_uid" in resp1["plan"]
 
     resp2, _ = zmq_single_request("queue_get")
     assert resp2["queue"] != []
@@ -186,7 +186,7 @@ def test_zmq_api_queue_item_add_2(re_manager, pos, pos_result, success):  # noqa
     assert resp1["plan"]["args"] == plan2["args"]
     assert resp1["plan"]["user"] == _user
     assert resp1["plan"]["user_group"] == _user_group
-    assert "plan_uid" in resp1["plan"]
+    assert "item_uid" in resp1["plan"]
 
     resp2, _ = zmq_single_request("queue_get")
 
@@ -211,24 +211,24 @@ def test_zmq_api_queue_item_add_3(re_manager):  # noqa F811
 
     base_plans = zmq_single_request("queue_get")[0]["queue"]
 
-    params = {"plan": plan3, "after_uid": base_plans[0]["plan_uid"], "user": _user, "user_group": _user_group}
+    params = {"plan": plan3, "after_uid": base_plans[0]["item_uid"], "user": _user, "user_group": _user_group}
     resp1, _ = zmq_single_request("queue_item_add", params)
     assert resp1["success"] is True
     assert resp1["qsize"] == 3
-    uid1 = resp1["plan"]["plan_uid"]
+    uid1 = resp1["plan"]["item_uid"]
     resp1a, _ = zmq_single_request("queue_get")
     assert len(resp1a["queue"]) == 3
-    assert resp1a["queue"][1]["plan_uid"] == uid1
+    assert resp1a["queue"][1]["item_uid"] == uid1
     resp1b, _ = zmq_single_request("queue_item_remove", {"uid": uid1})
     assert resp1b["success"] is True
 
-    params = {"plan": plan3, "before_uid": base_plans[1]["plan_uid"], "user": _user, "user_group": _user_group}
+    params = {"plan": plan3, "before_uid": base_plans[1]["item_uid"], "user": _user, "user_group": _user_group}
     resp2, _ = zmq_single_request("queue_item_add", params)
     assert resp2["success"] is True
-    uid2 = resp2["plan"]["plan_uid"]
+    uid2 = resp2["plan"]["item_uid"]
     resp2a, _ = zmq_single_request("queue_get")
     assert len(resp2a["queue"]) == 3
-    assert resp2a["queue"][1]["plan_uid"] == uid2
+    assert resp2a["queue"][1]["item_uid"] == uid2
     resp2b, _ = zmq_single_request("queue_item_remove", {"uid": uid2})
     assert resp2b["success"] is True
 
@@ -263,7 +263,7 @@ def test_zmq_api_queue_item_add_4(re_manager):  # noqa F811
     assert resp0b["success"] is True
 
     base_plans = zmq_single_request("queue_get")[0]["queue"]
-    uid = base_plans[0]["plan_uid"]
+    uid = base_plans[0]["item_uid"]
 
     # Start the first plan (this removes it from the queue)
     #   Also the rest of the operations will be performed on a running queue.
@@ -310,13 +310,13 @@ def test_zmq_api_queue_item_add_5(re_manager):  # noqa: F811
     plan1 = {"name": "count", "args": [["det1", "det2"]]}
 
     # Set plan UID. This UID is expected to be replaced when the plan is added
-    plan1["plan_uid"] = PlanQueueOperations.new_item_uid()
+    plan1["item_uid"] = PlanQueueOperations.new_item_uid()
 
     params1 = {"plan": plan1, "user": _user, "user_group": _user_group}
     resp1, _ = zmq_single_request("queue_item_add", params1)
     assert resp1["success"] is True
     assert resp1["msg"] == ""
-    assert resp1["plan"]["plan_uid"] != plan1["plan_uid"]
+    assert resp1["plan"]["item_uid"] != plan1["item_uid"]
 
 
 def test_zmq_api_queue_item_add_6(re_manager):  # noqa: F811
@@ -397,7 +397,7 @@ def test_zmq_api_queue_item_add_7_fail(re_manager):  # noqa F811
     assert resp7["plan"]["args"] == [["det1", "det2"]]
     assert resp7["plan"]["user"] == _user
     assert resp7["plan"]["user_group"] == _user_group
-    assert "plan_uid" in resp7["plan"]
+    assert "item_uid" in resp7["plan"]
 
     resp8, _ = zmq_single_request("queue_get")
     assert resp8["queue"] != []
@@ -506,7 +506,7 @@ def test_zmq_api_queue_item_get_remove_1(re_manager):  # noqa F811
     assert resp2["plan"]["name"] == _plan3["name"]
     assert resp2["plan"]["args"] == _plan3["args"]
     assert resp2["plan"]["kwargs"] == _plan3["kwargs"]
-    assert "plan_uid" in resp2["plan"]
+    assert "item_uid" in resp2["plan"]
 
     # Remove the last plan from the queue
     resp3, _ = zmq_single_request("queue_item_remove")
@@ -515,7 +515,7 @@ def test_zmq_api_queue_item_get_remove_1(re_manager):  # noqa F811
     assert resp3["plan"]["name"] == "count"
     assert resp3["plan"]["args"] == [["det1", "det2"]]
     assert resp2["plan"]["kwargs"] == _plan3["kwargs"]
-    assert "plan_uid" in resp3["plan"]
+    assert "item_uid" in resp3["plan"]
 
 
 # fmt: off
@@ -542,9 +542,9 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
     """
 
     plans = [
-        {"plan_uid": "one", "name": "count", "args": [["det1"]]},
-        {"plan_uid": "two", "name": "count", "args": [["det2"]]},
-        {"plan_uid": "three", "name": "count", "args": [["det1", "det2"]]},
+        {"item_uid": "one", "name": "count", "args": [["det1"]]},
+        {"item_uid": "two", "name": "count", "args": [["det2"]]},
+        {"item_uid": "three", "name": "count", "args": [["det1", "det2"]]},
     ]
     for plan in plans:
         resp0, _ = zmq_single_request("queue_item_add", {"plan": plan, "user": _user, "user_group": _user_group})
@@ -558,7 +558,7 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
     assert resp1["success"] is success
     if success:
         assert resp1["plan"]["args"] == plans[pos_result]["args"]
-        assert "plan_uid" in resp1["plan"]
+        assert "item_uid" in resp1["plan"]
         assert resp1["msg"] == ""
     else:
         assert resp1["plan"] == {}
@@ -570,7 +570,7 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
     assert resp2["qsize"] == (2 if success else None)
     if success:
         assert resp2["plan"]["args"] == plans[pos_result]["args"]
-        assert "plan_uid" in resp2["plan"]
+        assert "item_uid" in resp2["plan"]
         assert resp2["msg"] == ""
     else:
         assert resp2["plan"] == {}
@@ -595,13 +595,13 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     assert len(plans_in_queue) == 3
 
     # Get and then remove plan 2 from the queue
-    uid = plans_in_queue[1]["plan_uid"]
+    uid = plans_in_queue[1]["item_uid"]
     resp2a, _ = zmq_single_request("queue_item_get", {"uid": uid})
-    assert resp2a["plan"]["plan_uid"] == plans_in_queue[1]["plan_uid"]
+    assert resp2a["plan"]["item_uid"] == plans_in_queue[1]["item_uid"]
     assert resp2a["plan"]["name"] == plans_in_queue[1]["name"]
     assert resp2a["plan"]["args"] == plans_in_queue[1]["args"]
     resp2b, _ = zmq_single_request("queue_item_remove", {"uid": uid})
-    assert resp2b["plan"]["plan_uid"] == plans_in_queue[1]["plan_uid"]
+    assert resp2b["plan"]["item_uid"] == plans_in_queue[1]["item_uid"]
     assert resp2b["plan"]["name"] == plans_in_queue[1]["name"]
     assert resp2b["plan"]["args"] == plans_in_queue[1]["args"]
 
@@ -617,7 +617,7 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     assert resp4["success"] is True
 
     ttime.sleep(1)
-    uid = plans_in_queue[0]["plan_uid"]
+    uid = plans_in_queue[0]["item_uid"]
     resp5a, _ = zmq_single_request("queue_item_get", {"uid": uid})
     assert resp5a["success"] is False
     assert "is currently running" in resp5a["msg"]
@@ -634,7 +634,7 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     assert "not in the queue" in resp6b["msg"]
 
     # Remove the last entry
-    uid = plans_in_queue[2]["plan_uid"]
+    uid = plans_in_queue[2]["item_uid"]
     resp7a, _ = zmq_single_request("queue_item_get", {"uid": uid})
     assert resp7a["success"] is True
     resp7b, _ = zmq_single_request("queue_item_remove", {"uid": uid})
@@ -711,17 +711,17 @@ def test_zmq_api_move_plan_1(re_manager, params, src, order, success, msg):  # n
     queue = resp1["queue"]
     assert len(queue) == 3
 
-    plan_uids = [_["plan_uid"] for _ in queue]
+    item_uids = [_["item_uid"] for _ in queue]
     # Add one more 'nonexistent' uid (that is not in the queue)
-    plan_uids.append("nonexistent")
+    item_uids.append("nonexistent")
 
     # Replace indices with actual UIDs that will be sent to the function
     if "uid" in params:
-        params["uid"] = plan_uids[params["uid"]]
+        params["uid"] = item_uids[params["uid"]]
     if "before_uid" in params:
-        params["before_uid"] = plan_uids[params["before_uid"]]
+        params["before_uid"] = item_uids[params["before_uid"]]
     if "after_uid" in params:
-        params["after_uid"] = plan_uids[params["after_uid"]]
+        params["after_uid"] = item_uids[params["after_uid"]]
 
     resp2, _ = zmq_single_request("queue_item_move", params)
     if success:
@@ -731,11 +731,11 @@ def test_zmq_api_move_plan_1(re_manager, params, src, order, success, msg):  # n
         assert resp2["msg"] == ""
 
         # Compare the order of UIDs in the queue with the expected order
-        plan_uids_reordered = [plan_uids[_] for _ in order]
+        item_uids_reordered = [item_uids[_] for _ in order]
         resp3, _ = zmq_single_request("queue_get")
-        plan_uids_from_queue = [_["plan_uid"] for _ in resp3["queue"]]
+        item_uids_from_queue = [_["item_uid"] for _ in resp3["queue"]]
 
-        assert plan_uids_from_queue == plan_uids_reordered
+        assert item_uids_from_queue == item_uids_reordered
 
     else:
         assert resp2["success"] is False

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -555,7 +555,7 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
     # Remove entry at the specified position
     params = {} if pos is None else {"pos": pos}
 
-    # Testing '/queue/plan/get'
+    # Testing 'queue_item_get'
     resp1, _ = zmq_single_request("queue_item_get", params)
     assert resp1["success"] is success
     if success:
@@ -566,7 +566,7 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
         assert resp1["plan"] == {}
         assert "Failed to get an item" in resp1["msg"]
 
-    # Testing '/queue/plan/remove'
+    # Testing 'queue_item_remove'
     resp2, _ = zmq_single_request("queue_item_remove", params)
     assert resp2["success"] is success
     assert resp2["qsize"] == (2 if success else None)

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -101,7 +101,7 @@ def test_zmq_api_environment_open_close_3(re_manager):  # noqa F811
     assert wait_for_condition(time=3, condition=condition_environment_created)
 
     # Start a plan
-    resp2, _ = zmq_single_request("queue_plan_add", {"plan": _plan3, "user": _user, "user_group": _user_group})
+    resp2, _ = zmq_single_request("queue_item_add", {"plan": _plan3, "user": _user, "user_group": _user_group})
     assert resp2["success"] is True
     resp3, _ = zmq_single_request("queue_start")
     assert resp3["success"] is True
@@ -121,14 +121,14 @@ def test_zmq_api_environment_open_close_3(re_manager):  # noqa F811
 
 
 # =======================================================================================
-#                             Method 'queue_plan_add'
+#                             Method 'queue_item_add'
 
 
-def test_zmq_api_queue_plan_add_1(re_manager):  # noqa F811
+def test_zmq_api_queue_item_add_1(re_manager):  # noqa F811
     """
-    Basic test for `queue_plan_add` method.
+    Basic test for `queue_item_add` method.
     """
-    resp1, _ = zmq_single_request("queue_plan_add", {"plan": _plan1, "user": _user, "user_group": _user_group})
+    resp1, _ = zmq_single_request("queue_item_add", {"plan": _plan1, "user": _user, "user_group": _user_group})
     assert resp1["success"] is True
     assert resp1["qsize"] == 1
     assert resp1["plan"]["name"] == _plan1["name"]
@@ -161,16 +161,16 @@ def test_zmq_api_queue_plan_add_1(re_manager):  # noqa F811
     (-100, 0, True),
 ])
 # fmt: on
-def test_zmq_api_queue_plan_add_2(re_manager, pos, pos_result, success):  # noqa F811
+def test_zmq_api_queue_item_add_2(re_manager, pos, pos_result, success):  # noqa F811
 
     plan1 = {"name": "count", "args": [["det1"]]}
     plan2 = {"name": "count", "args": [["det1", "det2"]]}
 
     # Create the queue with 2 entries
     params1 = {"plan": plan1, "user": _user, "user_group": _user_group}
-    resp0a, _ = zmq_single_request("queue_plan_add", params1)
+    resp0a, _ = zmq_single_request("queue_item_add", params1)
     assert resp0a["success"] is True
-    resp0b, _ = zmq_single_request("queue_plan_add", params1)
+    resp0b, _ = zmq_single_request("queue_item_add", params1)
     assert resp0b["success"] is True
 
     # Add another entry at the specified position
@@ -178,7 +178,7 @@ def test_zmq_api_queue_plan_add_2(re_manager, pos, pos_result, success):  # noqa
     if pos is not None:
         params2.update({"pos": pos})
 
-    resp1, _ = zmq_single_request("queue_plan_add", params2)
+    resp1, _ = zmq_single_request("queue_item_add", params2)
 
     assert resp1["success"] is success
     assert resp1["qsize"] == (3 if success else None)
@@ -197,22 +197,22 @@ def test_zmq_api_queue_plan_add_2(re_manager, pos, pos_result, success):  # noqa
         assert resp2["queue"][pos_result]["args"] == plan2["args"]
 
 
-def test_zmq_api_queue_plan_add_3(re_manager):  # noqa F811
+def test_zmq_api_queue_item_add_3(re_manager):  # noqa F811
     plan1 = {"name": "count", "args": [["det1"]]}
     plan2 = {"name": "count", "args": [["det1", "det2"]]}
     plan3 = {"name": "count", "args": [["det2"]]}
 
     params = {"plan": plan1, "user": _user, "user_group": _user_group}
-    resp0a, _ = zmq_single_request("queue_plan_add", params)
+    resp0a, _ = zmq_single_request("queue_item_add", params)
     assert resp0a["success"] is True
     params = {"plan": plan2, "user": _user, "user_group": _user_group}
-    resp0b, _ = zmq_single_request("queue_plan_add", params)
+    resp0b, _ = zmq_single_request("queue_item_add", params)
     assert resp0b["success"] is True
 
     base_plans = zmq_single_request("queue_get")[0]["queue"]
 
     params = {"plan": plan3, "after_uid": base_plans[0]["plan_uid"], "user": _user, "user_group": _user_group}
-    resp1, _ = zmq_single_request("queue_plan_add", params)
+    resp1, _ = zmq_single_request("queue_item_add", params)
     assert resp1["success"] is True
     assert resp1["qsize"] == 3
     uid1 = resp1["plan"]["plan_uid"]
@@ -223,7 +223,7 @@ def test_zmq_api_queue_plan_add_3(re_manager):  # noqa F811
     assert resp1b["success"] is True
 
     params = {"plan": plan3, "before_uid": base_plans[1]["plan_uid"], "user": _user, "user_group": _user_group}
-    resp2, _ = zmq_single_request("queue_plan_add", params)
+    resp2, _ = zmq_single_request("queue_item_add", params)
     assert resp2["success"] is True
     uid2 = resp2["plan"]["plan_uid"]
     resp2a, _ = zmq_single_request("queue_get")
@@ -234,32 +234,32 @@ def test_zmq_api_queue_plan_add_3(re_manager):  # noqa F811
 
     # Non-existing uid
     params = {"plan": plan3, "before_uid": "non-existing-uid", "user": _user, "user_group": _user_group}
-    resp2, _ = zmq_single_request("queue_plan_add", params)
+    resp2, _ = zmq_single_request("queue_item_add", params)
     assert resp2["success"] is False
     assert "is not in the queue" in resp2["msg"]
 
     # Ambiguous parameters
     params = {"plan": plan3, "pos": 1, "before_uid": uid2, "user": _user, "user_group": _user_group}
-    resp2, _ = zmq_single_request("queue_plan_add", params)
+    resp2, _ = zmq_single_request("queue_item_add", params)
     assert resp2["success"] is False
     assert "Ambiguous parameters" in resp2["msg"]
 
     # Ambiguous parameters
     params = {"plan": plan3, "before_uid": uid2, "after_uid": uid2, "user": _user, "user_group": _user_group}
-    resp2, _ = zmq_single_request("queue_plan_add", params)
+    resp2, _ = zmq_single_request("queue_item_add", params)
     assert resp2["success"] is False
     assert "Ambiguous parameters" in resp2["msg"]
 
 
-def test_zmq_api_queue_plan_add_4(re_manager):  # noqa F811
+def test_zmq_api_queue_item_add_4(re_manager):  # noqa F811
     """
     Try inserting plans before and after the running plan
     """
     params = {"plan": _plan3, "user": _user, "user_group": _user_group}
-    resp0a, _ = zmq_single_request("queue_plan_add", params)
+    resp0a, _ = zmq_single_request("queue_item_add", params)
     assert resp0a["success"] is True
     params = {"plan": _plan3, "user": _user, "user_group": _user_group}
-    resp0b, _ = zmq_single_request("queue_plan_add", params)
+    resp0b, _ = zmq_single_request("queue_item_add", params)
     assert resp0b["success"] is True
 
     base_plans = zmq_single_request("queue_get")[0]["queue"]
@@ -280,13 +280,13 @@ def test_zmq_api_queue_plan_add_4(re_manager):  # noqa F811
 
     # Try to insert a plan before the running plan
     params = {"plan": _plan3, "before_uid": uid, "user": _user, "user_group": _user_group}
-    resp3, _ = zmq_single_request("queue_plan_add", params)
+    resp3, _ = zmq_single_request("queue_item_add", params)
     assert resp3["success"] is False
     assert "Can not insert a plan in the queue before a currently running plan" in resp3["msg"]
 
     # Insert the plan after the running plan
     params = {"plan": _plan3, "after_uid": uid, "user": _user, "user_group": _user_group}
-    resp4, _ = zmq_single_request("queue_plan_add", params)
+    resp4, _ = zmq_single_request("queue_item_add", params)
     assert resp4["success"] is True
 
     assert wait_for_condition(
@@ -303,7 +303,7 @@ def test_zmq_api_queue_plan_add_4(re_manager):  # noqa F811
     assert wait_for_condition(time=5, condition=condition_environment_closed)
 
 
-def test_zmq_api_queue_plan_add_5(re_manager):  # noqa: F811
+def test_zmq_api_queue_item_add_5(re_manager):  # noqa: F811
     """
     Make sure that the new plan UID is generated when the plan is added
     """
@@ -313,29 +313,29 @@ def test_zmq_api_queue_plan_add_5(re_manager):  # noqa: F811
     plan1["plan_uid"] = PlanQueueOperations.new_item_uid()
 
     params1 = {"plan": plan1, "user": _user, "user_group": _user_group}
-    resp1, _ = zmq_single_request("queue_plan_add", params1)
+    resp1, _ = zmq_single_request("queue_item_add", params1)
     assert resp1["success"] is True
     assert resp1["msg"] == ""
     assert resp1["plan"]["plan_uid"] != plan1["plan_uid"]
 
 
-def test_zmq_api_queue_plan_add_6(re_manager):  # noqa: F811
+def test_zmq_api_queue_item_add_6(re_manager):  # noqa: F811
     """
     Add instruction ('queue_stop') to the queue.
     """
 
     params1a = {"plan": _plan1, "user": _user, "user_group": _user_group}
-    resp1a, _ = zmq_single_request("queue_plan_add", params1a)
+    resp1a, _ = zmq_single_request("queue_item_add", params1a)
     assert resp1a["success"] is True, f"resp={resp1a}"
 
     params1 = {"instruction": _instruction_stop, "user": _user, "user_group": _user_group}
-    resp1, _ = zmq_single_request("queue_plan_add", params1)
+    resp1, _ = zmq_single_request("queue_item_add", params1)
     assert resp1["success"] is True, f"resp={resp1}"
     assert resp1["msg"] == ""
     assert resp1["instruction"]["action"] == "queue_stop"
 
     params1c = {"plan": _plan2, "user": _user, "user_group": _user_group}
-    resp1c, _ = zmq_single_request("queue_plan_add", params1c)
+    resp1c, _ = zmq_single_request("queue_item_add", params1c)
     assert resp1c["success"] is True, f"resp={resp1c}"
 
     resp2, _ = zmq_single_request("queue_get")
@@ -345,43 +345,43 @@ def test_zmq_api_queue_plan_add_6(re_manager):  # noqa: F811
     assert resp2["queue"][2]["item_type"] == "plan"
 
 
-def test_zmq_api_queue_plan_add_7_fail(re_manager):  # noqa F811
+def test_zmq_api_queue_item_add_7_fail(re_manager):  # noqa F811
 
     # Unknown plan name
     plan1 = {"name": "count_test", "args": [["det1", "det2"]]}
     params1 = {"plan": plan1, "user": _user, "user_group": _user_group}
-    resp1, _ = zmq_single_request("queue_plan_add", params1)
+    resp1, _ = zmq_single_request("queue_item_add", params1)
     assert resp1["success"] is False
     assert "Plan 'count_test' is not in the list of allowed plans" in resp1["msg"]
 
     # Unknown kwarg
     plan2 = {"name": "count", "args": [["det1", "det2"]], "kwargs": {"abc": 10}}
     params2 = {"plan": plan2, "user": _user, "user_group": _user_group}
-    resp2, _ = zmq_single_request("queue_plan_add", params2)
+    resp2, _ = zmq_single_request("queue_item_add", params2)
     assert resp2["success"] is False
     assert "Failed to add a plan: Plan validation failed: got an unexpected keyword argument 'abc'" in resp2["msg"]
 
     # User name is not specified
     params3 = {"plan": plan2, "user_group": _user_group}
-    resp3, _ = zmq_single_request("queue_plan_add", params3)
+    resp3, _ = zmq_single_request("queue_item_add", params3)
     assert resp3["success"] is False
     assert "user name is not specified" in resp3["msg"]
 
     # User group is not specified
     params4 = {"plan": plan2, "user": _user}
-    resp4, _ = zmq_single_request("queue_plan_add", params4)
+    resp4, _ = zmq_single_request("queue_item_add", params4)
     assert resp4["success"] is False
     assert "user group is not specified" in resp4["msg"]
 
     # User group is not specified
     params5 = {"plan": plan2, "user": _user, "user_group": "no_such_group"}
-    resp5, _ = zmq_single_request("queue_plan_add", params5)
+    resp5, _ = zmq_single_request("queue_item_add", params5)
     assert resp5["success"] is False
     assert "Unknown user group: 'no_such_group'" in resp5["msg"]
 
     # User group is not specified
     params6 = {"user": _user, "user_group": "no_such_group"}
-    resp6, _ = zmq_single_request("queue_plan_add", params6)
+    resp6, _ = zmq_single_request("queue_item_add", params6)
     assert resp6["success"] is False
     assert "plan" not in resp6
     assert "instruction" not in resp6
@@ -390,7 +390,7 @@ def test_zmq_api_queue_plan_add_7_fail(re_manager):  # noqa F811
     # Valid plan
     plan7 = {"name": "count", "args": [["det1", "det2"]]}
     params7 = {"plan": plan7, "user": _user, "user_group": _user_group}
-    resp7, _ = zmq_single_request("queue_plan_add", params7)
+    resp7, _ = zmq_single_request("queue_item_add", params7)
     assert resp7["success"] is True
     assert resp7["qsize"] == 1
     assert resp7["plan"]["name"] == "count"
@@ -492,7 +492,7 @@ def test_zmq_api_queue_plan_get_remove_1(re_manager):  # noqa F811
     """
     plans = [_plan1, _plan2, _plan3]
     for plan in plans:
-        resp0, _ = zmq_single_request("queue_plan_add", {"plan": plan, "user": _user, "user_group": _user_group})
+        resp0, _ = zmq_single_request("queue_item_add", {"plan": plan, "user": _user, "user_group": _user_group})
         assert resp0["success"] is True
 
     resp1, _ = zmq_single_request("queue_get")
@@ -547,7 +547,7 @@ def test_zmq_api_queue_plan_get_remove_2(re_manager, pos, pos_result, success): 
         {"plan_uid": "three", "name": "count", "args": [["det1", "det2"]]},
     ]
     for plan in plans:
-        resp0, _ = zmq_single_request("queue_plan_add", {"plan": plan, "user": _user, "user_group": _user_group})
+        resp0, _ = zmq_single_request("queue_item_add", {"plan": plan, "user": _user, "user_group": _user_group})
         assert resp0["success"] is True
 
     # Remove entry at the specified position
@@ -587,7 +587,7 @@ def test_zmq_api_queue_plan_get_remove_3(re_manager):  # noqa F811
     """
     plans = [_plan3, _plan2, _plan1]
     for plan in plans:
-        resp0, _ = zmq_single_request("queue_plan_add", {"plan": plan, "user": _user, "user_group": _user_group})
+        resp0, _ = zmq_single_request("queue_item_add", {"plan": plan, "user": _user, "user_group": _user_group})
         assert resp0["success"] is True
 
     resp1, _ = zmq_single_request("queue_get")
@@ -704,7 +704,7 @@ def test_zmq_api_queue_plan_get_remove_4_failing(re_manager):  # noqa F811
 def test_zmq_api_move_plan_1(re_manager, params, src, order, success, msg):  # noqa: F811
     plans = [_plan1, _plan2, _plan3]
     for plan in plans:
-        resp0, _ = zmq_single_request("queue_plan_add", {"plan": plan, "user": _user, "user_group": _user_group})
+        resp0, _ = zmq_single_request("queue_item_add", {"plan": plan, "user": _user, "user_group": _user_group})
         assert resp0["success"] is True
 
     resp1, _ = zmq_single_request("queue_get")
@@ -753,26 +753,26 @@ def test_zmq_api_queue_execution_1(re_manager):  # noqa: F811
 
     # Instruction STOP
     params1a = {"instruction": _instruction_stop, "user": _user, "user_group": _user_group}
-    resp1a, _ = zmq_single_request("queue_plan_add", params1a)
+    resp1a, _ = zmq_single_request("queue_item_add", params1a)
     assert resp1a["success"] is True, f"resp={resp1a}"
     assert resp1a["msg"] == ""
     assert resp1a["instruction"]["action"] == "queue_stop"
 
     # Plan
     params1b = {"plan": _plan1, "user": _user, "user_group": _user_group}
-    resp1b, _ = zmq_single_request("queue_plan_add", params1b)
+    resp1b, _ = zmq_single_request("queue_item_add", params1b)
     assert resp1b["success"] is True, f"resp={resp1b}"
 
     # Instruction STOP
     params1c = {"instruction": _instruction_stop, "user": _user, "user_group": _user_group}
-    resp1c, _ = zmq_single_request("queue_plan_add", params1c)
+    resp1c, _ = zmq_single_request("queue_item_add", params1c)
     assert resp1c["success"] is True, f"resp={resp1c}"
     assert resp1c["msg"] == ""
     assert resp1c["instruction"]["action"] == "queue_stop"
 
     # Plan
     params1d = {"plan": _plan2, "user": _user, "user_group": _user_group}
-    resp1d, _ = zmq_single_request("queue_plan_add", params1d)
+    resp1d, _ = zmq_single_request("queue_item_add", params1d)
     assert resp1d["success"] is True, f"resp={resp1d}"
 
     # The queue contains only a single instruction (stop the queue).

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -219,7 +219,7 @@ def test_zmq_api_queue_item_add_3(re_manager):  # noqa F811
     resp1a, _ = zmq_single_request("queue_get")
     assert len(resp1a["queue"]) == 3
     assert resp1a["queue"][1]["plan_uid"] == uid1
-    resp1b, _ = zmq_single_request("queue_plan_remove", {"uid": uid1})
+    resp1b, _ = zmq_single_request("queue_item_remove", {"uid": uid1})
     assert resp1b["success"] is True
 
     params = {"plan": plan3, "before_uid": base_plans[1]["plan_uid"], "user": _user, "user_group": _user_group}
@@ -229,7 +229,7 @@ def test_zmq_api_queue_item_add_3(re_manager):  # noqa F811
     resp2a, _ = zmq_single_request("queue_get")
     assert len(resp2a["queue"]) == 3
     assert resp2a["queue"][1]["plan_uid"] == uid2
-    resp2b, _ = zmq_single_request("queue_plan_remove", {"uid": uid2})
+    resp2b, _ = zmq_single_request("queue_item_remove", {"uid": uid2})
     assert resp2b["success"] is True
 
     # Non-existing uid
@@ -483,7 +483,7 @@ def test_zmq_api_plans_allowed_and_devices_allowed_3_fail(re_manager, params, me
 
 
 # =======================================================================================
-#                      Method 'queue_item_get', 'queue_plan_remove'
+#                      Method 'queue_item_get', 'queue_item_remove'
 
 
 def test_zmq_api_queue_item_get_remove_1(re_manager):  # noqa F811
@@ -509,7 +509,7 @@ def test_zmq_api_queue_item_get_remove_1(re_manager):  # noqa F811
     assert "plan_uid" in resp2["plan"]
 
     # Remove the last plan from the queue
-    resp3, _ = zmq_single_request("queue_plan_remove")
+    resp3, _ = zmq_single_request("queue_item_remove")
     assert resp3["success"] is True
     assert resp3["qsize"] == 2
     assert resp3["plan"]["name"] == "count"
@@ -565,7 +565,7 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
         assert "Failed to get a plan" in resp1["msg"]
 
     # Testing '/queue/plan/remove'
-    resp2, _ = zmq_single_request("queue_plan_remove", params)
+    resp2, _ = zmq_single_request("queue_item_remove", params)
     assert resp2["success"] is success
     assert resp2["qsize"] == (2 if success else None)
     if success:
@@ -600,7 +600,7 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     assert resp2a["plan"]["plan_uid"] == plans_in_queue[1]["plan_uid"]
     assert resp2a["plan"]["name"] == plans_in_queue[1]["name"]
     assert resp2a["plan"]["args"] == plans_in_queue[1]["args"]
-    resp2b, _ = zmq_single_request("queue_plan_remove", {"uid": uid})
+    resp2b, _ = zmq_single_request("queue_item_remove", {"uid": uid})
     assert resp2b["plan"]["plan_uid"] == plans_in_queue[1]["plan_uid"]
     assert resp2b["plan"]["name"] == plans_in_queue[1]["name"]
     assert resp2b["plan"]["args"] == plans_in_queue[1]["args"]
@@ -621,7 +621,7 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     resp5a, _ = zmq_single_request("queue_item_get", {"uid": uid})
     assert resp5a["success"] is False
     assert "is currently running" in resp5a["msg"]
-    resp5b, _ = zmq_single_request("queue_plan_remove", {"uid": uid})
+    resp5b, _ = zmq_single_request("queue_item_remove", {"uid": uid})
     assert resp5b["success"] is False
     assert "Can not remove a plan which is currently running" in resp5b["msg"]
 
@@ -629,7 +629,7 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     resp6a, _ = zmq_single_request("queue_item_get", {"uid": uid})
     assert resp6a["success"] is False
     assert "not in the queue" in resp6a["msg"]
-    resp6b, _ = zmq_single_request("queue_plan_remove", {"uid": uid})
+    resp6b, _ = zmq_single_request("queue_item_remove", {"uid": uid})
     assert resp6b["success"] is False
     assert "not in the queue" in resp6b["msg"]
 
@@ -637,7 +637,7 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     uid = plans_in_queue[2]["plan_uid"]
     resp7a, _ = zmq_single_request("queue_item_get", {"uid": uid})
     assert resp7a["success"] is True
-    resp7b, _ = zmq_single_request("queue_plan_remove", {"uid": uid})
+    resp7b, _ = zmq_single_request("queue_item_remove", {"uid": uid})
     assert resp7b["success"] is True
 
     assert wait_for_condition(

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -294,8 +294,8 @@ def test_zmq_api_queue_item_add_4(re_manager):  # noqa F811
     ), "Timeout while waiting for environment to be opened"
 
     state = get_queue_state()
-    assert state["plans_in_queue"] == 0
-    assert state["plans_in_history"] == 3
+    assert state["items_in_queue"] == 0
+    assert state["items_in_history"] == 3
 
     # Close the environment
     resp5, _ = zmq_single_request("environment_close")
@@ -359,7 +359,7 @@ def test_zmq_api_queue_item_add_7_fail(re_manager):  # noqa F811
     params2 = {"plan": plan2, "user": _user, "user_group": _user_group}
     resp2, _ = zmq_single_request("queue_item_add", params2)
     assert resp2["success"] is False
-    assert "Failed to add a plan: Plan validation failed: got an unexpected keyword argument 'abc'" in resp2["msg"]
+    assert "Failed to add an item: Plan validation failed: got an unexpected keyword argument 'abc'" in resp2["msg"]
 
     # User name is not specified
     params3 = {"plan": plan2, "user_group": _user_group}
@@ -562,7 +562,7 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
         assert resp1["msg"] == ""
     else:
         assert resp1["plan"] == {}
-        assert "Failed to get a plan" in resp1["msg"]
+        assert "Failed to get an item" in resp1["msg"]
 
     # Testing '/queue/plan/remove'
     resp2, _ = zmq_single_request("queue_item_remove", params)
@@ -574,7 +574,7 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
         assert resp2["msg"] == ""
     else:
         assert resp2["plan"] == {}
-        assert "Failed to remove a plan" in resp2["msg"]
+        assert "Failed to remove an item" in resp2["msg"]
 
     resp3, _ = zmq_single_request("queue_get")
     assert len(resp3["queue"]) == (2 if success else 3)
@@ -645,8 +645,8 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     ), "Timeout while waiting for environment to be opened"
 
     state = get_queue_state()
-    assert state["plans_in_queue"] == 0
-    assert state["plans_in_history"] == 1
+    assert state["items_in_queue"] == 0
+    assert state["items_in_history"] == 1
 
     # Close the environment
     resp8, _ = zmq_single_request("environment_close")
@@ -781,8 +781,8 @@ def test_zmq_api_queue_execution_1(re_manager):  # noqa: F811
     assert wait_for_condition(time=10, condition=condition_environment_created)
 
     resp2a, _ = zmq_single_request("status")
-    assert resp2a["plans_in_queue"] == 4
-    assert resp2a["plans_in_history"] == 0
+    assert resp2a["items_in_queue"] == 4
+    assert resp2a["items_in_history"] == 0
 
     resp3, _ = zmq_single_request("queue_start")
     assert resp3["success"] is True
@@ -790,8 +790,8 @@ def test_zmq_api_queue_execution_1(re_manager):  # noqa: F811
     assert wait_for_condition(time=5, condition=condition_manager_idle)
 
     resp3a, _ = zmq_single_request("status")
-    assert resp3a["plans_in_queue"] == 3
-    assert resp3a["plans_in_history"] == 0
+    assert resp3a["items_in_queue"] == 3
+    assert resp3a["items_in_history"] == 0
 
     resp4, _ = zmq_single_request("queue_start")
     assert resp4["success"] is True
@@ -799,8 +799,8 @@ def test_zmq_api_queue_execution_1(re_manager):  # noqa: F811
     assert wait_for_condition(time=5, condition=condition_manager_idle)
 
     resp4a, _ = zmq_single_request("status")
-    assert resp4a["plans_in_queue"] == 1
-    assert resp4a["plans_in_history"] == 1
+    assert resp4a["items_in_queue"] == 1
+    assert resp4a["items_in_history"] == 1
 
     resp5, _ = zmq_single_request("queue_start")
     assert resp5["success"] is True
@@ -808,8 +808,8 @@ def test_zmq_api_queue_execution_1(re_manager):  # noqa: F811
     assert wait_for_condition(time=5, condition=condition_queue_processing_finished)
 
     resp5a, _ = zmq_single_request("status")
-    assert resp5a["plans_in_queue"] == 0
-    assert resp5a["plans_in_history"] == 2
+    assert resp5a["items_in_queue"] == 0
+    assert resp5a["items_in_history"] == 2
 
     # Close the environment
     resp6, _ = zmq_single_request("environment_close")

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -625,7 +625,7 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     assert "is currently running" in resp5a["msg"]
     resp5b, _ = zmq_single_request("queue_item_remove", {"uid": uid})
     assert resp5b["success"] is False
-    assert "Can not remove a plan which is currently running" in resp5b["msg"]
+    assert "Can not remove an item which is currently running" in resp5b["msg"]
 
     uid = "nonexistent"
     resp6a, _ = zmq_single_request("queue_item_get", {"uid": uid})

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -248,13 +248,13 @@ class RunEngineWorker(Process):
         """
         Returns the state information of RE Worker environment.
         """
-        plan_uid = self._state["running_plan"]["plan_uid"] if self._state["running_plan"] else None
+        item_uid = self._state["running_plan"]["item_uid"] if self._state["running_plan"] else None
         plan_completed = self._state["running_plan_completed"]
         re_state = str(self._RE._state) if self._RE else "null"
         env_state = self._state["environment_state"]
         re_report_available = self._re_report is not None
         msg_out = {
-            "running_plan_uid": plan_uid,
+            "running_item_uid": item_uid,
             "running_plan_completed": plan_completed,
             "re_report_available": re_report_available,
             "re_state": re_state,

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -182,7 +182,7 @@ async def qqueue_item_remove_handler(payload: dict):
     return msg
 
 
-@app.post("/queue/plan/move")
+@app.post("/queue/item/move")
 async def queue_item_move_handler(payload: dict):
     """
     Remove plan from the queue

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -174,11 +174,11 @@ async def queue_item_add_handler(payload: dict):
 
 
 @app.post("/queue/plan/remove")
-async def queue_plan_remove_handler(payload: dict):
+async def qqueue_item_remove_handler(payload: dict):
     """
     Remove plan from the queue
     """
-    msg = await zmq_to_manager.send_message(method="queue_plan_remove", params=payload)
+    msg = await zmq_to_manager.send_message(method="queue_item_remove", params=payload)
     return msg
 
 

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -160,7 +160,7 @@ async def queue_stop_cancel():
     return msg
 
 
-@app.post("/queue/plan/add")
+@app.post("/queue/item/add")
 async def queue_item_add_handler(payload: dict):
     """
     Adds new plan to the queue
@@ -173,7 +173,7 @@ async def queue_item_add_handler(payload: dict):
     return msg
 
 
-@app.post("/queue/plan/remove")
+@app.post("/queue/item/remove")
 async def qqueue_item_remove_handler(payload: dict):
     """
     Remove plan from the queue

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -183,11 +183,11 @@ async def qqueue_item_remove_handler(payload: dict):
 
 
 @app.post("/queue/plan/move")
-async def queue_plan_move_handler(payload: dict):
+async def queue_item_move_handler(payload: dict):
     """
     Remove plan from the queue
     """
-    msg = await zmq_to_manager.send_message(method="queue_plan_move", params=payload)
+    msg = await zmq_to_manager.send_message(method="queue_item_move", params=payload)
     return msg
 
 

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -192,11 +192,11 @@ async def queue_plan_move_handler(payload: dict):
 
 
 @app.post("/queue/plan/get")
-async def queue_plan_get_handler(payload: dict):
+async def queue_item_get_handler(payload: dict):
     """
     Get a plan from the queue
     """
-    msg = await zmq_to_manager.send_message(method="queue_plan_get", params=payload)
+    msg = await zmq_to_manager.send_message(method="queue_item_get", params=payload)
     return msg
 
 

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -161,7 +161,7 @@ async def queue_stop_cancel():
 
 
 @app.post("/queue/plan/add")
-async def queue_plan_add_handler(payload: dict):
+async def queue_item_add_handler(payload: dict):
     """
     Adds new plan to the queue
     """
@@ -169,7 +169,7 @@ async def queue_plan_add_handler(payload: dict):
     params = payload
     params["user"] = _login_data["user"]
     params["user_group"] = _login_data["user_group"]
-    msg = await zmq_to_manager.send_message(method="queue_plan_add", params=params)
+    msg = await zmq_to_manager.send_message(method="queue_item_add", params=params)
     return msg
 
 

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -191,7 +191,7 @@ async def queue_item_move_handler(payload: dict):
     return msg
 
 
-@app.post("/queue/plan/get")
+@app.post("/queue/item/get")
 async def queue_item_get_handler(payload: dict):
     """
     Get a plan from the queue

--- a/bluesky_queueserver/server/tests/conftest.py
+++ b/bluesky_queueserver/server/tests/conftest.py
@@ -33,13 +33,13 @@ def add_plans_to_queue():
         [
             "qserver",
             "-c",
-            "queue_plan_add",
+            "queue_item_add",
             "-p",
             "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':10, 'delay':1}}",
         ]
     )
-    subprocess.call(["qserver", "-c", "queue_plan_add", "-p", "{'name':'count', 'args':[['det1', 'det2']]}"])
-    subprocess.call(["qserver", "-c", "queue_plan_add", "-p", "{'name':'count', 'args':[['det1', 'det2']]}"])
+    subprocess.call(["qserver", "-c", "queue_item_add", "-p", "{'name':'count', 'args':[['det1', 'det2']]}"])
+    subprocess.call(["qserver", "-c", "queue_item_add", "-p", "{'name':'count', 'args':[['det1', 'det2']]}"])
 
     yield
 

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -197,7 +197,7 @@ def test_http_server_queue_item_add_handler_6_fail(re_manager, fastapi_server): 
     assert "Incorrect request format: request contains no item info." in resp1["msg"]
 
 
-def test_http_server_queue_plan_get_remove_handler_1(re_manager, fastapi_server, add_plans_to_queue):  # noqa F811
+def test_http_server_queue_item_get_remove_handler_1(re_manager, fastapi_server, add_plans_to_queue):  # noqa F811
 
     resp1 = _request_to_json("get", "/queue/get")
     assert resp1["queue"] != []
@@ -236,7 +236,7 @@ def test_http_server_queue_plan_get_remove_handler_1(re_manager, fastapi_server,
     (-100, 0, False),
 ])
 # fmt: on
-def test_http_server_queue_plan_get_remove_handler_2(
+def test_http_server_queue_item_get_remove_handler_2(
     re_manager, fastapi_server, pos, pos_result, success  # noqa F811
 ):
     plans = [
@@ -278,10 +278,10 @@ def test_http_server_queue_plan_get_remove_handler_2(
     assert resp3["running_plan"] == {}
 
 
-def test_http_server_queue_plan_get_remove_3(re_manager, fastapi_server):  # noqa F811
+def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noqa F811
     """
     Get and remove elements using plan UID. Successful and failing cases.
-    Note: the test is derived from ZMQ API test ``test_zmq_api_queue_plan_get_remove_3()``
+    Note: the test is derived from ZMQ API test ``test_zmq_api_queue_item_get_remove_3()``
     """
     _request_to_json("post", "/queue/plan/add", json={"plan": _plan3})
     _request_to_json("post", "/queue/plan/add", json={"plan": _plan2})
@@ -342,10 +342,10 @@ def test_http_server_queue_plan_get_remove_3(re_manager, fastapi_server):  # noq
     assert state["plans_in_history"] == 1
 
 
-def test_http_server_queue_plan_get_remove_4_failing(re_manager, fastapi_server):  # noqa F811
+def test_http_server_queue_item_get_remove_4_failing(re_manager, fastapi_server):  # noqa F811
     """
     Failing cases that are not tested in other places.
-    Note: derived from ``test_zmq_api_queue_plan_get_remove_4_failing()``
+    Note: derived from ``test_zmq_api_queue_item_get_remove_4_failing()``
     """
     # Ambiguous parameters
     resp1 = _request_to_json("post", "/queue/plan/get", json={"pos": 5, "uid": "some_uid"})

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -143,7 +143,9 @@ def test_http_server_queue_item_add_handler_3(re_manager, fastapi_server):  # no
     plan2 = {"plan": {"name": "count", "args": [["det1", "det2"]], "kwargs": {"abc": 10}}}
     resp2 = _request_to_json("post", "/queue/plan/add", json=plan2)
     assert resp2["success"] is False
-    assert "Failed to add an item: Plan validation failed: got an unexpected keyword argument 'abc'" in resp2["msg"]
+    assert (
+        "Failed to add an item: Plan validation failed: got an unexpected keyword argument 'abc'" in resp2["msg"]
+    )
 
     # Valid plan
     plan3 = {"plan": {"name": "count", "args": [["det1", "det2"]]}}

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -38,8 +38,8 @@ def test_http_server_ping_handler(re_manager, fastapi_server):  # noqa F811
     resp = _request_to_json("get", "/")
     assert resp["msg"] == "RE Manager"
     assert resp["manager_state"] == "idle"
-    assert resp["plans_in_queue"] == 0
-    assert resp["running_plan_uid"] is None
+    assert resp["items_in_queue"] == 0
+    assert resp["running_item_uid"] is None
     assert resp["worker_environment_exists"] is False
 
 
@@ -47,8 +47,8 @@ def test_http_server_status_handler(re_manager, fastapi_server):  # noqa F811
     resp = _request_to_json("get", "/status")
     assert resp["msg"] == "RE Manager"
     assert resp["manager_state"] == "idle"
-    assert resp["plans_in_queue"] == 0
-    assert resp["running_plan_uid"] is None
+    assert resp["items_in_queue"] == 0
+    assert resp["running_item_uid"] is None
     assert resp["worker_environment_exists"] is False
 
 
@@ -143,7 +143,7 @@ def test_http_server_queue_item_add_handler_3(re_manager, fastapi_server):  # no
     plan2 = {"plan": {"name": "count", "args": [["det1", "det2"]], "kwargs": {"abc": 10}}}
     resp2 = _request_to_json("post", "/queue/plan/add", json=plan2)
     assert resp2["success"] is False
-    assert "Failed to add a plan: Plan validation failed: got an unexpected keyword argument 'abc'" in resp2["msg"]
+    assert "Failed to add an item: Plan validation failed: got an unexpected keyword argument 'abc'" in resp2["msg"]
 
     # Valid plan
     plan3 = {"plan": {"name": "count", "args": [["det1", "det2"]]}}
@@ -259,7 +259,7 @@ def test_http_server_queue_item_get_remove_handler_2(
         assert resp1["msg"] == ""
     else:
         assert resp1["plan"] == {}
-        assert "Failed to get a plan" in resp1["msg"]
+        assert "Failed to get an item" in resp1["msg"]
 
     # Testing '/queue/plan/remove'
     resp2 = _request_to_json("post", "/queue/plan/remove", json=params)
@@ -271,7 +271,7 @@ def test_http_server_queue_item_get_remove_handler_2(
         assert resp2["msg"] == ""
     else:
         assert resp2["plan"] == {}
-        assert "Failed to remove a plan" in resp2["msg"]
+        assert "Failed to remove an item" in resp2["msg"]
 
     resp3 = _request_to_json("get", "/queue/get")
     assert len(resp3["queue"]) == (2 if success else 3)
@@ -338,8 +338,8 @@ def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noq
     ttime.sleep(10)  # TODO: wait for the queue processing to be completed
 
     state = _request_to_json("get", "/status")
-    assert state["plans_in_queue"] == 0
-    assert state["plans_in_history"] == 1
+    assert state["items_in_queue"] == 0
+    assert state["items_in_history"] == 1
 
 
 def test_http_server_queue_item_get_remove_4_failing(re_manager, fastapi_server):  # noqa F811
@@ -596,8 +596,8 @@ def test_http_server_manager_kill(re_manager, fastapi_server):  # noqa F811
     resp = _request_to_json("get", "/status")
     assert resp["msg"] == "RE Manager"
     assert resp["manager_state"] == "idle"
-    assert resp["plans_in_queue"] == 0
-    assert resp["running_plan_uid"] is None
+    assert resp["items_in_queue"] == 0
+    assert resp["running_item_uid"] is None
     assert resp["worker_environment_exists"] is True
 
 
@@ -630,9 +630,9 @@ def test_http_server_clear_queue_handler_2(re_manager, fastapi_server, add_plans
     resp = _request_to_json("get", "/status")
     assert resp["msg"] == "RE Manager"
     assert resp["manager_state"] == "executing_queue"
-    assert resp["plans_in_queue"] == 2
-    assert resp["running_plan_uid"] is not None
-    assert resp["plans_in_history"] == 0
+    assert resp["items_in_queue"] == 2
+    assert resp["running_item_uid"] is not None
+    assert resp["items_in_history"] == 0
     assert resp["worker_environment_exists"] is True
 
     # Attempt to stop
@@ -649,9 +649,9 @@ def test_http_server_clear_queue_handler_2(re_manager, fastapi_server, add_plans
         resp = _request_to_json("get", "/status")
         assert resp["msg"] == "RE Manager"
         assert resp["manager_state"] == "idle"
-        assert resp["plans_in_queue"] == 0
-        assert resp["plans_in_history"] == 3
-        assert resp["running_plan_uid"] is None
+        assert resp["items_in_queue"] == 0
+        assert resp["items_in_history"] == 3
+        assert resp["running_item_uid"] is None
         assert resp["worker_environment_exists"] is True
 
 
@@ -693,8 +693,8 @@ def test_http_server_queue_stop(re_manager, fastapi_server, add_plans_to_queue, 
 
     status = _request_to_json("get", "/status")
     assert status["manager_state"] == "idle"
-    assert status["plans_in_queue"] == (0 if deactivate else 2)
-    assert status["plans_in_history"] == (3 if deactivate else 1)
-    assert status["running_plan_uid"] is None
+    assert status["items_in_queue"] == (0 if deactivate else 2)
+    assert status["items_in_history"] == (3 if deactivate else 1)
+    assert status["running_item_uid"] is None
     assert status["worker_environment_exists"] is True
     assert status["queue_stop_pending"] is False

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -320,7 +320,7 @@ def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noq
     assert "is currently running" in resp5a["msg"]
     resp5b = _request_to_json("post", "/queue/item/remove", json={"uid": uid})
     assert resp5b["success"] is False
-    assert "Can not remove a plan which is currently running" in resp5b["msg"]
+    assert "Can not remove an item which is currently running" in resp5b["msg"]
 
     uid = "nonexistent"
     resp6a = _request_to_json("post", "/queue/item/get", json={"uid": uid})

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -206,7 +206,7 @@ def test_http_server_queue_item_get_remove_handler_1(re_manager, fastapi_server,
     assert len(resp1["queue"]) == 3
     assert resp1["running_plan"] == {}
 
-    resp2 = _request_to_json("post", "/queue/plan/get", json={})
+    resp2 = _request_to_json("post", "/queue/item/get", json={})
     assert resp2["success"] is True
     assert resp2["plan"]["name"] == "count"
     assert resp2["plan"]["args"] == [["det1", "det2"]]
@@ -252,8 +252,8 @@ def test_http_server_queue_item_get_remove_handler_2(
     # Remove entry at the specified position
     params = {} if pos is None else {"pos": pos}
 
-    # Testing '/queue/plan/get'
-    resp1 = _request_to_json("post", "/queue/plan/get", json=params)
+    # Testing '/queue/item/get'
+    resp1 = _request_to_json("post", "/queue/item/get", json=params)
     assert resp1["success"] is success
     if success:
         assert resp1["plan"]["args"] == plans[pos_result]["args"]
@@ -295,7 +295,7 @@ def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noq
 
     # Get and then remove plan 2 from the queue
     uid = plans_in_queue[1]["item_uid"]
-    resp2a = _request_to_json("post", "/queue/plan/get", json={"uid": uid})
+    resp2a = _request_to_json("post", "/queue/item/get", json={"uid": uid})
     assert resp2a["plan"]["item_uid"] == plans_in_queue[1]["item_uid"]
     assert resp2a["plan"]["name"] == plans_in_queue[1]["name"]
     assert resp2a["plan"]["args"] == plans_in_queue[1]["args"]
@@ -315,7 +315,7 @@ def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noq
 
     ttime.sleep(1)
     uid = plans_in_queue[0]["item_uid"]
-    resp5a = _request_to_json("post", "/queue/plan/get", json={"uid": uid})
+    resp5a = _request_to_json("post", "/queue/item/get", json={"uid": uid})
     assert resp5a["success"] is False
     assert "is currently running" in resp5a["msg"]
     resp5b = _request_to_json("post", "/queue/item/remove", json={"uid": uid})
@@ -323,7 +323,7 @@ def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noq
     assert "Can not remove a plan which is currently running" in resp5b["msg"]
 
     uid = "nonexistent"
-    resp6a = _request_to_json("post", "/queue/plan/get", json={"uid": uid})
+    resp6a = _request_to_json("post", "/queue/item/get", json={"uid": uid})
     assert resp6a["success"] is False
     assert "not in the queue" in resp6a["msg"]
     resp6b = _request_to_json("post", "/queue/item/remove", json={"uid": uid})
@@ -332,7 +332,7 @@ def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noq
 
     # Remove the last entry
     uid = plans_in_queue[2]["item_uid"]
-    resp7a = _request_to_json("post", "/queue/plan/get", json={"uid": uid})
+    resp7a = _request_to_json("post", "/queue/item/get", json={"uid": uid})
     assert resp7a["success"] is True
     resp7b = _request_to_json("post", "/queue/item/remove", json={"uid": uid})
     assert resp7b["success"] is True
@@ -350,7 +350,7 @@ def test_http_server_queue_item_get_remove_4_failing(re_manager, fastapi_server)
     Note: derived from ``test_zmq_api_queue_item_get_remove_4_failing()``
     """
     # Ambiguous parameters
-    resp1 = _request_to_json("post", "/queue/plan/get", json={"pos": 5, "uid": "some_uid"})
+    resp1 = _request_to_json("post", "/queue/item/get", json={"pos": 5, "uid": "some_uid"})
     assert resp1["success"] is False
     assert "Ambiguous parameters" in resp1["msg"]
 

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -67,7 +67,7 @@ def test_http_server_plans_allowed_and_devices(re_manager, fastapi_server):  # n
     assert len(resp2["devices_allowed"]) > 0
 
 
-def test_http_server_queue_plan_add_handler_1(re_manager, fastapi_server):  # noqa F811
+def test_http_server_queue_item_add_handler_1(re_manager, fastapi_server):  # noqa F811
     resp1 = _request_to_json(
         "post", "/queue/plan/add", json={"plan": {"name": "count", "args": [["det1", "det2"]]}}
     )
@@ -101,7 +101,7 @@ def test_http_server_queue_plan_add_handler_1(re_manager, fastapi_server):  # no
     (-100, 0, True),
 ])
 # fmt: on
-def test_http_server_queue_plan_add_handler_2(re_manager, fastapi_server, pos, pos_result, success):  # noqa F811
+def test_http_server_queue_item_add_handler_2(re_manager, fastapi_server, pos, pos_result, success):  # noqa F811
 
     plan1 = {"name": "count", "args": [["det1"]]}
     plan2 = {"name": "count", "args": [["det1", "det2"]]}
@@ -131,7 +131,7 @@ def test_http_server_queue_plan_add_handler_2(re_manager, fastapi_server, pos, p
         assert resp2["queue"][pos_result]["args"] == plan2["args"]
 
 
-def test_http_server_queue_plan_add_handler_3(re_manager, fastapi_server):  # noqa F811
+def test_http_server_queue_item_add_handler_3(re_manager, fastapi_server):  # noqa F811
 
     # Unknown plan name
     plan1 = {"plan": {"name": "count_test", "args": [["det1", "det2"]]}}
@@ -161,7 +161,7 @@ def test_http_server_queue_plan_add_handler_3(re_manager, fastapi_server):  # no
     assert resp4["running_plan"] == {}
 
 
-def test_http_server_queue_plan_add_handler_4(re_manager, fastapi_server):  # noqa: F811
+def test_http_server_queue_item_add_handler_4(re_manager, fastapi_server):  # noqa: F811
     """
     Add instruction ('queue_stop') to the queue.
     """
@@ -185,7 +185,7 @@ def test_http_server_queue_plan_add_handler_4(re_manager, fastapi_server):  # no
     assert resp4["queue"][2]["item_type"] == "plan"
 
 
-def test_http_server_queue_plan_add_handler_6_fail(re_manager, fastapi_server):  # noqa F811
+def test_http_server_queue_item_add_handler_6_fail(re_manager, fastapi_server):  # noqa F811
     """
     Failing case: call without sending a plan.
     """

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -75,7 +75,7 @@ def test_http_server_queue_item_add_handler_1(re_manager, fastapi_server):  # no
     assert resp1["qsize"] == 1
     assert resp1["plan"]["name"] == "count"
     assert resp1["plan"]["args"] == [["det1", "det2"]]
-    assert "plan_uid" in resp1["plan"]
+    assert "item_uid" in resp1["plan"]
 
     resp2 = _request_to_json("get", "/queue/get")
     assert resp2["queue"] != []
@@ -120,7 +120,7 @@ def test_http_server_queue_item_add_handler_2(re_manager, fastapi_server, pos, p
     assert resp1["qsize"] == (3 if success else None)
     assert resp1["plan"]["name"] == "count"
     assert resp1["plan"]["args"] == plan2["args"]
-    assert "plan_uid" in resp1["plan"]
+    assert "item_uid" in resp1["plan"]
 
     resp2 = _request_to_json("get", "/queue/get")
 
@@ -152,7 +152,7 @@ def test_http_server_queue_item_add_handler_3(re_manager, fastapi_server):  # no
     assert resp3["qsize"] == 1
     assert resp3["plan"]["name"] == "count"
     assert resp3["plan"]["args"] == [["det1", "det2"]]
-    assert "plan_uid" in resp3["plan"]
+    assert "item_uid" in resp3["plan"]
 
     resp4 = _request_to_json("get", "/queue/get")
     assert resp4["queue"] != []
@@ -208,14 +208,14 @@ def test_http_server_queue_item_get_remove_handler_1(re_manager, fastapi_server,
     assert resp2["success"] is True
     assert resp2["plan"]["name"] == "count"
     assert resp2["plan"]["args"] == [["det1", "det2"]]
-    assert "plan_uid" in resp2["plan"]
+    assert "item_uid" in resp2["plan"]
 
     resp3 = _request_to_json("post", "/queue/plan/remove", json={})
     assert resp3["success"] is True
     assert resp3["qsize"] == 2
     assert resp3["plan"]["name"] == "count"
     assert resp3["plan"]["args"] == [["det1", "det2"]]
-    assert "plan_uid" in resp3["plan"]
+    assert "item_uid" in resp3["plan"]
 
 
 # fmt: off
@@ -255,7 +255,7 @@ def test_http_server_queue_item_get_remove_handler_2(
     assert resp1["success"] is success
     if success:
         assert resp1["plan"]["args"] == plans[pos_result]["args"]
-        assert "plan_uid" in resp1["plan"]
+        assert "item_uid" in resp1["plan"]
         assert resp1["msg"] == ""
     else:
         assert resp1["plan"] == {}
@@ -267,7 +267,7 @@ def test_http_server_queue_item_get_remove_handler_2(
     assert resp2["qsize"] == (2 if success else None)
     if success:
         assert resp2["plan"]["args"] == plans[pos_result]["args"]
-        assert "plan_uid" in resp2["plan"]
+        assert "item_uid" in resp2["plan"]
         assert resp2["msg"] == ""
     else:
         assert resp2["plan"] == {}
@@ -292,13 +292,13 @@ def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noq
     assert len(plans_in_queue) == 3
 
     # Get and then remove plan 2 from the queue
-    uid = plans_in_queue[1]["plan_uid"]
+    uid = plans_in_queue[1]["item_uid"]
     resp2a = _request_to_json("post", "/queue/plan/get", json={"uid": uid})
-    assert resp2a["plan"]["plan_uid"] == plans_in_queue[1]["plan_uid"]
+    assert resp2a["plan"]["item_uid"] == plans_in_queue[1]["item_uid"]
     assert resp2a["plan"]["name"] == plans_in_queue[1]["name"]
     assert resp2a["plan"]["args"] == plans_in_queue[1]["args"]
     resp2b = _request_to_json("post", "/queue/plan/remove", json={"uid": uid})
-    assert resp2b["plan"]["plan_uid"] == plans_in_queue[1]["plan_uid"]
+    assert resp2b["plan"]["item_uid"] == plans_in_queue[1]["item_uid"]
     assert resp2b["plan"]["name"] == plans_in_queue[1]["name"]
     assert resp2b["plan"]["args"] == plans_in_queue[1]["args"]
 
@@ -312,7 +312,7 @@ def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noq
     assert resp4["success"] is True
 
     ttime.sleep(1)
-    uid = plans_in_queue[0]["plan_uid"]
+    uid = plans_in_queue[0]["item_uid"]
     resp5a = _request_to_json("post", "/queue/plan/get", json={"uid": uid})
     assert resp5a["success"] is False
     assert "is currently running" in resp5a["msg"]
@@ -329,7 +329,7 @@ def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noq
     assert "not in the queue" in resp6b["msg"]
 
     # Remove the last entry
-    uid = plans_in_queue[2]["plan_uid"]
+    uid = plans_in_queue[2]["item_uid"]
     resp7a = _request_to_json("post", "/queue/plan/get", json={"uid": uid})
     assert resp7a["success"] is True
     resp7b = _request_to_json("post", "/queue/plan/remove", json={"uid": uid})
@@ -397,17 +397,17 @@ def test_http_server_move_plan_1(re_manager, fastapi_server, params, src, order,
     queue = resp1["queue"]
     assert len(queue) == 3
 
-    plan_uids = [_["plan_uid"] for _ in queue]
+    item_uids = [_["item_uid"] for _ in queue]
     # Add one more 'nonexistent' uid (that is not in the queue)
-    plan_uids.append("nonexistent")
+    item_uids.append("nonexistent")
 
     # Replace indices with actual UIDs that will be sent to the function
     if "uid" in params:
-        params["uid"] = plan_uids[params["uid"]]
+        params["uid"] = item_uids[params["uid"]]
     if "before_uid" in params:
-        params["before_uid"] = plan_uids[params["before_uid"]]
+        params["before_uid"] = item_uids[params["before_uid"]]
     if "after_uid" in params:
-        params["after_uid"] = plan_uids[params["after_uid"]]
+        params["after_uid"] = item_uids[params["after_uid"]]
 
     resp2 = _request_to_json("post", "/queue/plan/move", json=params)
     if success:
@@ -417,11 +417,11 @@ def test_http_server_move_plan_1(re_manager, fastapi_server, params, src, order,
         assert resp2["msg"] == ""
 
         # Compare the order of UIDs in the queue with the expected order
-        plan_uids_reordered = [plan_uids[_] for _ in order]
+        item_uids_reordered = [item_uids[_] for _ in order]
         resp3 = _request_to_json("get", "/queue/get")
-        plan_uids_from_queue = [_["plan_uid"] for _ in resp3["queue"]]
+        item_uids_from_queue = [_["item_uid"] for _ in resp3["queue"]]
 
-        assert plan_uids_from_queue == plan_uids_reordered
+        assert item_uids_from_queue == item_uids_reordered
 
     else:
         assert resp2["success"] is False
@@ -507,7 +507,7 @@ def test_http_server_re_pause_continue_handlers(
     assert resp2["qsize"] == 1
     assert resp2["plan"]["name"] == "count"
     assert resp2["plan"]["args"] == [["det1", "det2"]]
-    assert "plan_uid" in resp2["plan"]
+    assert "item_uid" in resp2["plan"]
 
     resp3 = _request_to_json("post", "/queue/start")
     assert resp3 == {"success": True, "msg": ""}

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -411,7 +411,7 @@ def test_http_server_move_plan_1(re_manager, fastapi_server, params, src, order,
     if "after_uid" in params:
         params["after_uid"] = item_uids[params["after_uid"]]
 
-    resp2 = _request_to_json("post", "/queue/plan/move", json=params)
+    resp2 = _request_to_json("post", "/queue/item/move", json=params)
     if success:
         assert resp2["success"] is True
         assert resp2["plan"] == queue[src]


### PR DESCRIPTION
The changes in this PR include renaming of a number of API (both 0MQ and REST) to reflect the expansion of functionality of the plan queue. Since the plan queue may now include instructions (currently only instructions that stops execution of the queue is implemented), it is more consistent to name queue items as 'items', not as 'plans'. The PR includes only trivial changes: there are no changes to functionality of the Queue Server.

**NOTE**: In existing installation of QueueServer, history may contain 'old' items that have `plan_uid` instead of `item_uid`. Clear history by running `qserver -c history_clear` to clear the history to ensure consistency of data returned by `/history/get` API.

The following API were renamed:

-  `queue_plan_add` renamed to `queue_item_add`,

-  `queue_plan_remove` renamed to `queue_item_remove`,

-  `queue_plan_get` renamed to `queue_item_get`,

-  `queue_plan_move` renamed to `queue_item_move`,

- `/queue/plan/add' renamed to `/queue/item/add`,

- `/queue/plan/add' renamed to `/queue/item/add`,

- `/queue/plan/remove' renamed to `/queue/item/remove`,

- `/queue/plan/get' renamed to `/queue/item/get`,

- `/queue/plan/move' renamed to `/queue/item/move`.

Additionally `plan_uid` is renamed to `item_uid`. The UID is assigned to each queue item and does not have meaning outside the queue. It has no relationship with Run UID.

The following status fields (returned following `status` request) were renamed:

- `plans_in_queue` renamed to `items_in_queue`,

- `plans_in_history` renamed to `items_in_history`,

- `running_plan_uid` renamed to `running_item_uid`.



