### PR TITLE
New API to update/replace queue item

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -307,6 +307,29 @@ The following instruction moves item with <uid_source> to the front of the queue
   qserver queue item move <uid_source> "front"
   http POST http://localhost:60610/queue/item/move uid:='<uid_source>' pos_dest:='"front"'
 
+The parameters of queue items may be updated or replaced. When the item is replaced, it is assigned a new
+item UID, while if the item is updated, item UID remains the same. The commands implementing those
+operations do not distinguish plans and instructions, i.e. an instruction may be updated/replaced
+by a plan or a plan by an instruction. The operations may be performed using CLI tool by calling
+*'queue update'* and *'queue replace'* with parameter *<existing-uid>* being item UID of the item in the
+queue which is being replaced followed by the JSON representation of the dictionary of parameters
+of the new item::
+
+  qserver queue update plan <existing-uid> {"name":"count", "args":[["det1", "det2"]]}'
+  qserver queue update instruction <existing-uid> {"action":"queue_stop"}
+  qserver queue replace plan <existing-uid> {"name":"count", "args":[["det1", "det2"]]}'
+  qserver queue replace instruction <existing-uid> {"action":"queue_stop"}
+
+REST API */queue/item/update* is used to implement both operations. Item parameter *'item_uid'* must
+be set to the UID of the item to be updated. Additional API parameter 'replace' determines if the item
+is updated or replaced. If the parameter is skipped or set *false*, the item is updated. If the
+parameter is set *true*, the item is replaced (i.e. new item UID is generated)::
+
+  http POST http://localhost:60610/queue/item/update plan:='{"item_uid": "<existing-uid>", "name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/update instruction:='{"item_uid": "<existing-uid>", "action":"queue_stop"}'
+  http POST http://localhost:60610/queue/item/update replace:=true plan:='{"item_uid": "<existing-uid>", "name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/update replace:=true instruction:='{"item_uid": "<existing-uid>", "action":"queue_stop"}'
+
 Remove all entries from the plan queue::
 
   qserver queue clear

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -896,8 +896,7 @@ class RunEngineManager(Process):
                 break
         if item_type is None:
             raise Exception(
-                "Incorrect request format: request contains no item info. "
-                f"Supported item types: {item_types}"
+                "Incorrect request format: request contains no item info. " f"Supported item types: {item_types}"
             )
         return item, item_type
 
@@ -922,9 +921,7 @@ class RunEngineManager(Process):
 
         if item_type == "plan":
             allowed_plans = self._allowed_plans[user_group] if self._allowed_plans else self._allowed_plans
-            allowed_devices = (
-                self._allowed_devices[user_group] if self._allowed_devices else self._allowed_devices
-            )
+            allowed_devices = self._allowed_devices[user_group] if self._allowed_devices else self._allowed_devices
             success, msg = validate_plan(item, allowed_plans=allowed_plans, allowed_devices=allowed_devices)
         elif item_type == "instruction":
             # At this point we support only one instruction ('queue_stop'), so validation is trivial.
@@ -1008,7 +1005,9 @@ class RunEngineManager(Process):
         try:
             # Generate new UID if 'replace' flag is True, otherwise update the plan
             generate_new_uid = bool(request.get("replace", False))
-            item, item_type, item_uid_original = self._prepare_item(request=request, generate_new_uid=generate_new_uid)
+            item, item_type, item_uid_original = self._prepare_item(
+                request=request, generate_new_uid=generate_new_uid
+            )
 
             # item["item_uid"] will change if uid is replaced, but we still need
             #   'original' UID to update the correct item

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1010,10 +1010,11 @@ class RunEngineManager(Process):
             generate_new_uid = bool(request.get("replace", False))
             item, item_type, item_uid_original = self._prepare_item(request=request, generate_new_uid=generate_new_uid)
 
