### PR TITLE
DOC: add 'user' and 'user_group' as required parameters for 'queue_item_add' API

### DIFF
--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -474,6 +474,14 @@ Parameters    **plan or instruction**: *dict*
                   the dictionary of plan or instruction parameters. Plans are distinguished from
                   instructions based on whether 'plan' or 'instruction' parameter is included.
 
+              **user_group**: *str*
+                  the name of the user group (e.g. 'admin').
+
+              **user**: *str*
+                  the name of the user (e.g. 'John Doe'). The name is included in the plan metadata
+                  and may be used to identify the user who added the plan to the queue. It is not
+                  not passed to the Run Engine or included in run metadata.
+
               **pos**: *int*, *'front'* or *'back'* (optional)
                   position of the item in the queue. RE Manager will attempt to insert the item
                   at the specified position. The position may be positive or negative (counted

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -478,8 +478,8 @@ Parameters    **plan or instruction**: *dict*
                   the name of the user group (e.g. 'admin').
 
               **user**: *str*
-                  the name of the user (e.g. 'John Doe'). The name is included in the plan metadata
-                  and may be used to identify the user who added the plan to the queue. It is not
+                  the name of the user (e.g. 'John Doe'). The name is included in the item metadata
+                  and may be used to identify the user who added the item to the queue. It is not
                   passed to the Run Engine or included in run metadata.
 
               **pos**: *int*, *'front'* or *'back'* (optional)

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -480,7 +480,7 @@ Parameters    **plan or instruction**: *dict*
               **user**: *str*
                   the name of the user (e.g. 'John Doe'). The name is included in the plan metadata
                   and may be used to identify the user who added the plan to the queue. It is not
-                  not passed to the Run Engine or included in run metadata.
+                  passed to the Run Engine or included in run metadata.
 
               **pos**: *int*, *'front'* or *'back'* (optional)
                   position of the item in the queue. RE Manager will attempt to insert the item


### PR DESCRIPTION
Minor documentation fix: the required parameters `user_group` and `user` are missing from documentation for `queue_item_add` 0MQ API. 