### PR TITLE
Fix for minor inconsistencies in ZMQ API

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -966,7 +966,7 @@ class RunEngineManager(Process):
         """
         logger.info("Clearing the queue")
         await self._plan_queue.clear_queue()
-        return {"success": True, "msg": "Plan queue is now empty."}
+        return {"success": True, "msg": ""}
 
     async def _history_get_handler(self, request):
         """

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -905,13 +905,13 @@ class RunEngineManager(Process):
             plan, msg = {}, ""
             pos = request.get("pos", None)
             uid = request.get("uid", None)
-            plan = await self._plan_queue.get_item(pos=pos, uid=uid)
+            item = await self._plan_queue.get_item(pos=pos, uid=uid)
             success = True
         except Exception as ex:
             success = False
             msg = f"Failed to get an item: {str(ex)}"
 
-        return {"success": success, "msg": msg, "plan": plan}
+        return {"success": success, "msg": msg, "item": item}
 
     async def _queue_item_remove_handler(self, request):
         """

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -902,7 +902,7 @@ class RunEngineManager(Process):
         """
         logger.info("Getting an item from the queue.")
         try:
-            plan, msg = {}, ""
+            item, msg = {}, ""
             pos = request.get("pos", None)
             uid = request.get("uid", None)
             item = await self._plan_queue.get_item(pos=pos, uid=uid)
@@ -923,16 +923,16 @@ class RunEngineManager(Process):
         """
         logger.info("Removing item from the queue.")
         try:
-            plan, qsize, msg = {}, None, ""
+            item, qsize, msg = {}, None, ""
             pos = request.get("pos", None)
             uid = request.get("uid", None)
-            plan, qsize = await self._plan_queue.pop_item_from_queue(pos=pos, uid=uid)
+            item, qsize = await self._plan_queue.pop_item_from_queue(pos=pos, uid=uid)
             success = True
         except Exception as ex:
             success = False
             msg = f"Failed to remove an item: {str(ex)}"
 
-        return {"success": success, "msg": msg, "plan": plan, "qsize": qsize}
+        return {"success": success, "msg": msg, "item": item, "qsize": qsize}
 
     async def _queue_item_move_handler(self, request):
         """

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -944,13 +944,13 @@ class RunEngineManager(Process):
         """
         logger.info("Removing item from the queue.")
         try:
-            plan, qsize, msg = {}, None, ""
+            item, qsize, msg = {}, None, ""
             pos = request.get("pos", None)
             uid = request.get("uid", None)
             pos_dest = request.get("pos_dest", None)
             before_uid = request.get("before_uid", None)
             after_uid = request.get("after_uid", None)
-            plan, qsize = await self._plan_queue.move_item(
+            item, qsize = await self._plan_queue.move_item(
                 pos=pos, uid=uid, pos_dest=pos_dest, before_uid=before_uid, after_uid=after_uid
             )
             success = True
@@ -958,7 +958,7 @@ class RunEngineManager(Process):
             success = False
             msg = f"Failed to move the item: {str(ex)}"
 
-        return {"success": success, "msg": msg, "plan": plan, "qsize": qsize}
+        return {"success": success, "msg": msg, "item": item, "qsize": qsize}
 
     async def _queue_clear_handler(self, request):
         """

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -983,7 +983,7 @@ class RunEngineManager(Process):
         """
         logger.info("Clearing the plan execution history")
         await self._plan_queue.clear_history()
-        return {"success": True, "msg": "Plan history is now empty."}
+        return {"success": True, "msg": ""}
 
     async def _environment_open_handler(self, request):
         """

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -794,9 +794,9 @@ class RunEngineManager(Process):
         """
         logger.info("Returning current queue and running plan.")
         plan_queue = await self._plan_queue.get_queue()
-        running_plan = await self._plan_queue.get_running_item_info()
+        running_item = await self._plan_queue.get_running_item_info()
 
-        return {"queue": plan_queue, "running_plan": running_plan}
+        return {"success": True, "msg": "", "queue": plan_queue, "running_item": running_item}
 
     async def _queue_item_add_handler(self, request):
         """
@@ -975,7 +975,7 @@ class RunEngineManager(Process):
         logger.info("Returning plan history.")
         plan_history = await self._plan_queue.get_history()
 