-            # item["item_uid"] will change if uid is replaced, but we still need 'original' uid
-            #   to update the correct item
-
+            # item["item_uid"] will change if uid is replaced, but we still need
+            #   'original' UID to update the correct item
+            item, qsize = await self._plan_queue.replace_item(item, item_uid=item_uid_original)
             success = True
+
         except Exception as ex:
             success = False
             msg = f"Failed to add an item: {str(ex)}"

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1042,7 +1042,7 @@ class RunEngineManager(Process):
         (``replace=False`` - UID is not changed) or complete replacement of the item (``replace=True`` -
         new UID is generated).
         """
-        success, msg, qsize = True, "", 0
+        success, msg, qsize, item_type = True, "", 0, None
 
         try:
             # Generate new UID if 'replace' flag is True, otherwise update the plan

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -982,6 +982,11 @@ class RunEngineManager(Process):
 
         return rdict
 
+    async def _queue_item_update_handler(self, request):
+        success, msg, qsize, uid = True, "", 0, "some-uid"
+        rdict = {"success": success, "msg": msg, "qsize": qsize, "uid": uid}
+        return rdict
+
     async def _queue_item_get_handler(self, request):
         """
         Returns an item from the queue. The position of the item
@@ -1271,7 +1276,7 @@ class RunEngineManager(Process):
             "environment_close": "_environment_close_handler",
             "environment_destroy": "_environment_destroy_handler",
             "queue_item_add": "_queue_item_add_handler",
-            # "queue_item_replace": "_queue_item_replace_handler",
+            "queue_item_update": "_queue_item_update_handler",
             "queue_item_get": "_queue_item_get_handler",
             "queue_item_remove": "_queue_item_remove_handler",
             "queue_item_move": "_queue_item_move_handler",

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -578,7 +578,6 @@ class PlanQueueOperations:
         ----------
         item: dict
             Item (plan or instruction) represented as a dictionary of parameters
-
         pos: int, str or None
             Integer that specifies the position index, "front" or "back".
             If ``pos`` is in the range ``1..qsize-1`` the item is inserted
@@ -588,11 +587,9 @@ class PlanQueueOperations:
             (-1 - the last element of the queue). If ``pos>=qsize``,
             the plan is added to the back of the queue. If ``pos==0`` or
             ``pos<=-qsize``, the plan is pushed to the front of the queue.
-
         before_uid: str or None
             If UID is specified, then the item is inserted before the plan with UID.
             ``before_uid`` has precedence over ``after_uid``.
-
         after_uid: str or None
             If UID is specified, then the item is inserted before the plan with UID.
 
@@ -612,7 +609,9 @@ class PlanQueueOperations:
             return await self._add_item_to_queue(item, pos=pos, before_uid=before_uid, after_uid=after_uid)
 
     async def _replace_item(self, item, *, item_uid):
-
+        """
+        See ``self._replace_item()`` method
+        """
         # We can not replace currently running item, since it is technically not in the queue
         running_item = await self._get_running_item_info()
         running_item_uid = running_item["item_uid"] if running_item else None
@@ -648,6 +647,23 @@ class PlanQueueOperations:
         return item, qsize
 
     async def replace_item(self, item, *, item_uid):
+        """
+        Replace item in the queue. Item with UID ``item_uid`` is replaced by item ``item``. The new
+        item may have UID which is the same or different from UID of the item being replaced.
+
+        Parameters
+        ----------
+        item: dict
+            Item (plan or instruction) represented as a dictionary of parameters.
+
+        item_uid: str
+            UID of existing item in the queue that will be replaced.
+
+        Returns
+        -------
+        dict, int
+            The dictionary that contains the item that was added and the new size of the queue.
+        """
         async with self._lock:
             return await self._replace_item(item, item_uid=item_uid)
 

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -128,7 +128,8 @@ class PlanQueueOperations:
         """
         Verify that item (plan) structure is valid enough to be put in the queue.
         Current checks: item is a dictionary, ``item_uid`` key is present, Plan with the UID is not in
-        the queue or currently running. Ignore UIDs in the list ``ignore_uids``.
+        the queue or currently running. Ignore UIDs in the list ``ignore_uids``: those UIDs are expected
+        to be in the dictionary.
         """
         ignore_uids = ignore_uids or []
         self._verify_item_type(item)

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -616,9 +616,9 @@ class PlanQueueOperations:
         running_item = await self._get_running_item_info()
         running_item_uid = running_item["item_uid"] if running_item else None
         if not self._is_uid_in_dict(item_uid):
