### PR TITLE
Subscribing RE to 0MQ Publisher

### DIFF
--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -272,7 +272,7 @@ def start_manager():
         type=str,
         help="The address of ZMQ proxy used to publish data. If the parameter is specified, RE is "
         "be subscribed to 'bluesky.callbacks.zmq.Publisher' and documents are published via 0MQ proxy. "
-        "0MQ Proxy (see Bluesky 0MQ documentation) should be started before plans could be executed. "
+        "0MQ Proxy (see Bluesky 0MQ documentation) should be started before plans are executed. "
         "The address should be in the form '127.0.0.1:5567' or 'localhost:5567'. The address is passed "
         "to 'bluesky.callbacks.zmq.Publisher'. It is recommended to use Kafka instead of 0MQ proxy in "
         "production data acquisition systems and use Kafka instead.",

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -271,7 +271,7 @@ def start_manager():
         dest="zmq_data_proxy_addr",
         type=str,
         help="The address of ZMQ proxy used to publish data. If the parameter is specified, RE is "
-        "be subscribed to 'bluesky.callbacks.zmq.Publisher' and documents are published via 0MQ proxy. "
+        "subscribed to 'bluesky.callbacks.zmq.Publisher' and documents are published via 0MQ proxy. "
         "0MQ Proxy (see Bluesky 0MQ documentation) should be started before plans are executed. "
         "The address should be in the form '127.0.0.1:5567' or 'localhost:5567'. The address is passed "
         "to 'bluesky.callbacks.zmq.Publisher'. It is recommended to use Kafka instead of 0MQ proxy in "

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -256,6 +256,7 @@ def start_manager():
         "If the path is a directory, then the default file name "
         "'user_group_permissions.yaml' is used.",
     )
+
     parser.add_argument("--kafka-topic", dest="kafka_topic", type=str, help="The kafka topic to publish to.")
     parser.add_argument(
         "--kafka-server",
@@ -264,6 +265,19 @@ def start_manager():
         help="Bootstrap server to connect to.",
         default="127.0.0.1:9092",
     )
+
+    parser.add_argument(
+        "--zmq-data-proxy-addr",
+        dest="zmq_data_proxy_addr",
+        type=str,
+        help="The address of ZMQ proxy used to publish data. If the parameter is specified, RE is "
+             "be subscribed to 'bluesky.callbacks.zmq.Publisher' and documents are published via 0MQ proxy. "
+             "0MQ Proxy (see Bluesky 0MQ documentation) should be started before plans could be executed. "
+             "The address should be in the form '127.0.0.1:5567' or 'localhost:5567'. The address is passed "
+             "to 'bluesky.callbacks.zmq.Publisher'. It is recommended to avoid using 0MQ proxy in production "
+             "data acquisition systems and use Kafka instead."
+    )
+
     parser.add_argument(
         "--keep-re",
         dest="keep_re",
@@ -299,6 +313,9 @@ def start_manager():
         config_worker["kafka"] = {}
         config_worker["kafka"]["topic"] = args.kafka_topic
         config_worker["kafka"]["bootstrap"] = args.kafka_server
+
+    if args.zmq_data_proxy_addr is not None:
+        config_worker["zmq_data_proxy_addr"] = args.zmq_data_proxy_addr
 
     startup_dir, startup_module_name, startup_script_path = None, None, None
 

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -273,9 +273,9 @@ def start_manager():
         help="The address of ZMQ proxy used to publish data. If the parameter is specified, RE is "
         "be subscribed to 'bluesky.callbacks.zmq.Publisher' and documents are published via 0MQ proxy. "
         "0MQ Proxy (see Bluesky 0MQ documentation) should be started before plans could be executed. "
-        "The address should be in the form '127.0.0.1:5577' or 'localhost:5577'. The address is passed "
-        "to 'bluesky.callbacks.zmq.Publisher'. It is recommended to avoid using 0MQ proxy in production "
-        "data acquisition systems and use Kafka instead.",
+        "The address should be in the form '127.0.0.1:5567' or 'localhost:5567'. The address is passed "
+        "to 'bluesky.callbacks.zmq.Publisher'. It is recommended to use Kafka instead of 0MQ proxy in "
+        "production data acquisition systems and use Kafka instead.",
     )
 
     parser.add_argument(

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -271,11 +271,11 @@ def start_manager():
         dest="zmq_data_proxy_addr",
         type=str,
         help="The address of ZMQ proxy used to publish data. If the parameter is specified, RE is "
-             "be subscribed to 'bluesky.callbacks.zmq.Publisher' and documents are published via 0MQ proxy. "
-             "0MQ Proxy (see Bluesky 0MQ documentation) should be started before plans could be executed. "
-             "The address should be in the form '127.0.0.1:5567' or 'localhost:5567'. The address is passed "
-             "to 'bluesky.callbacks.zmq.Publisher'. It is recommended to avoid using 0MQ proxy in production "
-             "data acquisition systems and use Kafka instead."
+        "be subscribed to 'bluesky.callbacks.zmq.Publisher' and documents are published via 0MQ proxy. "
+        "0MQ Proxy (see Bluesky 0MQ documentation) should be started before plans could be executed. "
+        "The address should be in the form '127.0.0.1:5577' or 'localhost:5577'. The address is passed "
+        "to 'bluesky.callbacks.zmq.Publisher'. It is recommended to avoid using 0MQ proxy in production "
+        "data acquisition systems and use Kafka instead.",
     )
 
     parser.add_argument(

--- a/bluesky_queueserver/manager/tests/_common.py
+++ b/bluesky_queueserver/manager/tests/_common.py
@@ -373,7 +373,7 @@ def re_manager_cmd():
         _close()
         _create(params)
 
-    yield create_re_manager  # Nothing to return
+    yield create_re_manager
 
     _close()
 

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -634,6 +634,7 @@ class RunEngineWorker(Process):
 
                 if "zmq_data_proxy_addr" in self._config:
                     from bluesky.callbacks.zmq import Publisher
+
                     publisher = Publisher(self._config["zmq_data_proxy_addr"])
                     self._RE.subscribe(publisher)
 

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -632,6 +632,11 @@ class RunEngineWorker(Process):
                     )
                     self._RE.subscribe(kafka_publisher)
 
+                if "zmq_data_proxy_addr" in self._config:
+                    from bluesky.callbacks.zmq import Publisher
+                    publisher = Publisher(self._config["zmq_data_proxy_addr"])
+                    self._RE.subscribe(publisher)
+
                 self._execution_queue = queue.Queue()
 
                 self._state["environment_state"] = "ready"


### PR DESCRIPTION
A built-in option to subscribe Run Engine to `bluesky.callbacks.zmq.Publisher` is added. The address of 0MQ proxy is passed with `start-re-manager` CLI parameter `--zmq-data-proxy-addr`. Identically to subscription to Kafka, the option works for Run Engine created by RE Manager and in the startup script (`start-re-manager` called with `--keep-re`). If the parameter `--zmq-data-proxy-addr` is not used, RE is not subscribed to the Publisher callback.