### PR TITLE
Loading of startup files based on IPython profile name.

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -1350,7 +1350,7 @@ def load_profile_collection_from_ipython(path=None):
         load_profile_collection_from_ipython()
     """
     ip = get_ipython()  # noqa F821
-    for f in sorted(glob.glob("[0-9][0-9]*.py")):
+    for f in sorted(glob.glob("*.py")):
         print(f"Executing '{f}' in TravisCI")
         ip.parent._exec_file(f)
     print("Profile collection was loaded successfully.")

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 qserver_version = bluesky_queueserver.__version__
 
 
-def get_default_profile_collection_dir():
+def get_default_startup_dir():
     """
     Returns the path to the default profile collection that is distributed with the package.
     The function does not guarantee that the directory exists.

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -205,8 +205,9 @@ def load_profile_collection(path, *, patch_profiles=True, keep_re=False):
     if not os.path.isdir(path):
         raise IOError(f"Failed to load the profile collection. Path '{path}' is not a directory.")
 
-    file_pattern = os.path.join(path, "[0-9][0-9]*.py")
-    file_list = glob.glob(file_pattern)
+    file_pattern_py = os.path.join(path, "*.py")
+    file_pattern_ipy = os.path.join(path, "*.ipy")
+    file_list = glob.glob(file_pattern_py) + glob.glob(file_pattern_ipy)
     file_list.sort()  # Sort in alphabetical order
 
     # If the profile collection contains no startup files, it is very likely