-            raise RuntimeError(f"Failed to replace item: Item with UID {item_uid} is not in the queue")
+            raise RuntimeError(f"Failed to replace item: Item with UID '{item_uid}' is not in the queue")
         if (running_item_uid is not None) and (running_item_uid == item_uid):
-            raise RuntimeError(f"Failed to replace item: Item with UID {item_uid} is currently running")
+            raise RuntimeError(f"Failed to replace item: Item with UID '{item_uid}' is currently running")
 
         if "item_uid" not in item:
             item = self.set_new_item_uuid(item)

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -124,18 +124,20 @@ class PlanQueueOperations:
         if not isinstance(item, dict):
             raise TypeError(f"Parameter 'item' should be a dictionary: '{item}', (type '{type(item)}')")
 
-    def _verify_item(self, item):
+    def _verify_item(self, item, *, ignore_uids=None):
         """
         Verify that item (plan) structure is valid enough to be put in the queue.
         Current checks: item is a dictionary, ``item_uid`` key is present, Plan with the UID is not in
-        the queue or currently running.
+        the queue or currently running. Ignore UIDs in the list ``ignore_uids``.
         """
+        ignore_uids = ignore_uids or []
         self._verify_item_type(item)
         # Verify plan UID
         if "item_uid" not in item:
             raise ValueError("Item does not have UID.")
-        if self._is_uid_in_dict(item["item_uid"]):
-            raise RuntimeError(f"Item with UID {item['item_uid']} is already in the queue")
+        uid = item["item_uid"]
+        if (uid not in ignore_uids) and self._is_uid_in_dict(uid):
+            raise RuntimeError(f"Item with UID {uid} is already in the queue")
 
     @staticmethod
     def new_item_uid():
@@ -609,7 +611,39 @@ class PlanQueueOperations:
             return await self._add_item_to_queue(item, pos=pos, before_uid=before_uid, after_uid=after_uid)
 
     async def _replace_item(self, item, *, item_uid):
-        qsize = 0
+
+        # We can not replace currently running item, since it is technically not in the queue
+        running_item = await self._get_running_item_info()
+        running_item_uid = running_item["item_uid"] if running_item else None
+        if not self._is_uid_in_dict(item_uid) or (running_item_uid is not None and running_item_uid == item_uid):
+            raise RuntimeError(f"Failed to replace item: Item with UID {item_uid} is not in the queue")
+
+        if "item_uid" not in item:
+            item = self.set_new_item_uuid(item)
+
+        item_to_replace = self._uid_dict_get_item(item_uid)
+        if item == item_to_replace:
+            # There is nothing to do. Consider operation as successful.
+            qsize = await self._get_queue_size()
+            return item, qsize
+
+        # Item with 'item_uid' is expected to be in the queue, so ignore 'item_uid'.
+        #   The concern is that the queue may contain a plan with `item["item_uid"]`, which could be
+        #   different from 'item_uid'. Then inserting the item may violate integrity of the queue.
+        self._verify_item(item, ignore_uids=[item_uid])
+
+        # Insert the new item after the old one and remove the old one. At this point it is guaranteed
+        #   that they are not equal.
+        await self._r_pool.linsert(self._name_plan_queue, json.dumps(item_to_replace), json.dumps(item))
+        await self._r_pool.lrem(self._name_plan_queue, json.dumps(item_to_replace))
+
+        # Update self._uid_dict
+        self._uid_dict_remove(item_uid)
+        self._uid_dict_add(item)
+
+        # Read the actual size of the queue.
+        qsize = await self._get_queue_size()
+
         return item, qsize
 
     async def replace_item(self, item, *, item_uid):

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -608,6 +608,14 @@ class PlanQueueOperations:
         async with self._lock:
             return await self._add_item_to_queue(item, pos=pos, before_uid=before_uid, after_uid=after_uid)
 
