### PR TITLE
New CLI parameter: '--redis-addr' ('start-re-manager')

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -110,7 +110,9 @@ class RunEngineManager(Process):
         self._background_task = None  # asyncio.Task
         self._background_task_status = {"status": "success", "err_msg": ""}
 
-        self._config = config or {}
+        # Note: 'self._config' is a private attribute of 'multiprocessing.Process'. Overriding
+        #   this variable may lead to unpredictable and hard to debug issues.
+        self._config_dict = config or {}
         self._allowed_plans, self._allowed_devices = {}, {}
 
     async def _heartbeat_generator(self):
@@ -596,8 +598,8 @@ class RunEngineManager(Process):
         Load the list of allowed plans and devices
         """
         try:
-            path_pd = self._config["existing_plans_and_devices_path"]
-            path_ug = self._config["user_group_permissions_path"]
+            path_pd = self._config_dict["existing_plans_and_devices_path"]
+            path_ug = self._config_dict["user_group_permissions_path"]
             self._allowed_plans, self._allowed_devices = load_allowed_plans_and_devices(
                 path_existing_plans_and_devices=path_pd, path_user_group_permissions=path_ug
             )

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -11,7 +11,6 @@ from .comms import PipeJsonRpcSendAsync, CommTimeoutError
 from .profile_ops import load_allowed_plans_and_devices, validate_plan
 from .plan_queue_ops import PlanQueueOperations
 
-
 import logging
 
 logger = logging.getLogger(__name__)

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -91,6 +91,10 @@ class RunEngineManager(Process):
             self._ip_zmq_server = config["zmq_addr"]
         logger.info("Starting ZMQ server at '%s'", self._ip_zmq_server)
 
+        self._ip_redis_server = "localhost"
+        if config and ("redis_addr" in config):
+            self._ip_redis_server = config["redis_addr"]
+
         self._plan_queue = None  # Object of class plan_queue_ops.PlanQueueOperations
 
         self._heartbeat_generator_task = None  # Task for heartbeat generator
@@ -1324,7 +1328,7 @@ class RunEngineManager(Process):
         self._heartbeat_generator_task = asyncio.ensure_future(self._heartbeat_generator(), loop=self._loop)
         self._worker_status_task = asyncio.ensure_future(self._periodic_worker_state_request(), loop=self._loop)
 
-        self._plan_queue = PlanQueueOperations()
+        self._plan_queue = PlanQueueOperations(redis_host=self._ip_redis_server)
         await self._plan_queue.start()
 
         # Delete Redis entries (for testing and debugging)

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1266,6 +1266,7 @@ class RunEngineManager(Process):
             "environment_close": "_environment_close_handler",
             "environment_destroy": "_environment_destroy_handler",
             "queue_item_add": "_queue_item_add_handler",
+            # "queue_item_replace": "_queue_item_replace_handler",
             "queue_item_get": "_queue_item_get_handler",
             "queue_item_remove": "_queue_item_remove_handler",
             "queue_item_move": "_queue_item_move_handler",

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -448,9 +448,9 @@ def devices_from_nspace(nspace):
     return devices
 
 
-def parse_plan(plan, *, allowed_plans, allowed_devices):
+def prepare_plan(plan, *, allowed_plans, allowed_devices):
     """
-    Parse the plan: replace the device names (str) in the plan specification by
+    Prepare the plan: replace the device names (str) in the plan specification by
     references to ophyd objects; replace plan name by the reference to the plan.
 
     Parameters
@@ -535,13 +535,13 @@ def parse_plan(plan, *, allowed_plans, allowed_devices):
     if not success:
         raise RuntimeError(f"Error while parsing the plan: {err_msg}")
 
-    plan_parsed = {
+    plan_prepared = {
         "name": plan_func,
         "args": plan_args_parsed,
         "kwargs": plan_kwargs_parsed,
         "meta": plan_meta,
     }
-    return plan_parsed
+    return plan_prepared
 
 
 # ===============================================================================
@@ -1125,7 +1125,16 @@ def _prepare_devices(devices):
     """
     Prepare dictionary of existing devices for saving to YAML file.
     """
-    return {k: {"classname": type(v).__name__, "module": type(v).__module__} for k, v in devices.items()}
+    from bluesky.utils import is_movable
+
+    return {
+        k: {
+            "is_movable": is_movable(v),  # True - motor, False - detector
+            "classname": type(v).__name__,
+            "module": type(v).__module__,
+        }
+        for k, v in devices.items()
+    }
 
 
 def _unpickle_types(existing_dict):

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -199,15 +199,6 @@ def start_manager():
         help="The address of ZMQ server (control connection).",
     )
 