-        return {"history": plan_history}
+        return {"success": True, "msg": "", "history": plan_history}
 
     async def _history_clear_handler(self, request):
         """

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -62,7 +62,7 @@ def test_zmq_api_thread_based(re_manager):  # noqa F811
     assert resp2["queue"] != []
     assert len(resp2["queue"]) == 1
     assert resp2["queue"][0] == resp1["plan"]
-    assert resp2["running_plan"] == {}
+    assert resp2["running_item"] == {}
 
     with pytest.raises(CommTimeoutError, match="timeout occurred"):
         client.send_message(method="manager_kill")
@@ -104,7 +104,7 @@ def test_zmq_api_asyncio_based(re_manager):  # noqa F811
         assert resp2["queue"] != []
         assert len(resp2["queue"]) == 1
         assert resp2["queue"][0] == resp1["plan"]
-        assert resp2["running_plan"] == {}
+        assert resp2["running_item"] == {}
 
         with pytest.raises(CommTimeoutError, match="timeout occurred"):
             await client.send_message(method="manager_kill")
@@ -229,7 +229,7 @@ def test_zmq_api_queue_item_add_1(re_manager):  # noqa F811
     assert resp2["queue"] != []
     assert len(resp2["queue"]) == 1
     assert resp2["queue"][0] == resp1["plan"]
-    assert resp2["running_plan"] == {}
+    assert resp2["running_item"] == {}
 
 
 # fmt: off
@@ -279,7 +279,7 @@ def test_zmq_api_queue_item_add_2(re_manager, pos, pos_result, success):  # noqa
     resp2, _ = zmq_single_request("queue_get")
 
     assert len(resp2["queue"]) == (3 if success else 2)
-    assert resp2["running_plan"] == {}
+    assert resp2["running_item"] == {}
 
     if success:
         assert resp2["queue"][pos_result]["args"] == plan2["args"]
@@ -493,7 +493,7 @@ def test_zmq_api_queue_item_add_7_fail(re_manager):  # noqa F811
     assert resp8["queue"] != []
     assert len(resp8["queue"]) == 1
     assert resp8["queue"][0] == resp7["plan"]
-    assert resp8["running_plan"] == {}
+    assert resp8["running_item"] == {}
 
 
 # =======================================================================================
@@ -588,7 +588,7 @@ def test_zmq_api_queue_item_get_remove_1(re_manager):  # noqa F811
     resp1, _ = zmq_single_request("queue_get")
     assert resp1["queue"] != []
     assert len(resp1["queue"]) == 3
-    assert resp1["running_plan"] == {}
+    assert resp1["running_item"] == {}
 
     # Get the last plan from the queue
     resp2, _ = zmq_single_request("queue_item_get")
@@ -668,7 +668,7 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
 
     resp3, _ = zmq_single_request("queue_get")
     assert len(resp3["queue"]) == (2 if success else 3)
-    assert resp3["running_plan"] == {}
+    assert resp3["running_item"] == {}
 
 
 def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -593,19 +593,19 @@ def test_zmq_api_queue_item_get_remove_1(re_manager):  # noqa F811
     # Get the last plan from the queue
     resp2, _ = zmq_single_request("queue_item_get")
     assert resp2["success"] is True
-    assert resp2["plan"]["name"] == _plan3["name"]
-    assert resp2["plan"]["args"] == _plan3["args"]
-    assert resp2["plan"]["kwargs"] == _plan3["kwargs"]
-    assert "item_uid" in resp2["plan"]
+    assert resp2["item"]["name"] == _plan3["name"]
+    assert resp2["item"]["args"] == _plan3["args"]
+    assert resp2["item"]["kwargs"] == _plan3["kwargs"]
+    assert "item_uid" in resp2["item"]
 
     # Remove the last plan from the queue
     resp3, _ = zmq_single_request("queue_item_remove")
     assert resp3["success"] is True
     assert resp3["qsize"] == 2
-    assert resp3["plan"]["name"] == "count"
-    assert resp3["plan"]["args"] == [["det1", "det2"]]
-    assert resp2["plan"]["kwargs"] == _plan3["kwargs"]
-    assert "item_uid" in resp3["plan"]
+    assert resp3["item"]["name"] == "count"
+    assert resp3["item"]["args"] == [["det1", "det2"]]
+    assert resp2["item"]["kwargs"] == _plan3["kwargs"]
+    assert "item_uid" in resp3["item"]
 
 
 # fmt: off
@@ -647,11 +647,11 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
     resp1, _ = zmq_single_request("queue_item_get", params)
     assert resp1["success"] is success
     if success:
-        assert resp1["plan"]["args"] == plans[pos_result]["args"]
-        assert "item_uid" in resp1["plan"]
+        assert resp1["item"]["args"] == plans[pos_result]["args"]
+        assert "item_uid" in resp1["item"]
         assert resp1["msg"] == ""
     else:
-        assert resp1["plan"] == {}
+        assert resp1["item"] == {}
         assert "Failed to get an item" in resp1["msg"]
 
     # Testing 'queue_item_remove'
@@ -659,11 +659,11 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
     assert resp2["success"] is success
     assert resp2["qsize"] == (2 if success else None)
     if success:
-        assert resp2["plan"]["args"] == plans[pos_result]["args"]
-        assert "item_uid" in resp2["plan"]
+        assert resp2["item"]["args"] == plans[pos_result]["args"]
+        assert "item_uid" in resp2["item"]
         assert resp2["msg"] == ""
     else:
-        assert resp2["plan"] == {}
+        assert resp2["item"] == {}
         assert "Failed to remove an item" in resp2["msg"]
 
     resp3, _ = zmq_single_request("queue_get")
@@ -687,13 +687,13 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     # Get and then remove plan 2 from the queue
     uid = plans_in_queue[1]["item_uid"]
     resp2a, _ = zmq_single_request("queue_item_get", {"uid": uid})
-    assert resp2a["plan"]["item_uid"] == plans_in_queue[1]["item_uid"]
-    assert resp2a["plan"]["name"] == plans_in_queue[1]["name"]
-    assert resp2a["plan"]["args"] == plans_in_queue[1]["args"]
+    assert resp2a["item"]["item_uid"] == plans_in_queue[1]["item_uid"]
+    assert resp2a["item"]["name"] == plans_in_queue[1]["name"]
+    assert resp2a["item"]["args"] == plans_in_queue[1]["args"]
     resp2b, _ = zmq_single_request("queue_item_remove", {"uid": uid})
-    assert resp2b["plan"]["item_uid"] == plans_in_queue[1]["item_uid"]
-    assert resp2b["plan"]["name"] == plans_in_queue[1]["name"]
-    assert resp2b["plan"]["args"] == plans_in_queue[1]["args"]
+    assert resp2b["item"]["item_uid"] == plans_in_queue[1]["item_uid"]
+    assert resp2b["item"]["name"] == plans_in_queue[1]["name"]
+    assert resp2b["item"]["args"] == plans_in_queue[1]["args"]
 
     # Start the first plan (this removes it from the queue)
     #   Also the rest of the operations will be performed on a running queue.
@@ -816,7 +816,7 @@ def test_zmq_api_move_plan_1(re_manager, params, src, order, success, msg):  # n
     resp2, _ = zmq_single_request("queue_item_move", params)
     if success:
         assert resp2["success"] is True
-        assert resp2["plan"] == queue[src]
+        assert resp2["item"] == queue[src]
         assert resp2["qsize"] == len(plans)
         assert resp2["msg"] == ""
 

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -55,7 +55,7 @@ def test_http_server_status_handler(re_manager, fastapi_server):  # noqa F811
 def test_http_server_queue_get_handler(re_manager, fastapi_server):  # noqa F811
     resp = _request_to_json("get", "/queue/get")
     assert resp["queue"] == []
-    assert resp["running_plan"] == {}
+    assert resp["running_item"] == {}
 
 
 def test_http_server_plans_allowed_and_devices(re_manager, fastapi_server):  # noqa F811
@@ -81,7 +81,7 @@ def test_http_server_queue_item_add_handler_1(re_manager, fastapi_server):  # no
     assert resp2["queue"] != []
     assert len(resp2["queue"]) == 1
     assert resp2["queue"][0] == resp1["plan"]
-    assert resp2["running_plan"] == {}
+    assert resp2["running_item"] == {}
 
 
 # fmt: off
@@ -125,7 +125,7 @@ def test_http_server_queue_item_add_handler_2(re_manager, fastapi_server, pos, p
     resp2 = _request_to_json("get", "/queue/get")
 
     assert len(resp2["queue"]) == (3 if success else 2)
-    assert resp2["running_plan"] == {}
+    assert resp2["running_item"] == {}
 
     if success:
         assert resp2["queue"][pos_result]["args"] == plan2["args"]
@@ -160,7 +160,7 @@ def test_http_server_queue_item_add_handler_3(re_manager, fastapi_server):  # no
     assert resp4["queue"] != []
     assert len(resp4["queue"]) == 1
     assert resp4["queue"][0] == resp3["plan"]
-    assert resp4["running_plan"] == {}
+    assert resp4["running_item"] == {}
 
 
 def test_http_server_queue_item_add_handler_4(re_manager, fastapi_server):  # noqa: F811
@@ -206,7 +206,7 @@ def test_http_server_queue_item_get_remove_handler_1(re_manager, fastapi_server)
     resp1 = _request_to_json("get", "/queue/get")
     assert resp1["queue"] != []
     assert len(resp1["queue"]) == 3
-    assert resp1["running_plan"] == {}
+    assert resp1["running_item"] == {}
 
     resp2 = _request_to_json("post", "/queue/item/get", json={})
     assert resp2["success"] is True
@@ -279,7 +279,7 @@ def test_http_server_queue_item_get_remove_handler_2(
 
     resp3 = _request_to_json("get", "/queue/get")
     assert len(resp3["queue"]) == (2 if success else 3)
-    assert resp3["running_plan"] == {}
+    assert resp3["running_item"] == {}
 
 
 def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noqa F811
@@ -468,7 +468,7 @@ def test_http_server_queue_start_handler(re_manager, fastapi_server):  # noqa F8
     assert resp2 == {"success": True, "msg": ""}
     resp2a = _request_to_json("get", "/queue/get")
     assert len(resp2a["queue"]) == 3
-    assert resp2a["running_plan"] == {}
+    assert resp2a["running_item"] == {}
 
     assert wait_for_environment_to_be_created(10), "Timeout"
 
@@ -479,13 +479,13 @@ def test_http_server_queue_start_handler(re_manager, fastapi_server):  # noqa F8
     # The plan is currently being executed. 'get_queue' is expected to return currently executed plan.
     resp4 = _request_to_json("get", "/queue/get")
     assert len(resp4["queue"]) == 2
-    assert resp4["running_plan"]["name"] == "count"  # Check name of the running plan
+    assert resp4["running_item"]["name"] == "count"  # Check name of the running plan
 
     ttime.sleep(25)  # Wait until all plans are executed
 
     resp4 = _request_to_json("get", "/queue/get")
     assert len(resp4["queue"]) == 0
-    assert resp2a["running_plan"] == {}
+    assert resp2a["running_item"] == {}
 
 
 # fmt: off
@@ -524,7 +524,7 @@ def test_http_server_re_pause_continue_handlers(
     ttime.sleep(2)  # TODO: API is needed
     resp3b = _request_to_json("get", "/queue/get")
     assert len(resp3b["queue"]) == 0  # The plan is paused, but it is not in the queue
-    assert resp3b["running_plan"] != {}  # Running plan is set
+    assert resp3b["running_item"] != {}  # Running plan is set
 
     resp4 = _request_to_json("post", f"/re/{option_continue}")
     assert resp4 == {"msg": "", "success": True}
@@ -534,7 +534,7 @@ def test_http_server_re_pause_continue_handlers(
     resp4a = _request_to_json("get", "/queue/get")
     # The plan returns to the queue if it is stopped
     assert len(resp4a["queue"]) == 0 if option_continue == "resume" else 1
-    assert resp4a["running_plan"] == {}
+    assert resp4a["running_item"] == {}
 
 
 def test_http_server_close_print_db_uids_handler(re_manager, fastapi_server):  # noqa F811
@@ -553,7 +553,7 @@ def test_http_server_close_print_db_uids_handler(re_manager, fastapi_server):  #
 
     resp2a = _request_to_json("get", "/queue/get")
     assert len(resp2a["queue"]) == 0
-    assert resp2a["running_plan"] == {}
+    assert resp2a["running_item"] == {}
 
 
 def test_http_server_clear_queue_handler(re_manager, fastapi_server):  # noqa F811

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -210,16 +210,16 @@ def test_http_server_queue_item_get_remove_handler_1(re_manager, fastapi_server)
 
     resp2 = _request_to_json("post", "/queue/item/get", json={})
     assert resp2["success"] is True
-    assert resp2["plan"]["name"] == "count"
-    assert resp2["plan"]["args"] == [["det1", "det2"]]
-    assert "item_uid" in resp2["plan"]
+    assert resp2["item"]["name"] == "count"
+    assert resp2["item"]["args"] == [["det1", "det2"]]
+    assert "item_uid" in resp2["item"]
 
     resp3 = _request_to_json("post", "/queue/item/remove", json={})
     assert resp3["success"] is True
     assert resp3["qsize"] == 2
-    assert resp3["plan"]["name"] == "count"
-    assert resp3["plan"]["args"] == [["det1", "det2"]]
-    assert "item_uid" in resp3["plan"]
+    assert resp3["item"]["name"] == "count"
+    assert resp3["item"]["args"] == [["det1", "det2"]]
+    assert "item_uid" in resp3["item"]
 
 
 # fmt: off
@@ -258,11 +258,11 @@ def test_http_server_queue_item_get_remove_handler_2(
     resp1 = _request_to_json("post", "/queue/item/get", json=params)
     assert resp1["success"] is success
     if success:
-        assert resp1["plan"]["args"] == plans[pos_result]["args"]
-        assert "item_uid" in resp1["plan"]
+        assert resp1["item"]["args"] == plans[pos_result]["args"]
+        assert "item_uid" in resp1["item"]
         assert resp1["msg"] == ""
     else:
-        assert resp1["plan"] == {}
+        assert resp1["item"] == {}
         assert "Failed to get an item" in resp1["msg"]
 
     # Testing '/queue/item/remove'
@@ -270,11 +270,11 @@ def test_http_server_queue_item_get_remove_handler_2(
     assert resp2["success"] is success
     assert resp2["qsize"] == (2 if success else None)
     if success:
-        assert resp2["plan"]["args"] == plans[pos_result]["args"]
-        assert "item_uid" in resp2["plan"]
+        assert resp2["item"]["args"] == plans[pos_result]["args"]
+        assert "item_uid" in resp2["item"]
         assert resp2["msg"] == ""
     else:
-        assert resp2["plan"] == {}
+        assert resp2["item"] == {}
         assert "Failed to remove an item" in resp2["msg"]
 
     resp3 = _request_to_json("get", "/queue/get")
@@ -298,13 +298,13 @@ def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noq
     # Get and then remove plan 2 from the queue
     uid = plans_in_queue[1]["item_uid"]
     resp2a = _request_to_json("post", "/queue/item/get", json={"uid": uid})
-    assert resp2a["plan"]["item_uid"] == plans_in_queue[1]["item_uid"]
-    assert resp2a["plan"]["name"] == plans_in_queue[1]["name"]
-    assert resp2a["plan"]["args"] == plans_in_queue[1]["args"]
+    assert resp2a["item"]["item_uid"] == plans_in_queue[1]["item_uid"]
+    assert resp2a["item"]["name"] == plans_in_queue[1]["name"]
+    assert resp2a["item"]["args"] == plans_in_queue[1]["args"]
     resp2b = _request_to_json("post", "/queue/item/remove", json={"uid": uid})
-    assert resp2b["plan"]["item_uid"] == plans_in_queue[1]["item_uid"]
-    assert resp2b["plan"]["name"] == plans_in_queue[1]["name"]
-    assert resp2b["plan"]["args"] == plans_in_queue[1]["args"]
+    assert resp2b["item"]["item_uid"] == plans_in_queue[1]["item_uid"]
+    assert resp2b["item"]["name"] == plans_in_queue[1]["name"]
+    assert resp2b["item"]["args"] == plans_in_queue[1]["args"]
 
     # Start the first plan (this removes it from the queue)
     #   Also the rest of the operations will be performed on a running queue.
@@ -416,7 +416,7 @@ def test_http_server_move_plan_1(re_manager, fastapi_server, params, src, order,
     resp2 = _request_to_json("post", "/queue/item/move", json=params)
     if success:
         assert resp2["success"] is True
-        assert resp2["plan"] == queue[src]
+        assert resp2["item"] == queue[src]
         assert resp2["qsize"] == len(plans)
         assert resp2["msg"] == ""
 
@@ -565,7 +565,7 @@ def test_http_server_clear_queue_handler(re_manager, fastapi_server):  # noqa F8
 
     resp2 = _request_to_json("post", "/queue/clear")
     assert resp2["success"] is True
-    assert resp2["msg"] == "Plan queue is now empty."
+    assert resp2["msg"] == ""
 
     resp3 = _request_to_json("get", "/queue/get")
     assert len(resp3["queue"]) == 0


### PR DESCRIPTION
The PR contains fixes for minor inconsistencies in ZMQ API. The PR implements changes suggested in Issue https://github.com/bluesky/bluesky-queueserver/issues/104. Changes are applied to the following API:

**queue_get**
- Add return parameters `success` and `msg` (for consistency with the rest of API). 
- Rename `running_plan` to `running_item` (missed whan plan queue items were renamed from 'plans' to 'items').

**history_get**
- Add return parameters `success` and `msg` (for consistency with the rest of API). 

**history_clear**
- return parameter `msg` should be `""` if request is processed successfully.

**queue_item_get**, **queue_item_remove**, **queue_item_move**
- return parameter `plan` should be renamed to `item.

**queue_clear**
- return parameter `msg` should be `""` if request is processed successfully.

The PR contains commit from PR https://github.com/bluesky/bluesky-queueserver/pull/100 and PR https://github.com/bluesky/bluesky-queueserver/pull/103
