### PR TITLE
CI: updated configuration

### DIFF
--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -40,7 +40,7 @@ jobs:
       uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501  # v3.7.3
       with:
         deploy_key: ${{ secrets.ACTIONS_DOCUMENTATION_DEPLOY_KEY }}
-        publish_branch: main
+        publish_branch: master
         publish_dir: ./docs/build/html
         external_repository: bluesky/bluesky.github.io
         destination_dir: bluesky-queueserver


### PR DESCRIPTION
Follow up PR that fixes the name of `publish_branch`. Original PR: https://github.com/bluesky/bluesky-queueserver/pull/101