@@ -1350,7 +1351,7 @@ def load_profile_collection_from_ipython(path=None):
         load_profile_collection_from_ipython()
     """
     ip = get_ipython()  # noqa F821
-    for f in sorted(glob.glob("*.py")):
+    for f in sorted(glob.glob("*.py") + glob.glob("*.ipy")):
         print(f"Executing '{f}' in TravisCI")
         ip.parent._exec_file(f)
     print("Profile collection was loaded successfully.")

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -274,10 +274,12 @@ def start_manager():
         profile_name = args.profile_name
         try:
             import IPython
+
             path_to_ipython = IPython.paths.get_ipython_dir()
         except Exception:
-            logger.error("IPython is not installed. Specify directory to startup file by using "
-                         "'--startup-dir' option.")
+            logger.error(
+                "IPython is not installed. Specify directory to startup file by using " "'--startup-dir' option."
+            )
             return 1
         startup_dir = os.path.abspath(path_to_ipython)
         profile_name_full = f"profile_{profile_name}"

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -191,7 +191,7 @@ def start_manager():
         description="Start a RE Manager", epilog=f"blueksy-queueserver version {__version__}"
     )
     parser.add_argument(
-        "--zmq_addr",
+        "--zmq-addr",
         dest="zmq_addr",
         type=str,
         default="tcp://*:5555",
@@ -213,7 +213,7 @@ def start_manager():
     )
 
     parser.add_argument(
-        "--existing_plans_and_devices",
+        "--existing-plans-and-devices",
         dest="existing_plans_and_devices_path",
         type=str,
         help="Path to file that contains the list of existing plans and devices. "
@@ -222,7 +222,7 @@ def start_manager():
         "'existing_plans_and_devices.yaml' is used.",
     )
     parser.add_argument(
-        "--user_group_permissions",
+        "--user-group-permissions",
         dest="user_group_permissions_path",
         type=str,
         help="Path to file that contains lists of plans and devices available to users. "
@@ -230,12 +230,17 @@ def start_manager():
         "If the path is a directory, then the default file name "
         "'user_group_permissions.yaml' is used.",
     )
-    parser.add_argument("--kafka_topic", type=str, help="The kafka topic to publish to.")
+    parser.add_argument("--kafka-topic", dest="kafka_topic", type=str, help="The kafka topic to publish to.")
     parser.add_argument(
-        "--kafka_server", type=str, help="Bootstrap server to connect to.", default="127.0.0.1:9092"
+        "--kafka-server",
+        dest="kafka_server",
+        type=str,
+        help="Bootstrap server to connect to.",
+        default="127.0.0.1:9092",
     )
     parser.add_argument(
-        "--keep_re",
+        "--keep-re",
+        dest="keep_re",
         action="store_true",
         help="Keep RE created in profile collection. If the flag is set, RE must be "
         "created in the profile collection for the plans to run. RE will also "
@@ -252,7 +257,7 @@ def start_manager():
         "Run IDs between restarts of RE.",
     )
     parser.add_argument(
-        "--databroker_config",
+        "--databroker-config",
         dest="databroker_config",
         type=str,
         help="Name of the Data Broker configuration file.",

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -244,7 +244,8 @@ def start_manager():
         "is ignored.",
     )
     parser.add_argument(
-        "--use_mpack",
+        "--use-persistent-metadata",
+        dest="use_persistent_metadata",
         action="store_true",
         help="Use msgpack-based persistent storage for scan metadata. Currently this "
         "is the preferred method to keep continuously incremented sequence of "
@@ -297,7 +298,7 @@ def start_manager():
         return 1
 
     config_worker["keep_re"] = args.keep_re
-    config_worker["use_mpack"] = args.use_mpack
+    config_worker["use_persistent_metadata"] = args.use_persistent_metadata
 
     config_worker["databroker"] = {}
     if args.databroker_config:

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -205,18 +205,18 @@ def start_manager():
         dest="startup_dir",
         type=str,
         help="Path to directory that contains a set of startup files (*.py and *.ipy). All the scripts "
-             "in the directory will be sorted in alphabetical order of their names and loaded in "
-             "the Run Engine Worker environment. The set of startup files may be located in any accessible "
-             "directory.",
+        "in the directory will be sorted in alphabetical order of their names and loaded in "
+        "the Run Engine Worker environment. The set of startup files may be located in any accessible "
+        "directory.",
     )
     group.add_argument(
         "--startup-profile",
         dest="profile_name",
         type=str,
         help="The name of IPython profile used to find the location of startup files. Example: if IPython is "
-             "configured to look for profiles in '~/.ipython' directory (default behavior) and the profile "
-             "name is 'testing', then RE Manager will look for startup files in "
-             "'~/.ipython/profile_testing/startup' directory.",
+        "configured to look for profiles in '~/.ipython' directory (default behavior) and the profile "
+        "name is 'testing', then RE Manager will look for startup files in "
+        "'~/.ipython/profile_testing/startup' directory.",
     )
 
     parser.add_argument(

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -7,7 +7,7 @@ import os
 from .worker import RunEngineWorker
 from .manager import RunEngineManager
 from .comms import PipeJsonRpcReceive
-from .profile_ops import get_default_profile_collection_dir
+from .profile_ops import get_default_startup_dir
 
 from .. import __version__
 
@@ -198,9 +198,8 @@ def start_manager():
         help="The address of ZMQ server.",
     )
     parser.add_argument(
-        "--profile_collection",
-        "-p",
-        dest="profile_collection_path",
+        "--startup-dir",
+        dest="startup_dir",
         type=str,
         help="Path to directory that contains profile collection.",
     )
@@ -260,19 +259,19 @@ def start_manager():
         config_worker["kafka"]["topic"] = args.kafka_topic
         config_worker["kafka"]["bootstrap"] = args.kafka_server
 
-    if args.profile_collection_path:
-        pc_path = args.profile_collection_path
-        pc_path = os.path.abspath(os.path.expanduser(pc_path))
-        if not os.path.exists(pc_path):
-            logger.error("Profile collection directory '%s' does not exist", pc_path)
+    if args.startup_dir:
+        startup_dir = args.startup_dir
+        startup_dir = os.path.abspath(os.path.expanduser(startup_dir))
+        if not os.path.exists(startup_dir):
+            logger.error("Startup directory '%s' does not exist", startup_dir)
             return 1
-        if not os.path.isdir(pc_path):
-            logger.error("Path to profile collection '%s' is not a directory", pc_path)
+        if not os.path.isdir(startup_dir):
+            logger.error("Startup directory '%s' is not a directory", startup_dir)
             return 1
     else:
         # The default collection is the collection of simulated Ophyd devices
         #   and built-in Bluesky plans.
-        pc_path = get_default_profile_collection_dir()
+        startup_dir = get_default_startup_dir()
 
     config_worker["keep_re"] = args.keep_re
     config_worker["use_mpack"] = args.use_mpack
@@ -281,17 +280,17 @@ def start_manager():
     if args.databroker_config:
         config_worker["databroker"]["config"] = args.databroker_config
 
-    config_worker["profile_collection_path"] = pc_path
+    config_worker["startup_dir"] = startup_dir
 
     default_existing_pd_fln = "existing_plans_and_devices.yaml"
     if args.existing_plans_and_devices_path:
         existing_pd_path = os.path.expanduser(args.existing_plans_and_devices_path)
         if not os.path.isabs(existing_pd_path):
-            existing_pd_path = os.path.join(pc_path, existing_pd_path)
+            existing_pd_path = os.path.join(startup_dir, existing_pd_path)
         if not existing_pd_path.endswith(".yaml"):
             os.path.join(existing_pd_path, default_existing_pd_fln)
     else:
-        existing_pd_path = os.path.join(pc_path, default_existing_pd_fln)
+        existing_pd_path = os.path.join(startup_dir, default_existing_pd_fln)
     if not os.path.isfile(existing_pd_path):
         logger.error(
             "The list of allowed plans and devices was not found at "
@@ -304,11 +303,11 @@ def start_manager():
     if args.user_group_permissions_path:
         user_group_pd_path = os.path.expanduser(args.user_group_permissions_path)
         if not os.path.isabs(user_group_pd_path):
-            user_group_pd_path = os.path.join(pc_path, user_group_pd_path)
+            user_group_pd_path = os.path.join(startup_dir, user_group_pd_path)
         if not user_group_pd_path.endswith(".yaml"):
             os.path.join(user_group_pd_path, default_existing_pd_fln)
     else:
-        user_group_pd_path = os.path.join(pc_path, default_user_group_pd_fln)
+        user_group_pd_path = os.path.join(startup_dir, default_user_group_pd_fln)
     if not os.path.isfile(user_group_pd_path):
         logger.error(
             "The file with user permissions was not found at "

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -3,6 +3,7 @@ from multiprocessing import Pipe
 import threading
 import time as ttime
 import os
+from importlib.util import find_spec
 
 from .worker import RunEngineWorker
 from .manager import RunEngineManager
@@ -277,13 +278,13 @@ def start_manager():
     # Find startup directory
     if args.profile_name:
         profile_name = args.profile_name
-        try:
+        if find_spec("IPython"):
             import IPython
 
             path_to_ipython = IPython.paths.get_ipython_dir()
-        except Exception:
+        else:
             logger.error(
-                "IPython is not installed. Specify directory to startup file by using " "'--startup-dir' option."
+                "IPython is not installed. Specify directory to startup file by using '--startup-dir' option."
             )
             return 1
         startup_dir = os.path.abspath(path_to_ipython)

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -204,13 +204,19 @@ def start_manager():
         "--startup-dir",
         dest="startup_dir",
         type=str,
-        help="Path to directory that contains startup files (profile collection).",
+        help="Path to directory that contains a set of startup files (*.py and *.ipy). All the scripts "
+             "in the directory will be sorted in alphabetical order of their names and loaded in "
+             "the Run Engine Worker environment. The set of startup files may be located in any accessible "
+             "directory.",
     )
     group.add_argument(
         "--startup-profile",
         dest="profile_name",
         type=str,
-        help="The name of IPython profile used to find the location of startup files (profile collection).",
+        help="The name of IPython profile used to find the location of startup files. Example: if IPython is "
+             "configured to look for profiles in '~/.ipython' directory (default behavior) and the profile "
+             "name is 'testing', then RE Manager will look for startup files in "
+             "'~/.ipython/profile_testing/startup' directory.",
     )
 
     parser.add_argument(
@@ -287,9 +293,9 @@ def start_manager():
                 "IPython is not installed. Specify directory to startup file by using '--startup-dir' option."
             )
             return 1
-        startup_dir = os.path.abspath(path_to_ipython)
+        ipython_dir = os.path.abspath(path_to_ipython)
         profile_name_full = f"profile_{profile_name}"
-        startup_dir = os.path.join(startup_dir, profile_name_full, "startup")
+        startup_dir = os.path.join(ipython_dir, profile_name_full, "startup")
     elif args.startup_dir:
         startup_dir = args.startup_dir
         startup_dir = os.path.abspath(os.path.expanduser(startup_dir))

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -188,7 +188,7 @@ class WatchdogProcess:
 
 def start_manager():
     parser = argparse.ArgumentParser(
-        description="Start a RE Manager", epilog=f"blueksy-queueserver version {__version__}"
+        description="Start Run Engine (RE) Manager", epilog=f"blueksy-queueserver version {__version__}"
     )
     parser.add_argument(
         "--zmq-addr",

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -245,7 +245,7 @@ def start_manager():
         help="Keep RE created in profile collection. If the flag is set, RE must be "
         "created in the profile collection for the plans to run. RE will also "
         "keep all its subscriptions. Also must be subscribed to the Data Broker "
-        "inside the profile collection, since '--databroker_config' argument "
+        "inside the profile collection, since '--databroker-config' argument "
         "is ignored.",
     )
     parser.add_argument(

--- a/bluesky_queueserver/manager/tests/_common.py
+++ b/bluesky_queueserver/manager/tests/_common.py
@@ -32,7 +32,7 @@ def copy_default_profile_collection(tmp_path, *, copy_yaml=True):
     os.makedirs(new_pc_path, exist_ok=True)
 
     # Copy simulated profile collection (only .py files)
-    patterns = ["*.py"]
+    patterns = ["*.py", "*.ipy"]
     if copy_yaml:
         patterns.append("*.yaml")
     for pattern in patterns:
@@ -57,8 +57,9 @@ def patch_first_startup_file(pc_path, additional_code):
     """
 
     # Path to the first file (starts with 00)