+    async def _replace_item(self, item, *, item_uid):
+        qsize = 0
+        return item, qsize
+
+    async def replace_item(self, item, *, item_uid):
+        async with self._lock:
+            return await self._replace_item(item, item_uid=item_uid)
+
     async def _move_item(self, *, pos=None, uid=None, pos_dest=None, before_uid=None, after_uid=None):
         """
         See ``self.move_plan()`` method.

--- a/bluesky_queueserver/manager/profile_tools.py
+++ b/bluesky_queueserver/manager/profile_tools.py
@@ -292,6 +292,8 @@ def load_devices_from_happi(device_names, *, namespace, **kwargs):
     return list(ns_dict)
 
 
+# Name of the environment variable may change in the future. Use API to set/clear the variable.
+#   The variable name should not be included in the documentation.
 _env_re_worker_active = "QSERVER_RE_WORKER_ACTIVE"
 
 
@@ -338,4 +340,4 @@ def is_re_worker_active():
     boolean
         ``True`` - the code is executed in RE Worker environment, otherwise ``False``.
     """
-    return os.environ.get(_env_re_worker_active, "false").lower() not in ("n", "no", "f", "false", "off", "0", "")
+    return os.environ.get(_env_re_worker_active, "false").lower() not in ("", "n", "no", "f", "false", "off", "0")

