### PR TITLE
Thread-based API for communicating with RE Manager via ZMQ.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -691,7 +691,7 @@ class ZMQCommSendThreads:
         a name of a method supported by the server and a dictionary of parameters that
         are required by the method. In case of communication error (timeout), the function
         returns error message or raises ``CommTimeoutError`` exception depending on
-        the setting of ``raise_timeout_exceptions`` property.
+        the values ``raise_exceptions`` parameter in this function and class constructor.
 
         Parameters
         ----------
@@ -872,7 +872,7 @@ class ZMQCommSendAsync:
         a name of a method supported by the server and a dictionary of parameters that
         are required by the method. In case of communication error (timeout), the function
         returns error message or raises ``CommTimeoutError`` exception depending on
-        the setting of ``raise_timeout_exceptions`` property.
+        the values ``raise_exceptions`` parameter in this function and class constructor.
 
         Parameters
         ----------

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -885,7 +885,7 @@ class ZMQCommSendAsync:
         raise_exceptions: bool or None
             The flag indicates if exception should be raised in case of communication error
             (such as timeout). If ``False``, then error message is returned instead.
-            If None, then the field value ``self._raise_timeout_exceptions`` is used to
+            If None, then the field value ``self._raise_exceptions`` is used to
             determine if the exception needs to be raised. Non-blocking calls do not raise
             the exception. Instead, callback function receives the error message as one of the
             parameters

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -724,7 +724,7 @@ class ZMQCommSendThreads:
         Raises
         ------
         CommTimeoutError
-            Raised if communication error occurs and ``raise_timeout_exceptions`` is set ``True``.
+            Raised if communication error occurs and ``raise_exceptions`` is set ``True``.
         """
 
         # Send empty dictionary if no parameters are passed

--- a/bluesky_queueserver/manager/tests/test_comms.py
+++ b/bluesky_queueserver/manager/tests/test_comms.py
@@ -1004,7 +1004,6 @@ def test_ZMQCommSendAsync_4(raise_exception, delay_between_reads):
     """
     ZMQCommSendAsync: Timeout at the server.
     """
-
     thread = threading.Thread(target=_zmq_server_delay2)
     thread.start()
 
@@ -1018,7 +1017,7 @@ def test_ZMQCommSendAsync_4(raise_exception, delay_between_reads):
         for val in (10, 20):
             if (raise_exception in (True, None)) and (val == 10):
                 # The case when timeout is expected for blocking operation
-                with pytest.raises(CommTimeoutError, match="Resource temporarily unavailable"):
+                with pytest.raises(CommTimeoutError, match="timeout occurred"):
                     await zmq_comm.send_message(method=method, params=params, raise_exceptions=raise_exception)
             else:
                 msg_recv = await zmq_comm.send_message(
@@ -1028,7 +1027,7 @@ def test_ZMQCommSendAsync_4(raise_exception, delay_between_reads):
             if val == 10:
                 if raise_exception not in (True, None):
                     assert msg_recv["success"] is False, str(msg_recv)
-                    assert "Resource temporarily unavailable" in msg_recv["msg"], str(msg_recv)
+                    assert "timeout occurred" in msg_recv["msg"], str(msg_recv)
 
                 # Delay between consecutive reads. Test cases when read is initiated before and
                 #   after the server restored operation and sent the response.

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import time as ttime
+import asyncio
 
 from bluesky_queueserver.manager.profile_ops import (
     get_default_profile_collection_dir,
@@ -9,7 +10,7 @@ from bluesky_queueserver.manager.profile_ops import (
 
 from bluesky_queueserver.manager.plan_queue_ops import PlanQueueOperations
 
-from ..comms import zmq_single_request
+from ..comms import zmq_single_request, ZMQCommSendThreads, ZMQCommSendAsync, CommTimeoutError
 
 from ._common import (
     wait_for_condition,
@@ -35,7 +36,94 @@ _user_group_permissions_fln = "user_group_permissions.yaml"
 
 
 # =======================================================================================
+#                   Thread-based ZMQ API - ZMQCommSendThreads
+
+
+def test_zmq_api_thread_based(re_manager):  # noqa F811
+    """
+    Communicate with the server using thread-based API. The purpose of the test is make
+    sure that the API is compatible with the client. It is sufficiently to test only
+    the blocking call, since it is still using callbacks mechanism.
+    """
+    client = ZMQCommSendThreads()
+
+    resp1 = client.send_message(
+        method="queue_item_add", params={"plan": _plan1, "user": _user, "user_group": _user_group}
+    )
+    assert resp1["success"] is True
+    assert resp1["qsize"] == 1
+    assert resp1["plan"]["name"] == _plan1["name"]
+    assert resp1["plan"]["args"] == _plan1["args"]
+    assert resp1["plan"]["user"] == _user
+    assert resp1["plan"]["user_group"] == _user_group
+    assert "item_uid" in resp1["plan"]
+
+    resp2 = client.send_message(method="queue_get")
+    assert resp2["queue"] != []
+    assert len(resp2["queue"]) == 1
+    assert resp2["queue"][0] == resp1["plan"]
+    assert resp2["running_plan"] == {}
+
+    with pytest.raises(CommTimeoutError, match="ZMQ timeout occurred"):
+        client.send_message(method="manager_kill")
+
+    # Wait until the manager is restarted
+    ttime.sleep(6)
+
+    resp3 = client.send_message(method="status")
+    assert resp3["manager_state"] == "idle"
+    assert resp3["items_in_queue"] == 1
+    assert resp3["items_in_history"] == 0
+
+
+# =======================================================================================
+#                   Thread-based ZMQ API - ZMQCommSendThreads
+
+
+def test_zmq_api_asyncio_based(re_manager):  # noqa F811
+    """
+    Communicate with the server using asyncio-based API. The purpose of the test is make
+    sure that the API is compatible with the client.
+    """
+
+    async def testing():
+        client = ZMQCommSendAsync()
+
+        resp1 = await client.send_message(
+            method="queue_item_add", params={"plan": _plan1, "user": _user, "user_group": _user_group}
+        )
+        assert resp1["success"] is True
+        assert resp1["qsize"] == 1
+        assert resp1["plan"]["name"] == _plan1["name"]
+        assert resp1["plan"]["args"] == _plan1["args"]
+        assert resp1["plan"]["user"] == _user
+        assert resp1["plan"]["user_group"] == _user_group
+        assert "item_uid" in resp1["plan"]
+
+        resp2 = await client.send_message(method="queue_get")
+        assert resp2["queue"] != []
+        assert len(resp2["queue"]) == 1
+        assert resp2["queue"][0] == resp1["plan"]
+        assert resp2["running_plan"] == {}
+
+        with pytest.raises(CommTimeoutError, match="timeout occurred"):
+            await client.send_message(method="manager_kill")
+
+        # Wait until the manager is restarted
+        await asyncio.sleep(6)
+
+        resp3 = await client.send_message(method="status")
+        assert resp3["manager_state"] == "idle"
+        assert resp3["items_in_queue"] == 1
+        assert resp3["items_in_history"] == 0
+
+    asyncio.run(testing())
+
+
+# =======================================================================================
 #                   Methods 'environment_open', 'environment_close'
+
+
 def test_zmq_api_environment_open_close_1(re_manager):  # noqa F811
     """
     Basic test for `environment_open` and `environment_close` methods.

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -64,7 +64,7 @@ def test_zmq_api_thread_based(re_manager):  # noqa F811
     assert resp2["queue"][0] == resp1["plan"]
     assert resp2["running_plan"] == {}
 