-    file_pattern = os.path.join(pc_path, "*.py")
-    file_list = glob.glob(file_pattern)
+    file_pattern_py = os.path.join(pc_path, "*.py")
+    file_pattern_ipy = os.path.join(pc_path, "*.ipy")
+    file_list = glob.glob(file_pattern_py) + glob.glob(file_pattern_ipy)
     file_list.sort()
     fln = file_list[0]
 
@@ -80,8 +81,9 @@ def patch_first_startup_file_undo(pc_path):
     Remove patches applied to the first file of profile collection.
     """
     # Path to the first file (starts with 00)
-    file_pattern = os.path.join(pc_path, "*.py")
-    file_list = glob.glob(file_pattern)
+    file_pattern_py = os.path.join(pc_path, "*.py")
+    file_pattern_ipy = os.path.join(pc_path, "*.ipy")
+    file_list = glob.glob(file_pattern_py) + glob.glob(file_pattern_ipy)
     file_list.sort()
     fln = file_list[0]
 
@@ -104,8 +106,9 @@ def append_code_to_last_startup_file(pc_path, additional_code):
     """
 
     # Path to the last file
-    file_pattern = os.path.join(pc_path, "*.py")
-    file_list = glob.glob(file_pattern)
+    file_pattern_py = os.path.join(pc_path, "*.py")
+    file_pattern_ipy = os.path.join(pc_path, "*.ipy")
+    file_list = glob.glob(file_pattern_py) + glob.glob(file_pattern_ipy)
     file_list.sort()
     fln = file_list[-1]
 