--- a/bluesky_queueserver/manager/profile_tools.py
+++ b/bluesky_queueserver/manager/profile_tools.py
@@ -338,4 +338,4 @@ def is_re_worker_active():
     boolean
         ``True`` - the code is executed in RE Worker environment, otherwise ``False``.
     """
-    return os.environ.get(_env_re_worker_active, "false").lower() not in ("false", "0", "")
+    return os.environ.get(_env_re_worker_active, "false").lower() not in ("n", "no", "f", "false", "off", "0", "")

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -98,14 +98,19 @@ def test_verify_item_type(pq, plan, result):
 
 # fmt: off
 @pytest.mark.parametrize(
-    "plan, result, errmsg",
-    [({"a": 10}, False, "Item does not have UID"),
-     ([10, 20], False, errmsg_wrong_plan_type),
-     ({"item_uid": "one"}, True, ""),
-     ({"item_uid": "two"}, False, "Item with UID .+ is already in the queue"),
-     ({"item_uid": "three"}, False, "Item with UID .+ is already in the queue")])
+    "plan, f_kwargs, result, errmsg",
+    [({"a": 10}, {}, False, "Item does not have UID"),
+     ([10, 20], {}, False, errmsg_wrong_plan_type),
+     ({"item_uid": "one"}, {}, True, ""),
+     ({"item_uid": "two"}, {}, False, "Item with UID .+ is already in the queue"),
+     ({"item_uid": "three"}, {}, False, "Item with UID .+ is already in the queue"),
+     ({"item_uid": "two"}, {"ignore_uids": None}, False, "Item with UID .+ is already in the queue"),
+     ({"item_uid": "two"}, {"ignore_uids": ["two"]}, True, ""),
+     ({"item_uid": "two"}, {"ignore_uids": ["two", "three"]}, True, ""),
+     ({"item_uid": "two"}, {"ignore_uids": ["one", "three"]}, False, "Item with UID .+ is already in the queue"),
+     ])
 # fmt: on
-def test_verify_item(pq, plan, result, errmsg):
+def test_verify_item(pq, plan, f_kwargs, result, errmsg):
     """
     Tests for method ``_verify_item()``.
     """
@@ -126,10 +131,10 @@ def test_verify_item(pq, plan, result, errmsg):
     asyncio.run(set_plans())
 
     if result:
-        pq._verify_item(plan)
+        pq._verify_item(plan, **f_kwargs)
     else:
         with pytest.raises(Exception, match=errmsg):
-            pq._verify_item(plan)
+            pq._verify_item(plan, **f_kwargs)
 
 
 def test_new_item_uid(pq):

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -760,7 +760,7 @@ def test_queue_item_update_1(re_manager, replace, item_type):  # noqa F811
     queue_1 = get_queue()["queue"]
     assert len(queue_1) == 1
     item_1 = queue_1[0]
-    uid_1 = item_1["item_uid"]
+    uid_to_replace = item_1["item_uid"]
 
     if item_type == "plan":
         item = plan2
@@ -770,7 +770,7 @@ def test_queue_item_update_1(re_manager, replace, item_type):  # noqa F811
         assert False, f"Unsupported item type '{item_type}'"
     option = "replace" if replace else "update"
 
-    assert subprocess.call(["qserver", "queue", option, item_type, uid_1, item]) == SUCCESS
+    assert subprocess.call(["qserver", "queue", option, item_type, uid_to_replace, item]) == SUCCESS
 
     queue_2 = get_queue()["queue"]
     assert len(queue_2) == 1
@@ -781,6 +781,38 @@ def test_queue_item_update_1(re_manager, replace, item_type):  # noqa F811
     else:
         assert item_2["item_uid"] == item_1["item_uid"]
     item_2["item_type"] == item_type
+
+
+# fmt: on
+@pytest.mark.parametrize("replace", [False, True])
+@pytest.mark.parametrize("item_type", ["plan", "instruction"])
+# fmt: off
+def test_queue_item_update_2_fail(re_manager, replace, item_type):  # noqa F811
+    """
+    Failing cases for `queue_item_update`: no matching UID is found in the queue.
+    """
+    plan1 = "{'name':'count', 'args':[['det1', 'det2']]}"
+    plan2 = "{'name':'count', 'args':[['det1', 'det2']]}"
+    instruction = "queue-stop"
+
+    assert subprocess.call(["qserver", "queue", "add", "plan", plan1]) == SUCCESS
+
+    queue_1 = get_queue()["queue"]
+    assert len(queue_1) == 1
+    uid_to_replace = "non-existent-UID"
+
+    if item_type == "plan":
+        item = plan2
+    elif item_type == "instruction":
+        item = instruction
+    else:
+        assert False, f"Unsupported item type '{item_type}'"
+    option = "replace" if replace else "update"
+
+    assert subprocess.call(["qserver", "queue", option, item_type, uid_to_replace, item]) == REQ_FAILED
+
+    queue_2 = get_queue()["queue"]
+    assert queue_1 == queue_2
 
 
 # fmt: off

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -743,6 +743,46 @@ def test_queue_item_add_7_fail(re_manager, params, exit_code):  # noqa F811
     assert subprocess.call(["qserver", "queue", "add", "plan", *params]) == exit_code
 
 
+# fmt: on
+@pytest.mark.parametrize("replace", [False, True])
+@pytest.mark.parametrize("item_type", ["plan", "instruction"])
+# fmt: off
+def test_queue_item_update_1(re_manager, replace, item_type):  # noqa F811
+    """
+    Basic test for `queue_item_update` method.
+    """
+    plan1 = "{'name':'count', 'args':[['det1', 'det2']]}"
+    plan2 = "{'name':'count', 'args':[['det1', 'det2']]}"
+    instruction = "queue-stop"
+
+    assert subprocess.call(["qserver", "queue", "add", "plan", plan1]) == SUCCESS
+
+    queue_1 = get_queue()["queue"]
+    assert len(queue_1) == 1
+    item_1 = queue_1[0]
+    uid_1 = item_1["item_uid"]
+
+    if item_type == "plan":
+        item = plan2
+    elif item_type == "instruction":
+        item = instruction
+    else:
+        assert False, f"Unsupported item type '{item_type}'"
+    option = "replace" if replace else "update"
+
+    assert subprocess.call(["qserver", "queue", option, item_type, uid_1, item]) == SUCCESS
+
+    queue_2 = get_queue()["queue"]
+    assert len(queue_2) == 1
+    item_2 = queue_2[0]
+
+    if replace:
+        assert item_2["item_uid"] != item_1["item_uid"]
+    else:
+        assert item_2["item_uid"] == item_1["item_uid"]
+    item_2["item_type"] == item_type
+
+
 # fmt: off
 @pytest.mark.parametrize("pos, uid_ind, pos_result, success", [
     (None, None, 2, True),

--- a/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -3,11 +3,11 @@ user_groups:
     allowed_plans:
       - null  # Allow all
     forbidden_plans:
-      - "$_"  # All plans with names starting with '_'
+      - "^_"  # All plans with names starting with '_'
     allowed_devices:
       - null  # Allow all
     forbidden_devices:
-      - "$_"  # All devices with names starting with '_'
+      - "^_"  # All devices with names starting with '_'
   admin:  # The group includes beamline staff, includes all or most of the plans and devices
     allowed_plans:
       - ".*"  # A different way to allow all

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -174,6 +174,20 @@ async def queue_item_add_handler(payload: dict):
     return msg
 
 
+@app.post("/queue/item/update")
+async def queue_item_add_handler(payload: dict):
+    """
+    Update existing plan in the queue
+    """
+    # TODO: validate inputs! Also: payload["replace"] parameter may be use to change what metadata
+    #   is added to the plan (or whether metadata is changed at all)
+    params = payload
+    params["user"] = _login_data["user"]
+    params["user_group"] = _login_data["user_group"]
+    msg = await zmq_to_manager.send_message(method="queue_item_update", params=params)
+    return msg
+
+
 @app.post("/queue/item/remove")
 async def qqueue_item_remove_handler(payload: dict):
     """

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -189,7 +189,7 @@ async def queue_item_add_handler(payload: dict):
 
 
 @app.post("/queue/item/remove")