-    with pytest.raises(CommTimeoutError, match="ZMQ timeout occurred"):
+    with pytest.raises(CommTimeoutError, match="timeout occurred"):
         client.send_message(method="manager_kill")
 
     # Wait until the manager is restarted

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -41,7 +41,7 @@ _user_group_permissions_fln = "user_group_permissions.yaml"
 
 def test_zmq_api_thread_based(re_manager):  # noqa F811
     """
-    Communicate with the server using thread-based API. The purpose of the test is make
+    Communicate with the server using the thread-based API. The purpose of the test is to make
     sure that the API is compatible with the client. It is sufficient to test only
     the blocking call, since it is still using callbacks mechanism.
     """

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -42,7 +42,7 @@ _user_group_permissions_fln = "user_group_permissions.yaml"
 def test_zmq_api_thread_based(re_manager):  # noqa F811
     """
     Communicate with the server using thread-based API. The purpose of the test is make
-    sure that the API is compatible with the client. It is sufficiently to test only
+    sure that the API is compatible with the client. It is sufficient to test only
     the blocking call, since it is still using callbacks mechanism.
     """
     client = ZMQCommSendThreads()

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -25,7 +25,7 @@ zmq_to_manager = None
 async def startup_event():
     global zmq_to_manager
     # ZMQCommSendAsync should be created from the event loop of FastAPI server.
-    zmq_to_manager = ZMQCommSendAsync()
+    zmq_to_manager = ZMQCommSendAsync(raise_exceptions=False)
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
Implemented thread-based API for communicating with RE Manager from 3rd party applications. The QueueServer provided asyncio-based API (class `ZMQCommSendAsync`) used by HTTP Server and CLI tool. The thread-based version of the API (class `ZMQCommSendThreads`) proposed in this PR provides similar functionality for applications that are not running asyncio loop (e.g. PyQT applications).

The API allows to send ZMQ requests to RE Manager in blocking mode or using callbacks. 

Blocking mode:
```
    client = ZMQCommSendThreads()

    try:
        msg = client.send_message(
            method="queue_item_add", params={"plan": _plan1, "user":  "Some User", "user_group": "admin"}
        )
        print(f"Response is received from RE Manager: {msg}")
    except CommTimeoutError as ex:
        print(f"Communication error occurred: {ex}") 
```

The same functionality can be implemented using callbacks:
```
    client = ZMQCommSendThreads()

    def cb(msg, msg_err):
        # Some code for handling the received data
        if msg_err:        
            print(f"Response is received from RE Manager: {msg}")
        else:
            print(f"Communication error occurred: {msg_err}")

    resp1 = client.send_message(
        method="queue_item_add", 
        params={"plan": _plan1, "user": _user, "user_group": _user_group},
        cb=cb,
    )
```

This PR contains all commits from https://github.com/bluesky/bluesky-queueserver/pull/98