### PR TITLE
CLI arguments for 'start-re-manager' to set logging verbosity

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -896,7 +896,7 @@ class RunEngineManager(Process):
                 break
         if item_type is None:
             raise Exception(
-                "Incorrect request format: request contains no item info. Supported item types: {item_types}"
+                f"Incorrect request format: request contains no item info. Supported item types: {item_types}"
             )
         return item, item_type
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -896,7 +896,7 @@ class RunEngineManager(Process):
                 break
         if item_type is None:
             raise Exception(
-                "Incorrect request format: request contains no item info. " f"Supported item types: {item_types}"
+                "Incorrect request format: request contains no item info. Supported item types: {item_types}"
             )
         return item, item_type
 
@@ -1036,7 +1036,7 @@ class RunEngineManager(Process):
         ``queue_item_add`` request, except that the description must contain UID (``item_uid`` key).
         The queue must contain an item with the identical UID. This item will be replaced with
         the item passed as part of the request. The request may contain an optional parameter ``replace``.
-        If ``replace`` is missing or evaluated as ``False``, then the item UID in the queue does is
+        If ``replace`` is missing or evaluated as ``False``, then the item UID in the queue is
         not changed. If ``replace`` is ``True``, then the new UID is generated before the item is
         replaced. The original UID is still used to locate the item in the queue before replacing it.
         The ``replace`` parameter allows to distinguish between small changes to item parameters

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -53,7 +53,7 @@ class RunEngineManager(Process):
         `args` and `kwargs` of the `multiprocessing.Process`
     """
 
-    def __init__(self, *args, conn_watchdog, conn_worker, config=None, log_level="DEBUG", **kwargs):
+    def __init__(self, *args, conn_watchdog, conn_worker, config=None, log_level=logging.DEBUG, **kwargs):
 
         if not conn_watchdog:
             raise RuntimeError(
@@ -1522,8 +1522,7 @@ class RunEngineManager(Process):
         Overrides the `run()` function of the `multiprocessing.Process` class. Called
         by the `start` method.
         """
-
-        logging.basicConfig(level=logging.WARNING)
+        logging.basicConfig(level=max(logging.WARNING, self._log_level))
         logging.getLogger(__name__).setLevel(self._log_level)
 
         logger.info("Starting RE Manager process")

--- a/bluesky_queueserver/manager/plan_monitoring.py
+++ b/bluesky_queueserver/manager/plan_monitoring.py
@@ -120,8 +120,8 @@ class CallbackRegisterRun(CallbackBase):
             uid = doc["uid"]
             self._run_list.add_run(uid=uid)
 
-            print(f"New run was open: '{uid}'")
-            print(f"Run list: {self._run_list.get_run_list()}")
+            logger.info(f"New run was open: '{uid}'")
+            logger.debug(f"Run list: {self._run_list.get_run_list()}")
         except Exception as ex:
             logger.exception(f"RE Manager: Could not register new run: {ex}")
 

--- a/bluesky_queueserver/manager/plan_monitoring.py
+++ b/bluesky_queueserver/manager/plan_monitoring.py
@@ -120,8 +120,8 @@ class CallbackRegisterRun(CallbackBase):
             uid = doc["uid"]
             self._run_list.add_run(uid=uid)
 
-            logger.info(f"New run was open: '{uid}'")
-            logger.debug(f"Run list: {self._run_list.get_run_list()}")
+            logger.info("New run was open: '%s'", uid)
+            logger.debug("Run list: %s", str(self._run_list.get_run_list()))
         except Exception as ex:
             logger.exception(f"RE Manager: Could not register new run: {ex}")
 

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -653,14 +653,8 @@ def create_msg(params):
             raise CommandParameterError(f"Request '{command}' must include at least one parameter")
         supported_params = ("add", "update", "replace", "get", "clear", "item", "start", "stop")
         if params[0] in supported_params:
-            if params[0] == "add":
-                method, prms = msg_queue_add_update(params, cmd_opt="add")
-
-            elif params[0] == "update":
-                method, prms = msg_queue_add_update(params, cmd_opt="update")
-
-            elif params[0] == "replace":
-                method, prms = msg_queue_add_update(params, cmd_opt="replace")
+            if params[0] in ("add", "update", "replace"):
+                method, prms = msg_queue_add_update(params, cmd_opt=params[0])
 
             elif params[0] in ("get", "clear", "start"):
                 if len(params) != 1:

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -25,7 +25,7 @@ class WatchdogProcess:
         config_manager=None,
         cls_run_engine_worker=RunEngineWorker,
         cls_run_engine_manager=RunEngineManager,
-        log_level="DEBUG",
+        log_level=logging.DEBUG,
     ):
 
         self._log_level = log_level
@@ -149,7 +149,7 @@ class WatchdogProcess:
 
     def run(self):
 