-    parser.add_argument(
-        "--redis-addr",
-        dest="redis_addr",
-        type=str,
-        default="localhost",
-        help="The address of Redis server (e.g. 'localhost', '127.0.0.1', 'localhost:6379'). "
-        "RE Manager will connect to Redis at 'localhost' by default.",
-    )
-
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--startup-dir",
@@ -264,6 +255,15 @@ def start_manager():
         "The path may be a relative path to the profile collection directory. "
         "If the path is a directory, then the default file name "
         "'user_group_permissions.yaml' is used.",
+    )
+
+    parser.add_argument(
+        "--redis-addr",
+        dest="redis_addr",
+        type=str,
+        default="localhost",
+        help="The address of Redis server (e.g. 'localhost', '127.0.0.1', 'localhost:6379'). "
+        "RE Manager will connect to Redis at 'localhost' by default.",
     )
 
     parser.add_argument("--kafka-topic", dest="kafka_topic", type=str, help="The kafka topic to publish to.")

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -199,6 +199,15 @@ def start_manager():
         help="The address of ZMQ server (control connection).",
     )
 
+    parser.add_argument(
+        "--redis-addr",
+        dest="redis_addr",
+        type=str,
+        default="localhost",
+        help="The address of Redis server (e.g. 'localhost', '127.0.0.1', 'localhost:6379'). "
+        "RE Manager will connect to Redis at 'localhost' by default.",
+    )
+
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--startup-dir",
@@ -431,6 +440,12 @@ def start_manager():
     config_manager["user_group_permissions_path"] = user_group_pd_path
 
     config_manager["zmq_addr"] = args.zmq_addr
+
+    redis_addr = args.redis_addr
+    if redis_addr.count(":") > 1:
+        logger.error(f"Redis address is incorrectly formatted: '{redis_addr}'")
+        return 1
+    config_manager["redis_addr"] = redis_addr
 
     wp = WatchdogProcess(config_worker=config_worker, config_manager=config_manager)
     try:

--- a/bluesky_queueserver/manager/tests/test_manager_options.py
+++ b/bluesky_queueserver/manager/tests/test_manager_options.py
@@ -174,3 +174,22 @@ def test_manager_acq_with_0MQ_proxy(re_manager_cmd, zmq_proxy, zmq_dispatcher): 
     assert len(remote_accumulator) >= 2
     assert remote_accumulator[0][0] == "start"  # Start document
     assert remote_accumulator[-1][0] == "stop"  # Stop document
+
+
+# fmt: off
+@pytest.mark.parametrize("redis_addr, success", [
+    ("localhost", True),
+    ("localhost:6379", True),
+    ("localhost:6378", False)])
+# fmt: on
+def test_manager_redis_addr_parameter(re_manager_cmd, redis_addr, success):  # noqa: F811
+    if success:
+        re_manager_cmd(["--redis-addr", redis_addr])
+
+        # Try to communicate with the server to make sure Redis is configure correctly.
+        resp1, _ = zmq_single_request("status")
+        assert resp1["items_in_queue"] == 0
+        assert resp1["items_in_history"] == 0
+    else:
+        with pytest.raises(TimeoutError, match="RE Manager failed to start"):
+            re_manager_cmd(["--redis-addr", redis_addr])

--- a/bluesky_queueserver/manager/tests/test_manager_options.py
+++ b/bluesky_queueserver/manager/tests/test_manager_options.py
@@ -180,13 +180,14 @@ def test_manager_acq_with_0MQ_proxy(re_manager_cmd, zmq_proxy, zmq_dispatcher): 
 @pytest.mark.parametrize("redis_addr, success", [
     ("localhost", True),
     ("localhost:6379", True),
-    ("localhost:6378", False)])
+    ("localhost:6378", False)])  # Incorrect port.
 # fmt: on
 def test_manager_redis_addr_parameter(re_manager_cmd, redis_addr, success):  # noqa: F811
     if success:
         re_manager_cmd(["--redis-addr", redis_addr])
 
         # Try to communicate with the server to make sure Redis is configure correctly.