--- a/bluesky_queueserver/manager/tests/_common.py
+++ b/bluesky_queueserver/manager/tests/_common.py
@@ -10,7 +10,7 @@ import tempfile
 
 from databroker import catalog_search_path
 
-from bluesky_queueserver.manager.profile_ops import get_default_profile_collection_dir
+from bluesky_queueserver.manager.profile_ops import get_default_startup_dir
 from bluesky_queueserver.manager.plan_queue_ops import PlanQueueOperations
 from bluesky_queueserver.manager.comms import zmq_single_request
 
@@ -25,7 +25,7 @@ def copy_default_profile_collection(tmp_path, *, copy_yaml=True):
     Returns the new temporary directory.
     """
     # Default path
-    pc_path = get_default_profile_collection_dir()
+    pc_path = get_default_startup_dir()
     # New path
     new_pc_path = os.path.join(tmp_path, "startup")
 
@@ -393,7 +393,7 @@ def re_manager_pc_copy(tmp_path):
     Copy profile collection and return its temporary path.
     """
     pc_path = copy_default_profile_collection(tmp_path)
-    re = ReManager(["-p", pc_path])
+    re = ReManager(["--startup-dir", pc_path])
 
     # Wait until RE Manager is started
     assert wait_for_condition(time=10, condition=condition_manager_idle), "Timeout: RE Manager failed to start."

--- a/bluesky_queueserver/manager/tests/_common.py
+++ b/bluesky_queueserver/manager/tests/_common.py
@@ -32,7 +32,7 @@ def copy_default_profile_collection(tmp_path, *, copy_yaml=True):
     os.makedirs(new_pc_path, exist_ok=True)
 
     # Copy simulated profile collection (only .py files)