-        logging.basicConfig(level=logging.WARNING)
+        logging.basicConfig(level=max(logging.WARNING, self._log_level))
         logging.getLogger(__name__).setLevel(self._log_level)
 
         # Requests
@@ -483,7 +483,7 @@ def start_manager():
         return 1
     config_manager["redis_addr"] = redis_addr
 
-    wp = WatchdogProcess(config_worker=config_worker, config_manager=config_manager)
+    wp = WatchdogProcess(config_worker=config_worker, config_manager=config_manager, log_level=log_level)
     try:
         wp.run()
     except KeyboardInterrupt:

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -179,12 +179,12 @@ class WatchdogProcess:
             #   a clock to be completely independent from system clock.
             t_min, t_max = self._heartbeat_timeout, self._heartbeat_timeout + 10.0
             if (time_passed >= t_min) and (time_passed <= t_max) and not self._manager_is_stopping:
-                logger.error("Timeout detected by Watchdog. RE Manager malfunctioned and must be restarted.")
+                logger.error("Timeout detected by Watchdog. RE Manager malfunctioned and must be restarted")
                 self._re_manager.kill()
                 self._start_re_manager()
 
         self._comm_to_manager.stop()
-        logger.info("RE Watchdog is stopped.")
+        logger.info("RE Watchdog is stopped")
 
 
 def start_manager():
@@ -451,4 +451,4 @@ def start_manager():
     try:
         wp.run()
     except KeyboardInterrupt:
-        logger.info("The program was manually stopped.")
+        logger.info("The program was manually stopped")

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -316,7 +316,7 @@ def start_manager():
         "Logging verbosity settings",
         "The default logging settings (loglevel=INFO) provide optimal amount of data to monitor "
         "the operation of RE Manager. Select '--verbose' option to see detailed data on received and "
-        "sent messages, addeded and executed plans etc. Use options '--quiet' and '--silent' to "
+        "sent messages, added and executed plans, etc. Use options '--quiet' and '--silent' to "
         "see only warnings and error messages or disable logging output.",
     )
     group_v = group_verbosity.add_mutually_exclusive_group()

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -312,10 +312,46 @@ def start_manager():
         help="Name of the Data Broker configuration file.",
     )
 
-    logging.basicConfig(level=logging.WARNING)
-    logging.getLogger("bluesky_queueserver").setLevel("DEBUG")
+    group_verbosity = parser.add_argument_group(
+        "Logging verbosity settings",
+        "The default logging settings (loglevel=INFO) provide optimal amount of data to monitor "
+        "the operation of RE Manager. Select '--verbose' option to see detailed data on received and "
+        "sent messages, addeded and executed plans etc. Use options '--quiet' and '--silent' to "
+        "see only warnings and error messages or disable logging output.",
+    )
+    group_v = group_verbosity.add_mutually_exclusive_group()
+    group_v.add_argument(
+        "--verbose",
+        dest="logger_verbose",
+        action="store_true",
+        help="Set logger level to DEBUG.",
+    )
+    group_v.add_argument(
+        "--quiet",
+        dest="logger_quiet",
+        action="store_true",
+        help="Set logger level to WARNING.",
+    )
+    group_v.add_argument(
+        "--silent",
+        dest="logger_silent",
+        action="store_true",
+        help="Disables logging output.",
+    )
 
     args = parser.parse_args()
+
+    log_level = logging.INFO
+    if args.logger_verbose:
+        log_level = logging.DEBUG
+    elif args.logger_quiet:
+        log_level = logging.WARNING
+    elif args.logger_silent:
+        log_level = logging.CRITICAL + 1
+
+    logging.basicConfig(level=max(logging.WARNING, log_level))
+    logging.getLogger("bluesky_queueserver").setLevel(log_level)
+
     config_worker = {}
     config_manager = {}
     if args.kafka_topic is not None:

--- a/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -1,0 +1,41 @@
+import pytest
+
+from ..comms import zmq_single_request
+from ._common import re_manager_cmd  # noqa: F401
+
+from ._common import (
+    wait_for_condition,
+    condition_environment_created,
+    condition_environment_closed,
+)
+
+
+# fmt: off
+@pytest.mark.parametrize("option", ["--verbose", "--quiet", "--silent"])
+# fmt: on
+def test_start_re_manager_logging_1(re_manager_cmd, option):  # noqa: F811
+    """
+    Test if RE Manager is correctly started with parameters that define logging verbosity.
+    The test also creates the worker environment to make sure that the program does not crash
+    when worker process is created.
+
+    This is a smoke test: it does not verify that logging works.
+    """
+    re_manager_cmd([option])
+
+    resp1, _ = zmq_single_request("environment_open")
+    assert resp1["success"] is True
+    assert resp1["msg"] == ""
+
+    assert wait_for_condition(time=3, condition=condition_environment_created)
+
+    # Attemtp to communicate with RE Manager
+    resp2, _ = zmq_single_request("status")
+    assert resp2["items_in_queue"] == 0
+    assert resp2["items_in_history"] == 0
+
+    resp3, _ = zmq_single_request("environment_close")
+    assert resp3["success"] is True
+    assert resp3["msg"] == ""
+
+    assert wait_for_condition(time=3, condition=condition_environment_closed)

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -154,7 +154,7 @@ class RunEngineWorker(Process):
                 # Include RE state
                 self._re_report["re_state"] = str(self._RE._state)
 
