### PR TITLE
Changed the default ZMQ port for control connection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ QueueServer is supporting the following functions:
 
 
 In some cases the program may crash and leave some sockets open. This may prevent the Manager from
-restarting. To close the sockets (we are interested in sockets on ports 5555 and 60610), find
+restarting. To close the sockets (we are interested in sockets on ports 60615 and 60610), find
 PIDs of the processes::
 
   $ netstat -ltnp
@@ -113,10 +113,10 @@ The most basic request is 'ping' intended to fetch some response from RE Manager
   qserver ping
   http GET http://localhost:60610
 
-Current default address of RE Manager is set to tcp://localhost:5555, but different
+Current default address of RE Manager is set to tcp://localhost:60615, but different
 address may be passed as a parameter to CLI tool::
 
-  qserver ping -a "tcp://localhost:5555"
+  qserver ping -a "tcp://localhost:60615"
 
 The 'qserver' CLI tool may run in the monitoring mode (send 'ping' request to RE Manager every second)::
 

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -428,7 +428,7 @@ class ZMQCommSendThreads:
     Parameters
     ----------
     zmq_server_address : str or None
-        Address of ZMQ server. If None, then the default address is ``tcp://localhost:5555``
+        Address of ZMQ server. If None, then the default address is ``tcp://localhost:60615``
         is used.
     timeout_recv : int
         Timeout (in ms) for ZMQ receive operations.
@@ -486,7 +486,7 @@ class ZMQCommSendThreads:
         timeout_send=500,
         raise_exceptions=True,
     ):
-        zmq_server_address = zmq_server_address or "tcp://localhost:5555"
+        zmq_server_address = zmq_server_address or "tcp://localhost:60615"
 
         self._timeout_receive = timeout_recv  # Timeout for 'recv' operation (ms)
         self._timeout_send = timeout_send  # # Timeout for 'send' operation (ms)
@@ -767,7 +767,7 @@ class ZMQCommSendAsync:
     loop : asyncio loop
         Current event loop
     zmq_server_address : str or None
-        Address of ZMQ server. If None, then the default address is ``tcp://localhost:5555``
+        Address of ZMQ server. If None, then the default address is ``tcp://localhost:60615``
         is used.
     timeout_recv : int
         Timeout (in ms) for ZMQ receive operations.
@@ -807,7 +807,7 @@ class ZMQCommSendAsync:
     ):
         self._loop = loop if loop else asyncio.get_event_loop()
 
-        zmq_server_address = zmq_server_address or "tcp://localhost:5555"
+        zmq_server_address = zmq_server_address or "tcp://localhost:60615"
 
         self._timeout_receive = timeout_recv  # Timeout for 'recv' operation (ms)
         self._timeout_send = timeout_send  # # Timeout for 'send' operation (ms)

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -86,7 +86,7 @@ class RunEngineManager(Process):
         # Communication with the server using ZMQ
         self._ctx = None
         self._zmq_socket = None
-        self._ip_zmq_server = "tcp://*:5555"
+        self._ip_zmq_server = "tcp://*:60615"
         if config and ("zmq_addr" in config):
             self._ip_zmq_server = config["zmq_addr"]
         logger.info("Starting ZMQ server at '%s'", self._ip_zmq_server)

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -730,7 +730,7 @@ def qserver():
         dest="address",
         action="store",
         default=None,
-        help="Address of the server (e.g. 'tcp://localhost:5555', quoted string)",
+        help="Address of the server (e.g. 'tcp://localhost:60615', quoted string)",
     )
 
     args = parser.parse_args()

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -195,8 +195,8 @@ def start_manager():
         "--zmq-addr",
         dest="zmq_addr",
         type=str,
-        default="tcp://*:5555",
-        help="The address of ZMQ server.",
+        default="tcp://*:60615",
+        help="The address of ZMQ server (control connection).",
     )
 
     group = parser.add_mutually_exclusive_group()

--- a/bluesky_queueserver/manager/tests/test_comms.py
+++ b/bluesky_queueserver/manager/tests/test_comms.py
@@ -675,7 +675,7 @@ def _zmq_server_1msg():
     # ZMQ server that provides single response
     ctx = zmq.Context()
     zmq_socket = ctx.socket(zmq.REP)
-    zmq_socket.bind("tcp://*:5555")
+    zmq_socket.bind("tcp://*:60615")
     msg_in = zmq_socket.recv_json()
     msg_out = {"success": True, "some_data": 10, "msg_in": msg_in}
     zmq_socket.send_json(msg_out)
@@ -727,7 +727,7 @@ def _zmq_server_2msg():
     # ZMQ server: provides ability to communicate twice
     ctx = zmq.Context()
     zmq_socket = ctx.socket(zmq.REP)
-    zmq_socket.bind("tcp://*:5555")
+    zmq_socket.bind("tcp://*:60615")
     msg_in = zmq_socket.recv_json()
     msg_out = {"success": True, "some_data": 10, "msg_in": msg_in}
     zmq_socket.send_json(msg_out)
@@ -783,7 +783,7 @@ def _zmq_server_2msg_delay1():
     # ZMQ server: provides ability to communicate twice
     ctx = zmq.Context()
     zmq_socket = ctx.socket(zmq.REP)
-    zmq_socket.bind("tcp://*:5555")
+    zmq_socket.bind("tcp://*:60615")
     msg_in = zmq_socket.recv_json()
     ttime.sleep(0.1)  # Delay before the 1st response
     msg_out = {"success": True, "some_data": 10, "msg_in": msg_in}
@@ -861,7 +861,7 @@ def _zmq_server_delay2():
     # ZMQ server: provides ability to communicate twice
     ctx = zmq.Context()
     zmq_socket = ctx.socket(zmq.REP)
-    zmq_socket.bind("tcp://*:5555")
+    zmq_socket.bind("tcp://*:60615")
     msg_in = zmq_socket.recv_json()
     ttime.sleep(3)  # Generate timeout at the client
     msg_out = {"success": True, "some_data": 10, "msg_in": msg_in}


### PR DESCRIPTION
Changed default port number for ZMQ control connection from 5555 (common ZMQ port) to 60615.