-async def qqueue_item_remove_handler(payload: dict):
+async def queue_item_remove_handler(payload: dict):
     """
     Remove plan from the queue
     """

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -175,7 +175,7 @@ async def queue_item_add_handler(payload: dict):
 
 
 @app.post("/queue/item/update")
-async def queue_item_add_handler(payload: dict):
+async def queue_item_update_handler(payload: dict):
     """
     Update existing plan in the queue
     """

--- a/bluesky_queueserver/server/tests/conftest.py
+++ b/bluesky_queueserver/server/tests/conftest.py
@@ -8,7 +8,7 @@ SERVER_ADDRESS = "localhost"
 SERVER_PORT = "60610"
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def fastapi_server(xprocess):
     class Starter(ProcessStarter):
         pattern = "Connected to ZeroMQ server"

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -90,6 +90,7 @@ Operations with the plan queue:
 
 - :ref:`method_queue_get`
 - :ref:`method_queue_item_add`
+- :ref:`method_queue_item_update`
 - :ref:`method_queue_item_get`
 - :ref:`method_queue_item_remove`
 - :ref:`method_queue_item_move`
@@ -502,6 +503,62 @@ Returns       **success**: *boolean*
               **qsize**: *int* or *None*
                   the number of items in the plan queue after the plan was added if
                   the operation was successful, *None* otherwise
