### PR TITLE
Populating worker namespace by loading a scripts or importing a module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ On Mac OS::
 
   pip install -e .
 
-This also sets up an entry points for the 'qserver' and 'qserver_list_of_plans_and_devices' CLI tools.
+This also sets up an entry points for the 'qserver' and 'qserver-list-plans-devices' CLI tools.
 
 **Install httpie (optional)**::
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -379,6 +379,8 @@ def load_worker_startup_code(
 
     if startup_dir is not None:
         logger.info("Loading RE Worker startup code from directory '%s' ...", startup_dir)
+        startup_dir = os.path.abspath(os.path.expanduser(startup_dir))
+        print(f"startup_dir={startup_dir}") ##
         nspace = load_profile_collection(startup_dir, keep_re=keep_re)
 
     elif startup_module_name is not None:
@@ -387,6 +389,7 @@ def load_worker_startup_code(
 
     elif startup_script_path is not None:
         logger.info("Loading RE Worker startup code from script '%s' ...", startup_script_path)
+        startup_script_path = os.path.abspath(os.path.expanduser(startup_script_path))
         nspace = load_startup_script(startup_script_path, keep_re=keep_re)
 
     else:
@@ -1151,7 +1154,7 @@ def gen_list_of_plans_and_devices(
     startup_module_name=None,
     startup_script_path=None,
     file_dir=None,
-    file_name="existing_plans_and_devices.yaml",
+    file_name=None,
     overwrite=False,
 ):
     """
@@ -1174,7 +1177,7 @@ def gen_list_of_plans_and_devices(
     file_dir: str or None
         path to the directory where the file is to be created. None - create file in current directory.
     file_name: str
-        name of the output YAML file
+        name of the output YAML file, None - default file name is used
     overwrite: boolean
         overwrite the file if it already exists
 
@@ -1187,6 +1190,7 @@ def gen_list_of_plans_and_devices(
     RuntimeError
         Error occurred while creating or saving the lists.
     """
+    file_name = file_name or "existing_plans_and_devices.yaml"
     try:
         if file_dir is None:
             file_dir = os.getcwd()
@@ -1237,7 +1241,7 @@ def gen_list_of_plans_and_devices_cli():
         epilog=f"Bluesky-QServer version {qserver_version}.",
     )
     parser.add_argument(
-        "--file_dir",
+        "--file-dir",
         dest="file_dir",
         action="store",
         required=False,
@@ -1245,7 +1249,7 @@ def gen_list_of_plans_and_devices_cli():
         help="Directory where the list of plans and devices is saved. Default: current directory.",
     )
     parser.add_argument(
-        "--file_name",
+        "--file-name",
         dest="file_name",
         action="store",
         required=False,

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -380,7 +380,7 @@ def load_worker_startup_code(
     if startup_dir is not None:
         logger.info("Loading RE Worker startup code from directory '%s' ...", startup_dir)
         startup_dir = os.path.abspath(os.path.expanduser(startup_dir))
-        print(f"startup_dir={startup_dir}") ##
+        print(f"startup_dir={startup_dir}")
         nspace = load_profile_collection(startup_dir, keep_re=keep_re)
 
     elif startup_module_name is not None:

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -1246,7 +1246,8 @@ def gen_list_of_plans_and_devices_cli():
         action="store",
         required=False,
         default=None,
-        help="Directory where the list of plans and devices is saved. Default: current directory.",
+        help="Directory where the list of plans and devices is saved. By default, the list is saved "
+        "to the file 'existing_plans_and_devices.yaml' in the current directory.",
     )
     parser.add_argument(
         "--file-name",
@@ -1254,8 +1255,8 @@ def gen_list_of_plans_and_devices_cli():
         action="store",
         required=False,
         default=None,
-        help="Name of the file where the list of plans and devices is saved. Default file name is used"
-        "if the parameter is not specified.",
+        help="Name of the file where the list of plans and devices is saved. Default file name "
+        "'existing_plans_and_devices.yaml' is used unless the parameter is not specified.",
     )
 
     group = parser.add_mutually_exclusive_group()
@@ -1267,23 +1268,26 @@ def gen_list_of_plans_and_devices_cli():
         help="Path to directory that contains a set of startup files (*.py and *.ipy). All the scripts "
         "in the directory will be sorted in alphabetical order of their names and loaded in "
         "the Run Engine Worker environment. The set of startup files may be located in any accessible "
-        "directory.",
+        "directory. Example: 'qserver_list_of_plans_and_devices --startup-dir .' load startup "
+        "files from the current directory and saves the lists to the file in current directory.",
     )
     group.add_argument(
         "--startup-module",
         dest="startup_module_name",
         type=str,
         default=None,
-        help="The name of the module with startup code. The module is imported each time the RE Worker "
-        "environment is opened. Example: 'some.startup.module'.",
+        help="The name of the module with startup code. Example: "
+        "'qserver_list_of_plans_and_devices --startup-module some.startup.module' loads startup "
+        "code from the module 'some.startup.module' and saves results to the file in the current directory.",
     )
     group.add_argument(
         "--startup-script",
         dest="startup_script_path",
         type=str,
         default=None,
-        help="The path to the script with startup code. The script is loaded each time the RE Worker "
-        "environment is opened. Example: 'some.startup.module'.",
+        help="The path to the script with startup code. Example: "
+        "'qserver_list_of_plans_and_devices --startup-script ~/startup/scripts/script.py' loads"
+        "startup code from the script and saves the results to the file in the current directory.",
     )
 
     args = parser.parse_args()

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -1225,9 +1225,9 @@ def gen_list_of_plans_and_devices(
 
 def gen_list_of_plans_and_devices_cli():
     """
-    'qserver_list_of_plans_and_devices'
+    'qserver-list-plans-devices'
     CLI tool for generating the list of existing plans and devices based on profile collection.
-    The tool is supposed to be called as 'qserver_list_of_plans_and_devices' from command line.
+    The tool is supposed to be called as 'qserver-list-plans-devices' from command line.
     The function will ALWAYS overwrite the existing list of plans and devices (the list
     is automatically generated, so overwriting (updating) should be a safe operation that doesn't
     lead to loss configuration data.
@@ -1268,7 +1268,7 @@ def gen_list_of_plans_and_devices_cli():
         help="Path to directory that contains a set of startup files (*.py and *.ipy). All the scripts "
         "in the directory will be sorted in alphabetical order of their names and loaded in "
         "the Run Engine Worker environment. The set of startup files may be located in any accessible "
-        "directory. Example: 'qserver_list_of_plans_and_devices --startup-dir .' load startup "
+        "directory. Example: 'qserver-list-plans-devices --startup-dir .' load startup "
         "files from the current directory and saves the lists to the file in current directory.",
     )
     group.add_argument(
@@ -1277,7 +1277,7 @@ def gen_list_of_plans_and_devices_cli():
         type=str,
         default=None,
         help="The name of the module with startup code. Example: "
-        "'qserver_list_of_plans_and_devices --startup-module some.startup.module' loads startup "
+        "'qserver-list-plans-devices --startup-module some.startup.module' loads startup "
         "code from the module 'some.startup.module' and saves results to the file in the current directory.",
     )
     group.add_argument(
@@ -1286,7 +1286,7 @@ def gen_list_of_plans_and_devices_cli():
         type=str,
         default=None,
         help="The path to the script with startup code. Example: "
-        "'qserver_list_of_plans_and_devices --startup-script ~/startup/scripts/script.py' loads"
+        "'qserver-list-plans-devices --startup-script ~/startup/scripts/script.py' loads"
         "startup code from the script and saves the results to the file in the current directory.",
     )
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -327,7 +327,10 @@ def load_startup_script(script_path, *, keep_re=False, enable_local_imports=Fals
         sm_keys = list(sys.modules.keys())
 
     try:
-        exec(open(script_path).read(), None, nspace)
+        nspace_global, nspace_local = {}, {}
+        exec(open(script_path).read(), nspace_global, nspace_local)
+        nspace = nspace_global
+        nspace.update(nspace_local)
 
     except BaseException as ex:
         raise StartupLoadingError(f"Error encountered executing startup script at '{script_path}'") from ex

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -1220,7 +1220,7 @@ def gen_list_of_plans_and_devices(
             yaml.dump(existing_plans_and_devices, stream)
 
     except Exception as ex:
-        raise RuntimeError(f"Failed to create the list of devices and plans: {str(ex)}")
+        raise RuntimeError(f"Failed to create the list of plans and devices: {str(ex)}")
 
 
 def gen_list_of_plans_and_devices_cli():

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -329,6 +329,10 @@ def start_manager():
         #   and built-in Bluesky plans.
         startup_dir = get_default_startup_dir()
 
+    if sum([_ is not None for _ in [startup_dir, startup_module_name, startup_script_path]]) != 1:
+        logger.error("Multiple or no startup code sources were specified.")
+        return 1
+
     # Primitive error processing: make sure that all essential data exists.
     if startup_dir is not None:
         if not os.path.exists(startup_dir):
@@ -346,11 +350,18 @@ def start_manager():
                 "The path to the list of existing plans and devices (--existing-plans-and-devices) "
                 "is not specified."
             )
+            return 1
         if not args.user_group_permissions_path:
             logger.error(
                 "The path to the file containing user group permissions (--user-group-permissions) "
                 "is not specified."
             )
+            return 1
+        # Check if startup script exists (if it is specified)
+        if startup_script_path is not None:
+            if not os.path.isfile(startup_script_path):
+                logger.error("The script '{startup_script_path}' is not found.")
+            return 1
 
     config_worker["keep_re"] = args.keep_re
     config_worker["use_persistent_metadata"] = args.use_persistent_metadata

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -239,7 +239,7 @@ def start_manager():
     )
 
     parser.add_argument(
-        "--existing-plans-and-devices",
+        "--existing-plans-devices",
         dest="existing_plans_and_devices_path",
         type=str,
         help="Path to file that contains the list of existing plans and devices. "
@@ -323,7 +323,7 @@ def start_manager():
     elif args.startup_module_name:
         startup_module_name = args.startup_module_name
     elif args.startup_script_path:
-        startup_script_path = args.startup_script_path
+        startup_script_path = os.path.abspath(os.path.expanduser(args.startup_script_path))
     else:
         # The default collection is the collection of simulated Ophyd devices
         #   and built-in Bluesky plans.
@@ -345,7 +345,7 @@ def start_manager():
         # startup_module_name or startup_script_path is set. This option requires
         #   the paths to existing plans and devices and user group permissions to be set.
         #   (The default directory can not be used in this case).
-        if not args.existing_plans_and_devices:
+        if not args.existing_plans_and_devices_path:
             logger.error(
                 "The path to the list of existing plans and devices (--existing-plans-and-devices) "
                 "is not specified."
@@ -361,7 +361,7 @@ def start_manager():
         if startup_script_path is not None:
             if not os.path.isfile(startup_script_path):
                 logger.error("The script '{startup_script_path}' is not found.")
-            return 1
+                return 1
 
     config_worker["keep_re"] = args.keep_re
     config_worker["use_persistent_metadata"] = args.use_persistent_metadata
@@ -380,13 +380,13 @@ def start_manager():
         if not os.path.isabs(existing_pd_path):
             existing_pd_path = os.path.join(startup_dir, existing_pd_path)
         if not existing_pd_path.endswith(".yaml"):
-            os.path.join(existing_pd_path, default_existing_pd_fln)
+            existing_pd_path = os.path.join(existing_pd_path, default_existing_pd_fln)
     else:
         existing_pd_path = os.path.join(startup_dir, default_existing_pd_fln)
     if not os.path.isfile(existing_pd_path):
         logger.error(
             "The list of allowed plans and devices was not found at "
-            "'%s'. Proceed without the list: all plans and devices are allowed.",
+            "'%s'. Proceed without the list: all plans and devices will be accepted by RE Manager.",
             existing_pd_path,
         )
         existing_pd_path = None
@@ -397,13 +397,13 @@ def start_manager():
         if not os.path.isabs(user_group_pd_path):
             user_group_pd_path = os.path.join(startup_dir, user_group_pd_path)
         if not user_group_pd_path.endswith(".yaml"):
-            os.path.join(user_group_pd_path, default_existing_pd_fln)
+            user_group_pd_path = os.path.join(user_group_pd_path, default_user_group_pd_fln)
     else:
         user_group_pd_path = os.path.join(startup_dir, default_user_group_pd_fln)
     if not os.path.isfile(user_group_pd_path):
         logger.error(
             "The file with user permissions was not found at "
-            "'%s'. All existing plans and devices will be allowed to all users.",
+            "'%s'. User groups are not defined. USERS WILL NOT BE ABLE TO SUBMIT PLANS.",
             user_group_pd_path,
         )
         user_group_pd_path = None

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -233,7 +233,7 @@ def start_manager():
         dest="startup_script_path",
         type=str,
         help="The path to the script with startup code. The script is loaded each time the RE Worker "
-        "environment is opened. Example: 'some.startup.module'. Paths to the list of existing "
+        "environment is opened. Example: '~/startup/scripts/scripts.py'. Paths to the list of existing "
         "plans and devices (--existing-plans-and-devices) and user group permissions "
         "(--user-group-permissions) must be explicitly specified if this option is used.",
     )

--- a/bluesky_queueserver/manager/tests/_common.py
+++ b/bluesky_queueserver/manager/tests/_common.py
@@ -7,6 +7,7 @@ import asyncio
 import time as ttime
 import intake
 import tempfile
+import sys
 
 from databroker import catalog_search_path
 
@@ -407,3 +408,21 @@ def re_manager_pc_copy(tmp_path):
 
     yield re, pc_path  # Location of the copy of the default profile collection.
     re.stop_manager()
+
+
+@pytest.fixture
+def reset_sys_modules():
+    """
+    Resets `sys.modules` after each test. Allows importing the same module in multiple tests independently.
+    Intended for use in the tests for the functions that import modules or execute scripts that import modules.
+    """
+    # Save the set of keys before the test is called
+    sys_modules = list(sys.modules.keys())
+
+    yield
+
+    # Remove entries for all the modules loaded during the test
+    for key in list(sys.modules.keys()):
+        if key not in sys_modules:
+            print(f"Deleting the key '{key}'")
+            del sys.modules[key]

--- a/bluesky_queueserver/manager/tests/test_manager_options.py
+++ b/bluesky_queueserver/manager/tests/test_manager_options.py
@@ -40,7 +40,7 @@ def test_manager_options_startup_profile(re_manager_cmd, tmp_path, monkeypatch, 
     append_code_to_last_startup_file(pc_path, additional_code=_sample_plan1)
 
     # Generate the new list of allowed plans and devices and reload them
-    gen_list_of_plans_and_devices(pc_path, overwrite=True)
+    gen_list_of_plans_and_devices(startup_dir=pc_path, file_dir=pc_path, overwrite=True)
 
     # Start manager
     if option == "startup_dir":

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -950,6 +950,7 @@ def test_gen_list_of_plans_and_devices_cli(tmp_path, monkeypatch, test, exit_cod
         # Path does not exist
         path_nonexisting = os.path.join(tmp_path, "abcde")
         params = ["qserver_list_of_plans_and_devices", "--startup-dir", pc_path, "--file-dir", path_nonexisting]
+
     else:
         assert False, f"Unknown test '{test}'"
 

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -553,24 +553,24 @@ def test_gen_list_of_plans_and_devices_cli(tmp_path, test, exit_code):
 
     if test == "default_path":
         os.chdir(pc_path)
-        assert subprocess.call(["qserver_list_of_plans_and_devices", "--startup-dir", "."]) == exit_code
+        params = ["qserver_list_of_plans_and_devices", "--startup-dir", "."]
+        assert subprocess.call(params) == exit_code
     elif test == "specify_path":
-        assert subprocess.call(["qserver_list_of_plans_and_devices",
-                                "--startup-dir", pc_path, "--file-dir", pc_path]) == exit_code
+        params = ["qserver_list_of_plans_and_devices", "--startup-dir", pc_path, "--file-dir", pc_path]
+        assert subprocess.call(params) == exit_code
     elif test == "incorrect_path_startup":
         # Path exists (default path is used), but there are no startup files (fails)
-        assert subprocess.call(["qserver_list_of_plans_and_devices"]) == exit_code
+        params = ["qserver_list_of_plans_and_devices", "--startup-dir", "."]
+        assert subprocess.call(params) == exit_code
         # Path does not exist
         path_nonexisting = os.path.join(tmp_path, "abcde")
-        assert subprocess.call(["qserver_list_of_plans_and_devices",
-                                "--startup-dir", path_nonexisting, "--file-dir", pc_path]) == exit_code
+        params = ["qserver_list_of_plans_and_devices", "--startup-dir", path_nonexisting, "--file-dir", pc_path]
+        assert subprocess.call(params) == exit_code
     elif test == "incorrect_path_file":
-        # Path exists (default path is used), but there are no startup files (fails)
-        assert subprocess.call(["qserver_list_of_plans_and_devices"]) == exit_code
         # Path does not exist
         path_nonexisting = os.path.join(tmp_path, "abcde")
-        assert subprocess.call(["qserver_list_of_plans_and_devices",
-                                "--startup-dir", pc_path, "--file-dir", path_nonexisting]) == exit_code
+        params = ["qserver_list_of_plans_and_devices", "--startup-dir", pc_path, "--file-dir", path_nonexisting]
+        assert subprocess.call(params) == exit_code
     else:
         assert False, f"Unknown test '{test}'"
 

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -893,8 +893,9 @@ def test_gen_list_of_plans_and_devices_1(tmp_path):
 # fmt: on
 def test_gen_list_of_plans_and_devices_cli(tmp_path, monkeypatch, test, exit_code):
     """
+    Test for ``qserver-list-plans_devices`` CLI tool for generating list of plans and devices.
     Copy simulated profile collection and generate the list of allowed (in this case available)
-    plans and devices based on the profile collection
+    plans and devices based on the profile collection.
     """
     pc_path = os.path.join(tmp_path, "script_dir1")
     script_path = os.path.join(pc_path, "startup_script.py")
@@ -912,26 +913,26 @@ def test_gen_list_of_plans_and_devices_cli(tmp_path, monkeypatch, test, exit_cod
 
     if test == "startup_collection_at_current_dir":
         os.chdir(pc_path)
-        params = ["qserver_list_of_plans_and_devices", "--startup-dir", "."]
+        params = ["qserver-list-plans-devices", "--startup-dir", "."]
 
     elif test == "startup_collection_dir":
-        params = ["qserver_list_of_plans_and_devices", "--startup-dir", pc_path, "--file-dir", pc_path]
+        params = ["qserver-list-plans-devices", "--startup-dir", pc_path, "--file-dir", pc_path]
 
     elif test == "startup_collection_incorrect_path_A":
         # Path exists (default path is used), but there are no startup files (fails)
-        params = ["qserver_list_of_plans_and_devices", "--startup-dir", "."]
+        params = ["qserver-list-plans-devices", "--startup-dir", "."]
 
     elif test == "startup_collection_incorrect_path_B":
         # Path does not exist
         path_nonexisting = os.path.join(tmp_path, "abcde")
-        params = ["qserver_list_of_plans_and_devices", "--startup-dir", path_nonexisting, "--file-dir", pc_path]
+        params = ["qserver-list-plans-devices", "--startup-dir", path_nonexisting, "--file-dir", pc_path]
 
     elif test == "startup_script_path":
-        params = ["qserver_list_of_plans_and_devices", "--startup-script", script_path, "--file-dir", pc_path]
+        params = ["qserver-list-plans-devices", "--startup-script", script_path, "--file-dir", pc_path]
 
     elif test == "startup_script_path_incorrect":
         params = [
-            "qserver_list_of_plans_and_devices",
+            "qserver-list-plans-devices",
             "--startup-script",
             "non_existing_path",
             "--file-dir",
@@ -941,17 +942,17 @@ def test_gen_list_of_plans_and_devices_cli(tmp_path, monkeypatch, test, exit_cod
     elif test == "startup_module_name":
         monkeypatch.setenv("PYTHONPATH", os.path.split(pc_path)[0])
         s_name = "script_dir1.startup_script"
-        params = ["qserver_list_of_plans_and_devices", "--startup-module", s_name, "--file-dir", pc_path]
+        params = ["qserver-list-plans-devices", "--startup-module", s_name, "--file-dir", pc_path]
 
     elif test == "startup_module_name_incorrect":
         monkeypatch.setenv("PYTHONPATH", os.path.split(pc_path)[0])
         s_name = "incorrect.module.name"
-        params = ["qserver_list_of_plans_and_devices", "--startup-module", s_name, "--file-dir", pc_path]
+        params = ["qserver-list-plans-devices", "--startup-module", s_name, "--file-dir", pc_path]
 
     elif test == "file_incorrect_path":
         # Path does not exist
         path_nonexisting = os.path.join(tmp_path, "abcde")
-        params = ["qserver_list_of_plans_and_devices", "--startup-dir", pc_path, "--file-dir", path_nonexisting]
+        params = ["qserver-list-plans-devices", "--startup-dir", pc_path, "--file-dir", path_nonexisting]
 
     else:
         assert False, f"Unknown test '{test}'"

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -12,6 +12,8 @@ import ophyd
 
 from ._common import copy_default_profile_collection, patch_first_startup_file
 
+from ._common import reset_sys_modules  # noqa: F401
+
 from bluesky_queueserver.manager.annotation_decorator import parameter_annotation_decorator
 
 from bluesky_queueserver.manager.profile_ops import (
@@ -296,7 +298,7 @@ def simple_sample_plan_4():
 
 @pytest.mark.parametrize("keep_re", [True, False])
 @pytest.mark.parametrize("enable_local_imports", [True, False])
-def test_load_startup_script_1(tmp_path, keep_re, enable_local_imports):
+def test_load_startup_script_1(tmp_path, keep_re, enable_local_imports, reset_sys_modules):  # noqa: F811
     """
     Basic test for `load_startup_script` function. Load two scripts in sequence from two
     different locations and make sure that all the plans are loaded.
@@ -376,7 +378,7 @@ def plan_in_module_2():
 
 @pytest.mark.parametrize("keep_re", [True, False])
 @pytest.mark.parametrize("enable_local_imports", [True, False])
-def test_load_startup_script_2(tmp_path, keep_re, enable_local_imports):
+def test_load_startup_script_2(tmp_path, keep_re, enable_local_imports, reset_sys_modules):  # noqa: F811
     """
     Tests for `load_startup_script` function. Loading scripts WITH LOCAL IMPORTS.
     Loading is expected to fail if local imports are disabled.
@@ -469,7 +471,7 @@ def test_load_startup_script_2(tmp_path, keep_re, enable_local_imports):
 
 
 @pytest.mark.parametrize("keep_re", [True, False])
-def test_load_startup_module_1(tmp_path, monkeypatch, keep_re):
+def test_load_startup_module_1(tmp_path, monkeypatch, keep_re, reset_sys_modules):  # noqa: F811
     """
     Test for `load_startup_module` function: import module that is in the module search path.
     The test also demonstrates that if the code of the module or any module imported by the module
@@ -538,7 +540,7 @@ def test_load_startup_module_1(tmp_path, monkeypatch, keep_re):
 @pytest.mark.parametrize("option", ["startup_dir", "script", "module"])
 @pytest.mark.parametrize("keep_re", [True, False])
 # fmt: on
-def test_load_worker_startup_code_1(tmp_path, monkeypatch, keep_re, option):
+def test_load_worker_startup_code_1(tmp_path, monkeypatch, keep_re, option, reset_sys_modules):  # noqa: F811
     """
     Test for `load_worker_startup_code` function.
     """
@@ -577,7 +579,7 @@ def test_load_worker_startup_code_1(tmp_path, monkeypatch, keep_re, option):
 
 
 @pytest.mark.parametrize("option", ["no_sources", "multiple_sources"])
-def test_load_worker_startup_code_2_failing(option):
+def test_load_worker_startup_code_2_failing(option, reset_sys_modules):  # noqa: F811
     with pytest.raises(ValueError, match="multiple sources were specified"):
         if option == "no_sources":
             load_worker_startup_code(startup_dir="abc", startup_module_name="script_dir1.startup_script")

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -470,6 +470,34 @@ def test_load_startup_script_2(tmp_path, keep_re, enable_local_imports, reset_sy
             load_startup_script(script_path, keep_re=keep_re, enable_local_imports=enable_local_imports)
 
 
+_startup_script_3 = """
+a = 10
+locals()['b'] = 20
+globals()['c'] = 50
+"""
+
+
+def test_load_startup_script_3(tmp_path, reset_sys_modules):  # noqa: F811
+    """
+    Test for ``load_startup_script`` function.
+    Verifies if variables defined in global and local scope in the script are handled correctly.
+    """
+    # Load first script
+    script_dir = os.path.join(tmp_path, "script_dir1")
+    script_path = os.path.join(script_dir, "startup_script.py")
+
+    os.makedirs(script_dir, exist_ok=True)
+    with open(script_path, "w") as f:
+        f.write(_startup_script_3)
+
+    nspace = load_startup_script(script_path)
+
+    expected_results = {"a": 10, "b": 20, "c": 50}
+    for k, v in expected_results.items():
+        assert k in nspace
+        assert nspace[k] == v
+
+
 @pytest.mark.parametrize("keep_re", [True, False])
 def test_load_startup_module_1(tmp_path, monkeypatch, keep_re, reset_sys_modules):  # noqa: F811
     """

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -969,7 +969,7 @@ def test_qserver_reload_permissions(re_manager_pc_copy, tmp_path):  # noqa F811
     append_code_to_last_startup_file(pc_path, additional_code=_sample_trivial_plan1)
 
     # Generate the new list of allowed plans and devices and reload them
-    gen_list_of_plans_and_devices(pc_path, overwrite=True)
+    gen_list_of_plans_and_devices(startup_dir=pc_path, file_dir=pc_path, overwrite=True)
 
     plan = "{'name': 'trivial_plan_for_unit_test'}"
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -965,7 +965,7 @@ def test_re_runs_1(re_manager_pc_copy, tmp_path, test_with_manager_restart):  # 
     append_code_to_last_startup_file(pc_path, additional_code=_sample_multirun_plan1)
 
     # Generate the new list of allowed plans and devices and reload them
-    gen_list_of_plans_and_devices(pc_path, overwrite=True)
+    gen_list_of_plans_and_devices(startup_dir=pc_path, file_dir=pc_path, overwrite=True)
     resp1, _ = zmq_single_request("permissions_reload")
     assert resp1["success"] is True, f"resp={resp1}"
 

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -805,7 +805,7 @@ def test_http_server_reload_permissions(re_manager_pc_copy, fastapi_server, tmp_
     append_code_to_last_startup_file(pc_path, additional_code=_sample_trivial_plan1)
 
     # Generate the new list of allowed plans and devices and reload them
-    gen_list_of_plans_and_devices(pc_path, overwrite=True)
+    gen_list_of_plans_and_devices(startup_dir=pc_path, file_dir=pc_path, overwrite=True)
 
     plan = {"plan": {"name": "trivial_plan_for_unit_test"}}
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "console_scripts": [
             "qserver = bluesky_queueserver.manager.qserver_cli:qserver",
             "start-re-manager = bluesky_queueserver.manager.start_manager:start_manager",
-            "qserver_list_of_plans_and_devices = bluesky_queueserver.manager."
+            "qserver-list-plans-devices = bluesky_queueserver.manager."
             "profile_ops:gen_list_of_plans_and_devices_cli",
         ],
     },


### PR DESCRIPTION
The PR addresses the remaining requirements from issue https://github.com/bluesky/bluesky-queueserver/issues.
Changes:

- Additional parameters for `start-re-manager`: `--startup-module` followed by name of the module (on the module search path) and `--startup-script` followed by full path to the script to load.

- Scripts with local imports are not supported. The option to load scripts with local imports is implemented and tested, but disabled.

- CLI parameters for `qserver_list_of_plans_and_devices` are modified to support loading startup data from a script or a module.

- Unit tests covering new functionality are implemented.