-        logger.debug("Finished execution of a task")
+        logger.debug("Finished execution of the task")
 
     def _load_new_plan(self, plan_info):
         """
@@ -309,7 +309,7 @@ class RunEngineWorker(Process):
         Close RE Worker environment in orderly way.
         """
         # Stop the loop in main thread
-        logger.info("Closing RE Worker environment")
+        logger.info("Closing RE Worker environment ...")
         # TODO: probably the criteria on when the environment could be more precise.
         #       For now simply assume that we can not close the environment in which
         #       Run Engine is running using this method. Different method that kills
@@ -354,7 +354,7 @@ class RunEngineWorker(Process):
         """
         Initiate execution of a new plan.
         """
-        logger.info("Starting execution of a plan")
+        logger.info("Starting execution of a plan ...")
         # TODO: refine the criteria of acceptance of the new plan.
         invalid_state = 0
         if not self._execution_queue.empty():
@@ -398,7 +398,7 @@ class RunEngineWorker(Process):
         Pause running plan. Options: `deferred` and `immediate`.
         """
         # Stop the loop in main thread
-        logger.info("Pausing Run Engine")
+        logger.info("Pausing Run Engine ...")
         pausing_options = ("deferred", "immediate")
         # TODO: the question is whether it is possible or should be allowed to pause a plan in
         #       any other state than 'running'???
@@ -550,7 +550,7 @@ class RunEngineWorker(Process):
                 )
             self._existing_plans = plans_from_nspace(self._re_namespace)
             self._existing_devices = devices_from_nspace(self._re_namespace)
-            logger.info("Startup code was loaded completed.")
+            logger.info("Startup code loading was completed")
 
         except Exception as ex:
             logger.exception(
@@ -655,7 +655,7 @@ class RunEngineWorker(Process):
                 logger.exception("Error occurred while initializing the environment: %s.", str(ex))
 
         if success:
-            logger.info("RE Environment is ready.")
+            logger.info("RE Environment is ready")
             self._execute_in_main_thread()
         else:
             self._exit_event.set()
@@ -675,4 +675,4 @@ class RunEngineWorker(Process):
 
         self._comm_to_manager.stop()
 
-        logger.info("Run Engine environment was closed successfully.")
+        logger.info("Run Engine environment was closed successfully")

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -37,7 +37,7 @@ class RunEngineWorker(Process):
         `args` and `kwargs` of the `multiprocessing.Process`
     """
 
-    def __init__(self, *args, conn, config=None, log_level="DEBUG", **kwargs):
+    def __init__(self, *args, conn, config=None, log_level=logging.DEBUG, **kwargs):
 
         if not conn:
             raise RuntimeError("Invalid value of parameter 'conn': %S.", str(conn))
@@ -488,9 +488,10 @@ class RunEngineWorker(Process):
         Overrides the `run()` function of the `multiprocessing.Process` class. Called
         by the `start` method.
         """
-        success = True
-        logging.basicConfig(level=logging.WARNING)
+        logging.basicConfig(level=max(logging.WARNING, self._log_level))
         logging.getLogger(__name__).setLevel(self._log_level)
+
+        success = True
 
         from .profile_tools import set_re_worker_active, clear_re_worker_active
 

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -179,7 +179,7 @@ async def queue_item_update_handler(payload: dict):
     """
     Update existing plan in the queue
     """
-    # TODO: validate inputs! Also: payload["replace"] parameter may be use to change what metadata
+    # TODO: validate inputs! Also: payload["replace"] parameter may be used to change what metadata
     #   is added to the plan (or whether metadata is changed at all)
     params = payload
     params["user"] = _login_data["user"]


### PR DESCRIPTION
The set of CLI parameters was added to `start-re-manager` that allow to modify verbosity of logging output. Currently logging can only be sent to stdout/stderr. By default, RE Manager will display log messages starting from `loglevel=INFO`. The log includes warnings, errors, brief messages with information about the state of the manager and worker processes and executed steps. This behavior may be modified by calling `start-re-manager` with the following mutually exclusive parameters:

- `--verbose` prints all logging messages including `DEBUG` messages. In addition to short messages indicating the executed steps, the output will display contents of all received/send messages, submitted plans etc. Verbose output may be useful for debugging purposes, but may slow down the system if the plan queue, history or the lists of plans/devices become long.

- `--quiet` prints only warning and error message. Output is insufficient to monitor plan execution.

- `--silent` disables logging. 

Resolves the issue https://github.com/bluesky/bluesky-queueserver/issues/130