### PR TITLE
REST API and CLI support for 'permissions_reload' API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,17 @@ Get the lists (JSON) of allowed plans and devices::
   http GET http://localhost:60610/plans/allowed
   http GET http://localhost:60610/devices/allowed
 
+The list of allowed plans and devices is generated based on the list of existing plans and devices
+('existing_plans_and_devices.yaml' by default) and user group permissions ('user_group_permissions.yaml'
+by default). The files with permission data are loaded at RE Manager startup. If any of the files
+are changed while RE Manager is running (e.g. a new plan was added to the profile collection and
+the new 'existing_plans_and_devices.yaml' file was generated) and restarting RE Manager is not
+desirable, the data can be reloaded by sending 'permissions_reload' request::
+
+  qserver permissions reload
+
+  http GET http://localhost:60610/permissions/reload
+
 Before plans could be executed they should be placed in the **plan queue**. The plan queue contains
 **items**. The items are **plans** that could be executed by Run Engine or **instructions** that
 can modify the state of the queue or RE Manager. Currently only one instruction ('queue_stop' - stops

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -46,6 +46,7 @@ qserver environment destroy    # Destroy RE environment (kill RE worker process)
 
 qserver allowed plans          # Request the list of allowed plans
 qserver allowed devices        # Request the list of allowed devices
+qserver permissions reload     # Reload the list of allowed plans and devices and user permissions from disk
 
 qserver queue add plan '<plan-params>'                 # Add plan to the back of the queue
 qserver queue add instruction <instruction>            # Add instruction to the back of the queue
@@ -607,6 +608,15 @@ def create_msg(params):
         if params[0] in supported_params:
             method = f"{params[0]}_{command}"
             prms["user_group"] = default_user_group
+        else:
+            raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
+
+    # ----------- permissions ------------
+    elif command == "permissions":
+        if len(params) != 1:
+            raise CommandParameterError(f"Request '{command}' must include only one parameter")
+        if params[0] == "reload":
+            method = f"{command}_{params[0]}"
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
 

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -384,5 +384,3 @@ async def test_manager_kill_handler():
     """
     msg = await zmq_to_manager.send_message(method="manager_kill")
     return msg
-
-

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -356,6 +356,17 @@ async def devices_allowed_handler():
     return msg
 
 
+@app.post("/permissions/reload")
+async def permissions_reload_handler():
+    """
+    Reloads the list of allowed plans and devices and user group permission from the default location
+    or location set using command line parameters of RE Manager. Use this request to reload the data
+    if the respective files were changed on disk.
+    """
+    msg = await zmq_to_manager.send_message(method="permissions_reload")
+    return msg
+
+
 @app.post("/manager/stop")
 async def manager_stop_handler(payload: dict):
     """
@@ -373,3 +384,5 @@ async def test_manager_kill_handler():
     """
     msg = await zmq_to_manager.send_message(method="manager_kill")
     return msg
+
+

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -3,13 +3,22 @@ import time as ttime
 import requests
 import pytest
 
-from bluesky_queueserver.manager.tests._common import re_manager  # noqa F401
+from bluesky_queueserver.manager.tests._common import (  # noqa F401
+    re_manager,
+    re_manager_pc_copy,
+    copy_default_profile_collection,
+    append_code_to_last_startup_file,
+)
+
 from bluesky_queueserver.server.tests.conftest import (  # noqa F401
     SERVER_ADDRESS,
     SERVER_PORT,
     add_plans_to_queue,
     fastapi_server,
 )
+
+from bluesky_queueserver.manager.profile_ops import gen_list_of_plans_and_devices
+
 
 # Plans used in most of the tests: '_plan1' and '_plan2' are quickly executed '_plan3' runs for 5 seconds.
 _plan1 = {"name": "count", "args": [["det1", "det2"]]}
@@ -777,3 +786,38 @@ def test_http_server_re_runs(re_manager, fastapi_server, suffix, expected_n_item
     assert resp2["run_list_uid"] == run_list_uid
 
     assert wait_for_manager_state_idle(30), "Timeout"
+
+
+
+_sample_trivial_plan1 = """
+def trivial_plan_for_unit_test():
+    '''
+    Trivial plan for unit test.
+    '''
+    yield from scan([det1, det2], motor, -1, 1, 10)
+"""
+
+
+def test_http_server_reload_permissions(re_manager_pc_copy, fastapi_server, tmp_path):  # noqa F811
+
+    pc_path = copy_default_profile_collection(tmp_path)
+    append_code_to_last_startup_file(pc_path, additional_code=_sample_trivial_plan1)
+
+    # Generate the new list of allowed plans and devices and reload them
+    gen_list_of_plans_and_devices(pc_path, overwrite=True)
+
+    # Attempt to add the plan to the queue. The request is supposed to fail, because
+    #   the initially loaded profile collection does not contain the plan.
+    plan = {"plan": {"name": "trivial_plan_for_unit_test"}}
+    resp1 = _request_to_json("post", "/queue/item/add", json=plan)
+    assert resp1["success"] is False, str(resp1)
+
+    # Reload profile collection
+    resp2 = _request_to_json("post", "/permissions/reload")
+    assert resp2["success"] is True, str(resp2)
+
+    # Attempt to add the plan to the queue. It should be successful now.
+    plan = {"plan": {"name": "trivial_plan_for_unit_test"}}
+    resp3 = _request_to_json("post", "/queue/item/add", json=plan)
+    assert resp3["success"] is True, str(resp3)
+    assert resp3["qsize"] == 1, str(resp3)

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -799,16 +799,19 @@ def trivial_plan_for_unit_test():
 
 
 def test_http_server_reload_permissions(re_manager_pc_copy, fastapi_server, tmp_path):  # noqa F811
-
+    """
+    Tests for ``/permissions/reload`` API.
+    """
     pc_path = copy_default_profile_collection(tmp_path)
     append_code_to_last_startup_file(pc_path, additional_code=_sample_trivial_plan1)
 
     # Generate the new list of allowed plans and devices and reload them
     gen_list_of_plans_and_devices(pc_path, overwrite=True)
 
+    plan = {"plan": {"name": "trivial_plan_for_unit_test"}}
+
     # Attempt to add the plan to the queue. The request is supposed to fail, because
     #   the initially loaded profile collection does not contain the plan.
-    plan = {"plan": {"name": "trivial_plan_for_unit_test"}}
     resp1 = _request_to_json("post", "/queue/item/add", json=plan)
     assert resp1["success"] is False, str(resp1)
 
@@ -817,7 +820,6 @@ def test_http_server_reload_permissions(re_manager_pc_copy, fastapi_server, tmp_
     assert resp2["success"] is True, str(resp2)
 
     # Attempt to add the plan to the queue. It should be successful now.
-    plan = {"plan": {"name": "trivial_plan_for_unit_test"}}
     resp3 = _request_to_json("post", "/queue/item/add", json=plan)
     assert resp3["success"] is True, str(resp3)
     assert resp3["qsize"] == 1, str(resp3)

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -788,7 +788,6 @@ def test_http_server_re_runs(re_manager, fastapi_server, suffix, expected_n_item
     assert wait_for_manager_state_idle(30), "Timeout"
 
 
-
 _sample_trivial_plan1 = """
 def trivial_plan_for_unit_test():
     '''


### PR DESCRIPTION
Implementation of REST API (`/permissions/reload`) and CLI (`qserver permissions reload`) support for `permissions_reload` ZMQ API.

Contains all commits from PR https://github.com/bluesky/bluesky-queueserver/pull/110

Addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/112