+        #   RE Manager has to access Redis in order to prepare 'status'.
         resp1, _ = zmq_single_request("status")
         assert resp1["items_in_queue"] == 0
         assert resp1["items_in_history"] == 0

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -24,7 +24,7 @@ from bluesky_queueserver.manager.profile_ops import (
     load_worker_startup_code,
     plans_from_nspace,
     devices_from_nspace,
-    parse_plan,
+    prepare_plan,
     gen_list_of_plans_and_devices,
     load_existing_plans_and_devices,
     load_user_group_permissions,
@@ -1054,13 +1054,13 @@ def test_parse_plan(plan, success, err_msg):
     devices = devices_from_nspace(nspace)
 
     if success:
-        plan_parsed = parse_plan(plan, allowed_plans=plans, allowed_devices=devices)
+        plan_parsed = prepare_plan(plan, allowed_plans=plans, allowed_devices=devices)
         expected_keys = ("name", "args", "kwargs")
         for k in expected_keys:
             assert k in plan_parsed, f"Key '{k}' does not exist: {plan_parsed.keys()}"
     else:
         with pytest.raises(RuntimeError, match=err_msg):
-            parse_plan(plan, allowed_plans=plans, allowed_devices=devices)
+            prepare_plan(plan, allowed_plans=plans, allowed_devices=devices)
 
 
 def test_gen_list_of_plans_and_devices_1(tmp_path):

--- a/bluesky_queueserver/manager/tests/test_start_manager.py
+++ b/bluesky_queueserver/manager/tests/test_start_manager.py
@@ -22,7 +22,7 @@ class ReManagerEmulation(threading.Thread):
         self._restart = False
         self._send_heartbeat = True
         self._lock = threading.Lock()
-        self._config = config or {}
+        self._config_dict = config or {}
         self._log_level = log_level
 
     def _heartbeat(self):
@@ -98,7 +98,7 @@ class ReManagerEmulation(threading.Thread):
 class ReWorkerEmulation(threading.Thread):
     def __init__(self, *args, conn, config=None, log_level="DEBUG", **kwargs):
         super().__init__(*args, **kwargs)
-        self._config = config or {}
+        self._config_dict = config or {}
         self._exit = False
         self.n_loops = 0
         self._log_level = log_level
@@ -273,8 +273,8 @@ def test_WatchdogProcess_6():
     assert response["success"] is True, "Unexpected response from RE Manager"
 
     # Check if configuration was set correctly in RE Worker and RE manager
-    assert wp._re_worker._config == config_worker, "Worker configuration was not passed correctly"
-    assert wp._re_manager._config == config_manager, "Manager configuration was not passed correctly"
+    assert wp._re_worker._config_dict == config_worker, "Worker configuration was not passed correctly"
+    assert wp._re_manager._config_dict == config_manager, "Manager configuration was not passed correctly"
 
     # Exit the process (thread).
     wp._re_worker.exit()

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -22,6 +22,11 @@ from .profile_ops import (
     prepare_plan,
 )
 
+# TODO: Data Broker import fails in the worker process unless xarray is imported in the global namespace
+#       somewhere in the program (e.g. here) (with xarray==0.17.0). Everything worked fine with
+#       xarray==0.16.2. Why?
+import xarray  # noqa: F401
+
 logger = logging.getLogger(__name__)
 
 

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -22,11 +22,6 @@ from .profile_ops import (
     prepare_plan,
 )
 
-# TODO: Data Broker import fails in the worker process unless xarray is imported in the global namespace
-#       somewhere in the program (e.g. here) (with xarray==0.17.0). Everything worked fine with
-#       xarray==0.16.2. Why?
-import xarray  # noqa: F401
-
 logger = logging.getLogger(__name__)
 
 
@@ -81,7 +76,10 @@ class RunEngineWorker(Process):
         self._comm_to_manager = PipeJsonRpcReceive(conn=self._conn, name="RE Worker-Manager Comm")
 
         self._db = None
-        self._config = config or {}
+
+        # Note: 'self._config' is a private attribute of 'multiprocessing.Process'. Overriding
+        #   this variable may lead to unpredictable and hard to debug issues.
+        self._config_dict = config or {}
         self._allowed_plans, self._allowed_devices = {}, {}
 
         # The list of runs that were opened as part of execution of the currently running plan.
@@ -491,7 +489,6 @@ class RunEngineWorker(Process):
         by the `start` method.
         """
         success = True
-
         logging.basicConfig(level=logging.WARNING)
         logging.getLogger(__name__).setLevel(self._log_level)
 
@@ -529,10 +526,10 @@ class RunEngineWorker(Process):
         asyncio.set_event_loop(loop)
 
         try:
-            keep_re = self._config["keep_re"]
-            startup_dir = self._config.get("startup_dir", None)
-            startup_module_name = self._config.get("startup_module_name", None)
-            startup_script_path = self._config.get("startup_script_path", None)
+            keep_re = self._config_dict["keep_re"]
+            startup_dir = self._config_dict.get("startup_dir", None)
+            startup_module_name = self._config_dict.get("startup_module_name", None)
+            startup_script_path = self._config_dict.get("startup_script_path", None)
 
             self._re_namespace = load_worker_startup_code(
                 startup_dir=startup_dir,
@@ -558,8 +555,8 @@ class RunEngineWorker(Process):
 
         # Load lists of allowed plans and devices
         logger.info("Loading the lists of allowed plans and devices ...")
-        path_pd = self._config["existing_plans_and_devices_path"]
-        path_ug = self._config["user_group_permissions_path"]
+        path_pd = self._config_dict["existing_plans_and_devices_path"]
+        path_ug = self._config_dict["user_group_permissions_path"]
         try:
             self._allowed_plans, self._allowed_devices = load_allowed_plans_and_devices(
                 path_existing_plans_and_devices=path_pd, path_user_group_permissions=path_ug
@@ -576,14 +573,14 @@ class RunEngineWorker(Process):
                 # Make RE namespace available to the plan code.
                 global_user_namespace.set_user_namespace(user_ns=self._re_namespace, use_ipython=False)
 
-                if self._config["keep_re"]:
+                if self._config_dict["keep_re"]:
                     # Copy references from the namespace
                     self._RE = self._re_namespace["RE"]
                     self._db = self._re_namespace.get("RE", None)
                 else:
                     # Instantiate a new Run Engine and Data Broker (if needed)
                     md = {}
-                    if self._config["use_persistent_metadata"]:
+                    if self._config_dict["use_persistent_metadata"]:
                         # This code is temporarily copied from 'nslsii' before better solution for keeping
                         #   continuous sequence Run ID is found. TODO: continuous sequence of Run IDs.
                         directory = os.path.expanduser("~/.config/bluesky/md")
@@ -605,8 +602,8 @@ class RunEngineWorker(Process):
 
                     # Subscribe RE to databroker if config file name is provided
                     self._db = None
-                    if "databroker" in self._config:
-                        config_name = self._config["databroker"].get("config", None)
+                    if "databroker" in self._config_dict:
+                        config_name = self._config_dict["databroker"].get("config", None)
                         if config_name:
                             logger.info("Subscribing RE to Data Broker using configuration '%s'.", config_name)
                             from databroker import Broker
@@ -621,15 +618,15 @@ class RunEngineWorker(Process):
                 run_reg_cb = CallbackRegisterRun(run_list=self._active_run_list)
                 self._RE.subscribe(run_reg_cb)
 
-                if "kafka" in self._config:
+                if "kafka" in self._config_dict:
                     logger.info(
                         "Subscribing to Kafka: topic '%s', servers '%s'",
-                        self._config["kafka"]["topic"],
-                        self._config["kafka"]["bootstrap"],
+                        self._config_dict["kafka"]["topic"],
+                        self._config_dict["kafka"]["bootstrap"],
                     )
                     kafka_publisher = kafkaPublisher(
-                        topic=self._config["kafka"]["topic"],
-                        bootstrap_servers=self._config["kafka"]["bootstrap"],
+                        topic=self._config_dict["kafka"]["topic"],
+                        bootstrap_servers=self._config_dict["kafka"]["bootstrap"],
                         key="kafka-unit-test-key",
                         # work with a single broker
                         producer_config={"acks": 1, "enable.idempotence": False, "request.timeout.ms": 5000},
@@ -637,10 +634,10 @@ class RunEngineWorker(Process):
                     )
                     self._RE.subscribe(kafka_publisher)
 
-                if "zmq_data_proxy_addr" in self._config:
+                if "zmq_data_proxy_addr" in self._config_dict:
                     from bluesky.callbacks.zmq import Publisher
 
-                    publisher = Publisher(self._config["zmq_data_proxy_addr"])
+                    publisher = Publisher(self._config_dict["zmq_data_proxy_addr"])
                     self._RE.subscribe(publisher)
 
                 self._execution_queue = queue.Queue()

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -19,7 +19,7 @@ from .profile_ops import (
     plans_from_nspace,
     devices_from_nspace,
     load_allowed_plans_and_devices,
-    parse_plan,
+    prepare_plan,
 )
 
 logger = logging.getLogger(__name__)
@@ -175,7 +175,7 @@ class RunEngineWorker(Process):
         logger.info("Starting a plan '%s'.", plan_info["name"])
 
         try:
-            plan_parsed = parse_plan(
+            plan_parsed = prepare_plan(
                 plan_info, allowed_plans=self._existing_plans, allowed_devices=self._existing_devices
             )
 
@@ -452,7 +452,7 @@ class RunEngineWorker(Process):
             status = "accepted"
         else:
             status = "rejected"
-            err_msg = "Run Engine must be in 'idle' state to continue. " f"The state is '{self._RE._state}'"
+            err_msg = f"Run Engine must be in 'idle' state to continue. The state is '{self._RE._state}'"
 
         msg_out = {"status": status, "err_msg": err_msg}
         return msg_out

--- a/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
+++ b/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
@@ -2,81 +2,107 @@
 existing_devices:
   ab_det:
     classname: ABDetector
+    is_movable: false
     module: ophyd.sim
   det:
     classname: SynGauss
+    is_movable: false
     module: ophyd.sim
   det1:
     classname: SynGauss
+    is_movable: false
     module: ophyd.sim
   det2:
     classname: SynGauss
+    is_movable: false
     module: ophyd.sim
   det3:
     classname: SynGauss
+    is_movable: false
     module: ophyd.sim
   det4:
     classname: Syn2DGauss
+    is_movable: false
     module: ophyd.sim
   det5:
     classname: Syn2DGauss
+    is_movable: false
     module: ophyd.sim
   det_with_conf:
     classname: DetWithConf
+    is_movable: false
     module: ophyd.sim
   det_with_count_time:
     classname: DetWithCountTime
+    is_movable: false
     module: ophyd.sim
   direct_img:
     classname: DirectImage
+    is_movable: false
     module: ophyd.sim
   direct_img_list:
     classname: DirectImage
+    is_movable: false
     module: ophyd.sim
   identical_det:
     classname: SynGauss
+    is_movable: false
     module: ophyd.sim
   jittery_motor1:
     classname: SynAxis
+    is_movable: true
     module: ophyd.sim
   jittery_motor2:
     classname: SynAxis
+    is_movable: true
     module: ophyd.sim
   motor:
     classname: SynAxis
+    is_movable: true
     module: ophyd.sim
   motor1:
     classname: SynAxis
+    is_movable: true
     module: ophyd.sim
   motor2:
     classname: SynAxis
+    is_movable: true
     module: ophyd.sim
   motor3:
     classname: SynAxis
+    is_movable: true
     module: ophyd.sim
   motor_empty_hints1:
     classname: SynAxisEmptyHints
+    is_movable: true
     module: ophyd.sim
   motor_empty_hints2:
     classname: SynAxisEmptyHints
+    is_movable: true
     module: ophyd.sim
   motor_no_hints1:
     classname: SynAxisNoHints
+    is_movable: true
     module: ophyd.sim
   motor_no_hints2:
     classname: SynAxisNoHints
+    is_movable: true
     module: ophyd.sim
   motor_no_pos:
     classname: SynAxisNoPosition
+    is_movable: true
     module: ophyd.sim
   noisy_det:
     classname: SynGauss
+    is_movable: false
     module: ophyd.sim
   pseudo1x3:
     classname: SPseudo1x3
+    is_movable: true
     module: ophyd.sim
   pseudo3x3:
     classname: SPseudo3x3
+    is_movable: true
     module: ophyd.sim
 existing_plans:
   _sim_plan_inner:


### PR DESCRIPTION
Changes:

- new CLI parameter (`--redis-addr`) for passing Redis host name to RE Manager (`start-re-manager`). The parameter allows to pass Redis host name (e.g. `localhost` or `127.0.0.1`) or host name with Redis port number (e.g. `localhost:6379` or `127.0.0.1:6379`). If port is not specified, then the default Redis port (`6379`) is used.

- Minor code refactoring: the function `parse_plan` renamed to `prepare_plan`.

- A new parameter (`is_movable`) is added to device parameters in the list of available devices. The parameter is determined using `bluesky.utils.is_movable`.

- Fixed the issue that surfaced after upgrade to `xarray 0.17.0`. The fix includes renaming private attributes `RunEngineWorker._config` and `RunEngineManager._config` to `._config_dict`. Attribute `._config` overrides the attribute `multiprocessing.Process._config` of the base class.

The PR addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/127