### PR TITLE
API for detecting if the script is executed in RE Worker environment.

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -293,7 +293,7 @@ class StartupLoadingError(Exception):
     ...
 
 
-def load_startup_script(script_path, *, keep_re=False, enable_local_imports=False):
+def load_startup_script(script_path, *, keep_re=False, enable_local_imports=True):
     """
     Populate namespace by import a module.
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -1202,6 +1202,8 @@ def gen_list_of_plans_and_devices(
     RuntimeError
         Error occurred while creating or saving the lists.
     """
+    from .profile_tools import set_re_worker_active, clear_re_worker_active
+
     file_name = file_name or "existing_plans_and_devices.yaml"
     try:
         if file_dir is None:
@@ -1209,6 +1211,8 @@ def gen_list_of_plans_and_devices(
 
         if sum([_ is None for _ in [startup_dir, startup_module_name, startup_script_path]]) != 2:
             raise ValueError("Source of the startup code was not specified or multiple sources were specified.")
+
+        set_re_worker_active()
 
         nspace = load_worker_startup_code(
             startup_dir=startup_dir,
@@ -1233,6 +1237,9 @@ def gen_list_of_plans_and_devices(
 
     except Exception as ex:
         raise RuntimeError(f"Failed to create the list of plans and devices: {str(ex)}")
+
+    finally:
+        clear_re_worker_active()
 
 
 def gen_list_of_plans_and_devices_cli():

--- a/bluesky_queueserver/manager/profile_tools.py
+++ b/bluesky_queueserver/manager/profile_tools.py
@@ -301,7 +301,7 @@ def set_re_worker_active():
     Subsequent calls to ``is_re_worker_active`` in the current process will return ``True``.
     This function should not be used in the startup scripts.
     """
-    os.environ[_env_re_worker_active] = True
+    os.environ[_env_re_worker_active] = ""
 
 
 def clear_re_worker_active():
@@ -338,4 +338,4 @@ def is_re_worker_active():
     boolean
         ``True`` - the code is executed in RE Worker environment, otherwise ``False``.
     """
-    return bool(os.environ.get(_env_re_worker_active, False))
+    return _env_re_worker_active in os.environ

--- a/bluesky_queueserver/manager/profile_tools.py
+++ b/bluesky_queueserver/manager/profile_tools.py
@@ -301,7 +301,7 @@ def set_re_worker_active():
     Subsequent calls to ``is_re_worker_active`` in the current process will return ``True``.
     This function should not be used in the startup scripts.
     """
-    os.environ[_env_re_worker_active] = ""
+    os.environ[_env_re_worker_active] = "1"
 
 
 def clear_re_worker_active():
@@ -338,4 +338,4 @@ def is_re_worker_active():
     boolean
         ``True`` - the code is executed in RE Worker environment, otherwise ``False``.
     """
-    return _env_re_worker_active in os.environ
+    return bool(os.environ.get(_env_re_worker_active, False))

--- a/bluesky_queueserver/manager/profile_tools.py
+++ b/bluesky_queueserver/manager/profile_tools.py
@@ -338,4 +338,4 @@ def is_re_worker_active():
     boolean
         ``True`` - the code is executed in RE Worker environment, otherwise ``False``.
     """
-    return bool(os.environ.get(_env_re_worker_active, False))
+    return os.environ.get(_env_re_worker_active, "false").lower() not in ("false", "0", "")

--- a/bluesky_queueserver/manager/profile_tools.py
+++ b/bluesky_queueserver/manager/profile_tools.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 import re
+import os
 
 
 class UserNamespace:
@@ -289,3 +290,52 @@ def load_devices_from_happi(device_names, *, namespace, **kwargs):
     ns_dict = ns.__dict__
     namespace.update(ns_dict)
     return list(ns_dict)
+
+
+_env_re_worker_active = "QSERVER_RE_WORKER_ACTIVE"
+
+
+def set_re_worker_active():
+    """
+    Set the environment variable used to determine if the current process is RE Worker process.
+    Subsequent calls to ``is_re_worker_active`` in the current process will return ``True``.
+    This function should not be used in the startup scripts.
+    """
+    os.environ[_env_re_worker_active] = True
+
+
+def clear_re_worker_active():
+    """
+    Clear the environment variable used to determine if the current process is RE Worker process.
+    Subsequent calls to ``is_re_worker_active`` in the current process will return ``False``.
+    This function should not be used in the startup scripts.
+    """
+    if _env_re_worker_active in os.environ:
+        del os.environ[_env_re_worker_active]
+
+
+def is_re_worker_active():
+    """
+    The function can be used in startup scripts or modules to check if the script is imported or
+    executed in RE Worker environment. For example, an experimental plan may contain interactive
+    features that should be disabled if the plan is executed remotely:
+
+    .. code-block:: python
+
+        from bluesky_queueserver.manager.profile_tools import is_re_worker_active
+
+        ...
+
+        if is_re_worker_active():
+            (code without interactive features, e.g. reading data from a file)
+        else:
+            (code with interactive features, e.g. manual data input)
+
+        ...
+
+    Returns
+    -------
+    boolean
+        ``True`` - the code is executed in RE Worker environment, otherwise ``False``.
+    """
+    return bool(os.environ.get(_env_re_worker_active, False))

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -403,7 +403,7 @@ def start_manager():
     default_existing_pd_fln = "existing_plans_and_devices.yaml"
     if args.existing_plans_and_devices_path:
         existing_pd_path = os.path.expanduser(args.existing_plans_and_devices_path)
-        if not os.path.isabs(existing_pd_path):
+        if not os.path.isabs(existing_pd_path) and startup_dir:
             existing_pd_path = os.path.join(startup_dir, existing_pd_path)
         if not existing_pd_path.endswith(".yaml"):
             existing_pd_path = os.path.join(existing_pd_path, default_existing_pd_fln)
@@ -420,7 +420,7 @@ def start_manager():
     default_user_group_pd_fln = "user_group_permissions.yaml"
     if args.user_group_permissions_path:
         user_group_pd_path = os.path.expanduser(args.user_group_permissions_path)
-        if not os.path.isabs(user_group_pd_path):
+        if not os.path.isabs(user_group_pd_path) and startup_dir:
             user_group_pd_path = os.path.join(startup_dir, user_group_pd_path)
         if not user_group_pd_path.endswith(".yaml"):
             user_group_pd_path = os.path.join(user_group_pd_path, default_user_group_pd_fln)

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -386,7 +386,7 @@ def start_manager():
         # Check if startup script exists (if it is specified)
         if startup_script_path is not None:
             if not os.path.isfile(startup_script_path):
-                logger.error("The script '{startup_script_path}' is not found.")
+                logger.error(f"The script '{startup_script_path}' is not found.")
                 return 1
 
     config_worker["keep_re"] = args.keep_re

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -1046,7 +1046,7 @@ def test_devices_from_nspace():
         ),
     ],
 )
-def test_parse_plan(plan, success, err_msg):
+def test_prepare_plan(plan, success, err_msg):
 
     pc_path = get_default_startup_dir()
     nspace = load_profile_collection(pc_path)

--- a/bluesky_queueserver/manager/tests/test_profile_tools.py
+++ b/bluesky_queueserver/manager/tests/test_profile_tools.py
@@ -513,10 +513,21 @@ def test_is_re_worker_active_2(re_manager_cmd, tmp_path, monkeypatch, option):  
             ]
         )
     elif option == "module":
-        # Unfortunately, there seems to be no way to continue with the rest of the test,
-        #   because RE Manager can load only the installed modules. In this test we successfully
-        #   loaded the module in `gen_list_of_plans_and_devices()`, so let's consider it
-        #   a success and interrupt the test.
+        # The manager will still start, but the environment can not load, because
+        #   the module 'script_dir1.startup_script' is not installed.
+        re_manager_cmd(
+            [
+                "--startup-module",
+                "script_dir1.startup_script",
+                "--user-group-permissions",
+                path_user_permissions,
+                "--existing-plans-devices",
+                path_existing_plans_and_devices,
+            ]
+        )
+        # Since the environment can not be loaded, the rest of the test will not work.
+        #   We successfully loaded the module in `gen_list_of_plans_and_devices()`, so
+        #   let's consider it success and interrupt the test.
         return
     else:
         assert False, f"Unknown option '{option}'"

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -493,6 +493,7 @@ class RunEngineWorker(Process):
         logging.getLogger(__name__).setLevel(self._log_level)
 
         from .profile_tools import set_re_worker_active, clear_re_worker_active
+
         # Set the environment variable indicating that RE Worker is active. Status may be
         #   checked using 'is_re_worker_active()' in startup scripts or modules.
         set_re_worker_active()

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -492,6 +492,11 @@ class RunEngineWorker(Process):
         logging.basicConfig(level=logging.WARNING)
         logging.getLogger(__name__).setLevel(self._log_level)
 
+        from .profile_tools import set_re_worker_active, clear_re_worker_active
+        # Set the environment variable indicating that RE Worker is active. Status may be
+        #   checked using 'is_re_worker_active()' in startup scripts or modules.
+        set_re_worker_active()
+
         from .plan_monitoring import RunList, CallbackRegisterRun
 
         self._active_run_list = RunList()  # Initialization should be done before communication is enabled.
@@ -660,6 +665,10 @@ class RunEngineWorker(Process):
         # Wait until confirmation is received from RE Manager
         while not self._exit_confirmed_event.is_set():
             ttime.sleep(0.02)
+
+        # Clear the environment variable indicating that RE Worker is active. It is an optional step
+        #   since the process is about to close, but we still do it for consistency.
+        clear_re_worker_active()
 
         self._RE = None
 


### PR DESCRIPTION
Implementation of API function `is_re_worker_active()` for using in startup scripts or modules. The API function returns boolean value that tells if the script is executed in RE Worker environment. One potential use of the API is to disable interactive features in a script (such as manual input) when the script is executed autonomously in RE Worker environment:

```
from bluesky_queueserver.manager.profile_tools import is_re_worker_active

...

if is_re_worker_active():
    (code without interactive features, e.g. reading data from a file)
else:
    (code with interactive features, e.g. manual data input)

...
```
`is_re_worker_active()` may be used in any code executed by the RE Worker process including the modules imported by startup scripts. 

The `is_re_worker_active()` function checking if an environment variable `QSERVER_RE_WORKER_ACTIVE` is set in the current process and returns `True` if the variable is found and `False` otherwise. The environment variable is set/unset by the additional API functions `set_re_worker_active()` and `clear_re_worker_active()`. The functions add/remove elements in the dictionary `os.environ` and therefore influence only the process in which they are called.

The additional API functions `set_re_worker_active()` and `clear_re_worker_active()` are not designed to be used in startup scripts, but could be used to emulate RE Worker environment and force execution of the scripts in autonomous mode (see implementation of the function ``gen_list_of_plans_and_devices`` in ``bluesky_queueserver.manager.profile_ops`` module).

Addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/133