-    patterns = ["[0-9][0-9]*.py"]
+    patterns = ["*.py"]
     if copy_yaml:
         patterns.append("*.yaml")
     for pattern in patterns:
@@ -57,7 +57,7 @@ def patch_first_startup_file(pc_path, additional_code):
     """
 
     # Path to the first file (starts with 00)
-    file_pattern = os.path.join(pc_path, "[0-9][0-9]*.py")
+    file_pattern = os.path.join(pc_path, "*.py")
     file_list = glob.glob(file_pattern)
     file_list.sort()
     fln = file_list[0]
@@ -80,7 +80,7 @@ def patch_first_startup_file_undo(pc_path):
     Remove patches applied to the first file of profile collection.
     """
     # Path to the first file (starts with 00)
-    file_pattern = os.path.join(pc_path, "[0-9][0-9]*.py")
+    file_pattern = os.path.join(pc_path, "*.py")
     file_list = glob.glob(file_pattern)
     file_list.sort()
     fln = file_list[0]
@@ -104,7 +104,7 @@ def append_code_to_last_startup_file(pc_path, additional_code):
     """
 
     # Path to the last file
-    file_pattern = os.path.join(pc_path, "[0-9][0-9]*.py")
+    file_pattern = os.path.join(pc_path, "*.py")
     file_list = glob.glob(file_pattern)
     file_list.sort()
     fln = file_list[-1]

--- a/bluesky_queueserver/manager/tests/test_fixtures.py
+++ b/bluesky_queueserver/manager/tests/test_fixtures.py
@@ -57,7 +57,7 @@ def test_fixture_re_manager_cmd_2(re_manager_cmd, db_catalog):  # noqa F811
     start document.
     """
     db_name = db_catalog["catalog_name"]
-    re_manager_cmd(["--databroker_config", db_name])
+    re_manager_cmd(["--databroker-config", db_name])
 
     cat = db_catalog["catalog"]
 

