### PR TITLE
Rename ZMQ API 'ping' API

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1145,7 +1145,7 @@ class RunEngineManager(Process):
         method = msg["method"]
         params = msg["params"]
         handler_dict = {
-            "": "_ping_handler",
+            "ping": "_ping_handler",
             "status": "_status_handler",
             "queue_get": "_queue_get_handler",
             "plans_allowed": "_plans_allowed_handler",

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -914,3 +914,14 @@ def test_qserver_queue_stop(re_manager, deactivate):  # noqa: F811
     assert n_history == (2 if deactivate else 1)
     status = get_queue_state()
     assert status["queue_stop_pending"] is False
+
+
+def test_qserver_ping(re_manager):  # noqa: F811
+    """
+    Methods ``ping``: basic test
+    """
+    # Wait until RE Manager is started
+    assert wait_for_condition(time=10, condition=condition_manager_idle)
+
+    # Send 'ping' request
+    assert subprocess.call(["qserver", "ping"]) == 0

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -121,6 +121,21 @@ def test_zmq_api_asyncio_based(re_manager):  # noqa F811
 
 
 # =======================================================================================
+#                   Methods 'ping' (currently returning status), "status"
+
+# fmt: off
+@pytest.mark.parametrize("api_name", ["ping", "status"])
+# fmt: on
+def test_zmq_api_ping_status(re_manager, api_name):
+    resp, _ = zmq_single_request(api_name)
+    assert resp["msg"] == "RE Manager"
+    assert resp["manager_state"] == "idle"
+    assert resp["items_in_queue"] == 0
+    assert resp["running_item_uid"] is None
+    assert resp["worker_environment_exists"] is False
+
+
+# =======================================================================================
 #                   Methods 'environment_open', 'environment_close'
 
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -126,7 +126,7 @@ def test_zmq_api_asyncio_based(re_manager):  # noqa F811
 # fmt: off
 @pytest.mark.parametrize("api_name", ["ping", "status"])
 # fmt: on
-def test_zmq_api_ping_status(re_manager, api_name):
+def test_zmq_api_ping_status(re_manager, api_name):  # noqa F811
     resp, _ = zmq_single_request(api_name)
     assert resp["msg"] == "RE Manager"
     assert resp["manager_state"] == "idle"

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -90,15 +90,6 @@ def validate_payload_keys(payload, *, required_keys=None, optional_keys=None):
 
 
 @app.get("/")
-async def root_handler():
-    """
-    May be called to get some response from the server. Currently returns status of RE Manager.
-    Calls `ping` request to RE Manager. Identical to `/ping`.
-    """
-    msg = await zmq_to_manager.send_message(method="ping")
-    return msg
-
-
 @app.get("/ping")
 async def ping_handler():
     """

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -90,11 +90,21 @@ def validate_payload_keys(payload, *, required_keys=None, optional_keys=None):
 
 
 @app.get("/")
+async def root_handler():
+    """
+    May be called to get some response from the server. Currently returns status of RE Manager.
+    Calls `ping` request to RE Manager. Identical to `/ping`.
+    """
+    msg = await zmq_to_manager.send_message(method="ping")
+    return msg
+
+
+@app.get("/ping")
 async def ping_handler():
     """
     May be called to get some response from the server. Currently returns status of RE Manager.
     """
-    msg = await zmq_to_manager.send_message(method="")
+    msg = await zmq_to_manager.send_message(method="ping")
     return msg
 
 

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -34,8 +34,11 @@ def _request_to_json(request_type, path, **kwargs):
     return resp
 
 
-def test_http_server_ping_handler(re_manager, fastapi_server):  # noqa F811
-    resp = _request_to_json("get", "/")
+# fmt: off
+@pytest.mark.parametrize("api_call", ["/", "/ping"])
+# fmt: on
+def test_http_server_ping_handler(re_manager, fastapi_server, api_call):  # noqa F811
+    resp = _request_to_json("get", api_call)
     assert resp["msg"] == "RE Manager"
     assert resp["manager_state"] == "idle"
     assert resp["items_in_queue"] == 0


### PR DESCRIPTION
Change the method name for `ping` ZMQ API from `""` (empty string) to `ping`. The change is not expected to break any existing code. `ping` request can be sent via HTTP server using both `/` and `/ping` API.

Contains all commits from PR https://github.com/bluesky/bluesky-queueserver/pull/108

Addresses issue https://github.com/bluesky/bluesky-queueserver/issues/107 