+
+              **plan** or **instruction**: *dict*
+                  the inserted item. The item contains the assigned item UID.
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
+============  =========================================================================================
+
+
+.. _method_queue_item_update:
+
+**'queue_item_update'**
+^^^^^^^^^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'queue_item_update'**
+------------  -----------------------------------------------------------------------------------------
+Description   Update the existing item in the queue. The method is intended for editing queue items,
+              but may be used for replacing the existing items with completely different ones.
+              The updated item may be a plan or an instruction. The item parameter 'item_uid' must
+              be set to a UID of an existing queue item that is expected to be replaced. The method
+              fails if the item is not found. By default, the UID of the updated item is not changed
+              and 'user' and 'user_group' parameters are set to the values provided in the request.
+              The 'user_group' is also used for validation of submitted item. If it is preferable
+              to replace the item UID with a new random UID (e.g. if the item is replaced with
+              completely different item), the method should be called with the optional parameter
+              'replace=True'.
+------------  -----------------------------------------------------------------------------------------
+Parameters    **plan or instruction**: *dict*
+                  the dictionary of plan or instruction parameters. Plans are distinguished from
+                  instructions based on whether 'plan' or 'instruction' parameter is included.
+
+              **user_group**: *str*
+                  the name of the user group (e.g. 'admin').
+
+              **user**: *str*
+                  the name of the user (e.g. 'John Doe'). The name is included in the item metadata
+                  and may be used to identify the user who added the item to the queue. It is not
+                  passed to the Run Engine or included in run metadata.
+
+              **replace**: *boolean* (optional)
+                  replace the updated item UID with the new random UID (True) or keep the original
+                  UID (False). Default value is (False).
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+
+              **qsize**: *int* or *None*
+                  the number of items in the plan queue after the plan was added if
+                  the operation was successful, *None* otherwise
+
+              **plan** or **instruction**: *dict*
+                  the updated item. The item contains the new item UID if the method was called with
+                  'replace=True'.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================


### PR DESCRIPTION
New API to update/replace existing item in the queue. The updated/replaced item is addressed by item UID. If item is not found then request fails. The operations of updating and replacing items is almost identical, except that an item UID is not changed while the item is updated and replaced with the new randomly generated item UID when the item is replaced. The 'update' operation is intended for insignificant changes in item parameters (e.g. editing the existing plan) and 'replace' operation for replacing items with different items.

- 0MQ API: **queue_item_update** accepts parameters that include the modified item (`plan` or `instruction`) with `item_uid` set to item UID of the item to be updated, `user` and `user_group`, and optional boolean parameter `replace`. If only the item parameters are modified when editing and item UID is not changed, then the plan can simply be sent back to RE Manager by using the API. If the parameter `replace` is `False` or not specified, then the item in the queue is updated, if `replace=True`, then the item is replaced.
```
zmq_comm = ZMQCommSendAsync()

# Update plan
await zmq_comm.send_message(method="queue_item_update", params={"plan": {"name": "count", "args": [["det1", "det2"]]}, "user": "Some User", "user_group": "admin"})
await zmq_comm.send_message(method="queue_item_update", params{"plan": {"name": "count", "args": [["det1", "det2"]]}, "user": "Some User", "user_group": "admin", "replace": False})

# Replace plan
await zmq_comm.send_message(method="queue_item_update", params={"plan": {"name": "count", "args": [["det1", "det2"]]}, "user": "Some User", "user_group": "admin", "replace": True})
```

- CLI option of the API:
```
  qserver queue update plan <existing-uid> {"name":"count", "args":[["det1", "det2"]]}'
  qserver queue update instruction <existing-uid> {"action":"queue_stop"}
  qserver queue replace plan <existing-uid> {"name":"count", "args":[["det1", "det2"]]}'
  qserver queue replace instruction <existing-uid> {"action":"queue_stop"}
```
- REST API implementation of the API:
```
  http POST http://localhost:60610/queue/item/update plan:='{"item_uid": "<existing-uid>", "name":"count", "args":[["det1", "det2"]]}'
  http POST http://localhost:60610/queue/item/update instruction:='{"item_uid": "<existing-uid>", "action":"queue_stop"}'
  http POST http://localhost:60610/queue/item/update replace:=true plan:='{"item_uid": "<existing-uid>", "name":"count", "args":[["det1", "det2"]]}'
  http POST http://localhost:60610/queue/item/update replace:=true instruction:='{"item_uid": "<existing-uid>", "action":"queue_stop"}'
```

Addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/131