--- a/bluesky_queueserver/manager/tests/test_manager_options.py
+++ b/bluesky_queueserver/manager/tests/test_manager_options.py
@@ -1,0 +1,99 @@
+import pytest
+import shutil
+import os
+import glob
+
+from bluesky_queueserver.manager.profile_ops import gen_list_of_plans_and_devices
+from bluesky_queueserver.manager.comms import zmq_single_request
+
+from ._common import (
+    copy_default_profile_collection,
+    append_code_to_last_startup_file,
+    wait_for_condition,
+    condition_environment_created,
+    condition_queue_processing_finished,
+    condition_environment_closed,
+)
+
+from ._common import re_manager_cmd  # noqa: F401
+
+# User name and user group name used throughout most of the tests.
+_user, _user_group = "Testing Script", "admin"
+
+
+_sample_plan1 = """
+def simple_sample_plan():
+    '''
+    Simple plan for tests.
+    '''
+    yield from count([det1, det2])
+"""
+
+
+# fmt: off
+@pytest.mark.parametrize("option", ["startup_dir", "profile", "multiple"])
+# fmt: on
+def test_manager_options_startup_profile(re_manager_cmd, tmp_path, monkeypatch, option):  # noqa: F811
+    pc_path = copy_default_profile_collection(tmp_path)
+
+    # Add extra plan. The original set of startup files will not contain this plan.
+    append_code_to_last_startup_file(pc_path, additional_code=_sample_plan1)
+
+    # Generate the new list of allowed plans and devices and reload them
+    gen_list_of_plans_and_devices(pc_path, overwrite=True)
+
+    # Start manager
+    if option == "startup_dir":
+        re_manager_cmd(["--startup-dir", pc_path])
+    elif option == "profile":
+        # This option is more complicated: we want to recreate the structure of IPython startup
+        #   directory: <some root dir>/profile_<profile_name>/startup.
+        root_dir = os.path.split(pc_path)[0]
+        monkeypatch.setenv("IPYTHONDIR", root_dir)
+        profile_name = "testing"
+        startup_path = os.path.join(root_dir, f"profile_{profile_name}", "startup")
+        os.makedirs(startup_path)
+
+        file_pattern = os.path.join(pc_path, "*")
+        for fl_path in glob.glob(file_pattern):
+            shutil.move(fl_path, startup_path)
+
+        os.rmdir(pc_path)
+
+        # We pass only profile name as a parameter.
+        re_manager_cmd(["--startup-profile", profile_name])
+    elif option == "multiple":
+        # Expected to fail if multiple options are selected.
+        with pytest.raises(TimeoutError, match="RE Manager failed to start"):
+            re_manager_cmd(["--startup-dir", pc_path, "--startup-profile", "some_name"])
+        return
+    else:
+        assert False, f"Unknown option '{option}'"
+
+    # Open the environment (make sure that the environment loads)
+    resp1, _ = zmq_single_request("environment_open")
+    assert resp1["success"] is True
+    assert wait_for_condition(time=10, condition=condition_environment_created)
+
+    # Add the plan to the queue (will fail if incorrect environment is loaded)
+    plan = {"name": "simple_sample_plan"}
+    params = {"plan": plan, "user": _user, "user_group": _user_group}
+    resp2, _ = zmq_single_request("queue_item_add", params)
+    assert resp2["success"] is True, f"resp={resp2}"
+
+    # Start the queue
+    resp3, _ = zmq_single_request("queue_start")
+    assert resp3["success"] is True
+    assert wait_for_condition(time=10, condition=condition_queue_processing_finished)
+
+    # Make sure that the plan was executed
+    resp4, _ = zmq_single_request("status")
+    assert resp4["items_in_queue"] == 0
+    assert resp4["items_in_history"] == 1
+
+    # Close the environment
+    resp5, _ = zmq_single_request("environment_close")
+    assert resp5["success"] is True, f"resp={resp5}"
+    assert wait_for_condition(time=5, condition=condition_environment_closed)
+
+    monkeypatch.setenv("IPYTHONDIR", "abc")

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -13,7 +13,7 @@ from ._common import copy_default_profile_collection, patch_first_startup_file
 from bluesky_queueserver.manager.annotation_decorator import parameter_annotation_decorator
 
 from bluesky_queueserver.manager.profile_ops import (
-    get_default_profile_collection_dir,
+    get_default_startup_dir,
     load_profile_collection,
     plans_from_nspace,
     devices_from_nspace,
@@ -50,11 +50,11 @@ def test_hex2bytes_bytes2hex():
     assert dict_result == dict_initial
 
 
-def test_get_default_profile_collection_dir():
+def test_get_default_startup_dir():
     """
-    Function `get_default_profile_collection_dir`
+    Function `get_default_startup_dir`
     """
-    pc_path = get_default_profile_collection_dir()
+    pc_path = get_default_startup_dir()
     assert os.path.exists(pc_path), "Directory with default profile collection deos not exist."
 
 
@@ -62,7 +62,7 @@ def test_load_profile_collection_1():
     """
     Loading default profile collection
     """
-    pc_path = get_default_profile_collection_dir()
+    pc_path = get_default_startup_dir()
     nspace = load_profile_collection(pc_path)
     assert len(nspace) > 0, "Failed to load the profile collection"
 
@@ -464,7 +464,7 @@ def test_plans_from_nspace():
     """
     Function 'plans_from_nspace' is extracting a subset of callable items from the namespace
     """
-    pc_path = get_default_profile_collection_dir()
+    pc_path = get_default_startup_dir()
     nspace = load_profile_collection(pc_path)
     plans = plans_from_nspace(nspace)
     for name, plan in plans.items():
@@ -475,7 +475,7 @@ def test_devices_from_nspace():
     """
     Function 'plans_from_nspace' is extracting a subset of callable items from the namespace
     """
-    pc_path = get_default_profile_collection_dir()
+    pc_path = get_default_startup_dir()
     nspace = load_profile_collection(pc_path)
     devices = devices_from_nspace(nspace)
     for name, device in devices.items():
@@ -497,7 +497,7 @@ def test_devices_from_nspace():
 )
 def test_parse_plan(plan, success, err_msg):
 
-    pc_path = get_default_profile_collection_dir()
+    pc_path = get_default_startup_dir()
     nspace = load_profile_collection(pc_path)
     plans = plans_from_nspace(nspace)
     devices = devices_from_nspace(nspace)
@@ -574,7 +574,7 @@ def test_load_existing_plans_and_devices():
     """
     Loads the list of allowed plans and devices from simulated profile collection.
     """
-    pc_path = get_default_profile_collection_dir()
+    pc_path = get_default_startup_dir()
     file_path = os.path.join(pc_path, "existing_plans_and_devices.yaml")
 
     existing_plans, existing_devices = load_existing_plans_and_devices(file_path)
@@ -633,7 +633,7 @@ def test_verify_default_profile_collection():
     issue.
     """
     # Create dictionaries of existing plans and devices. Apply all preprocessing steps.
-    pc_path = get_default_profile_collection_dir()
+    pc_path = get_default_startup_dir()
     nspace = load_profile_collection(pc_path)
 
     plans = plans_from_nspace(nspace)
@@ -856,7 +856,7 @@ def test_select_allowed_items(item_dict, allow_patterns, disallow_patterns, resu
 # fmt: on
 def test_load_allowed_plans_and_devices_1(fln_existing_items, fln_user_groups, empty_dict, all_users):
     """"""
-    pc_path = get_default_profile_collection_dir()
+    pc_path = get_default_startup_dir()
 
     fln_existing_items = None if (fln_existing_items is None) else os.path.join(pc_path, fln_existing_items)
     fln_user_groups = None if (fln_user_groups is None) else os.path.join(pc_path, fln_user_groups)

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -466,7 +466,7 @@ def test_zmq_api_queue_item_add_7(db_catalog, re_manager_cmd, meta_param, meta_s
     """
     Add plan with metadata.
     """
-    re_manager_cmd(["--databroker_config", db_catalog["catalog_name"]])
+    re_manager_cmd(["--databroker-config", db_catalog["catalog_name"]])
     cat = db_catalog["catalog"]
 
     # Plan

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -5,7 +5,7 @@ import asyncio
 from copy import deepcopy
 
 from bluesky_queueserver.manager.profile_ops import (
-    get_default_profile_collection_dir,
+    get_default_startup_dir,
     load_allowed_plans_and_devices,
     gen_list_of_plans_and_devices,
 )
@@ -603,7 +603,7 @@ def test_zmq_api_plans_allowed_and_devices_allowed_2(re_manager):  # noqa F811
     separately somewhere else.
     """
 
-    pc_path = get_default_profile_collection_dir()
+    pc_path = get_default_startup_dir()
     path_epd = os.path.join(pc_path, _existing_plans_and_devices_fln)
     path_up = os.path.join(pc_path, _user_group_permissions_fln)
 

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -578,7 +578,7 @@ class RunEngineWorker(Process):
                 else:
                     # Instantiate a new Run Engine and Data Broker (if needed)
                     md = {}
-                    if self._config["use_mpack"]:
+                    if self._config["use_persistent_metadata"]:
                         # This code is temporarily copied from 'nslsii' before better solution for keeping
                         #   continuous sequence Run ID is found. TODO: continuous sequence of Run IDs.
                         directory = os.path.expanduser("~/.config/bluesky/md")

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -528,11 +528,11 @@ class RunEngineWorker(Process):
             self._existing_plans = {}
             self._existing_devices = {}
 
-        if "profile_collection_path" not in self._config:
-            logger.warning("Path to profile collection was not specified. No profile collection will be loaded.")
+        if "startup_dir" not in self._config:
+            logger.warning("Startup directory name was not specified. Profile collection will not be loaded.")
             init_namespace()
         else:
-            path = self._config["profile_collection_path"]
+            path = self._config["startup_dir"]
             logger.info("Loading beamline profile collection from directory '%s' ...", path)
             try:
                 keep_re = self._config["keep_re"]


### PR DESCRIPTION
The PR partially addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/114:

- Additional CLI option `--startup-profile` for `start-re-manager` is added, which allows to specify the name of IPython profile that contains the collection of startup files. The option works the same as `--startup-dir`, except that it does not require the user to specify path to the directory that contains startup files, but constructs the path based on the settings of IPython and provided profile name. The files are expected to be located at `<IPython_config_dir>/profile_<profile_name>/startup`. The parameter `--startup-profile` can not be used if IPython is not installed.

- The parameters `--startup-dir` and `--startup-profile` are mutually exclusive. The manager will fail to start if both parameters are specified.

- The existing parameter `--profile_collection` or `-p` is replaced by `--startup-dir`, since the old name does not accurately reflects the meaning.

- The parameter `--use_mpack` is renamed into `--use-persistent-metadata`, since the old name does not accurately describe the functionality.

- Removed restrictions on the names of startup files. In the original implementation, only files with names starting with two digits (`00` - `99`) were loaded. Now all files in the startup directory are loaded. The files are loaded in alphabetical order, so it i still recommended to number the files for convenience.

- Replaced `_` with `-` in all the other CLI parameters of `start-re-manager`:
 
