### PR TITLE
New RE Manager status fields: 'plan_queue_uid' and 'plan_history_uid'

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -788,6 +788,8 @@ class RunEngineManager(Process):
         worker_environment_exists = self._environment_exists
         re_state = self._worker_state_info["re_state"] if self._worker_state_info else None
         run_list_uid = self._re_run_list_uid
+        plan_queue_uid = self._plan_queue.plan_queue_uid()
+        plan_history_uid = self._plan_queue.plan_history_uid()
         # worker_state_info = self._worker_state_info
 
         # TODO: consider different levels of verbosity for ping or other command to
@@ -804,6 +806,8 @@ class RunEngineManager(Process):
             # If Run List UID change, download the list of runs for the current plan.
             # Run List UID is updated when the list is cleared as well.
             "run_list_uid": run_list_uid,
+            "plan_queue_uid": plan_queue_uid,
+            "plan_history_uid": plan_history_uid,
             # "worker_state_info": worker_state_info
         }
         return msg
@@ -883,8 +887,15 @@ class RunEngineManager(Process):
         logger.info("Returning current queue and running plan ...")
         plan_queue = await self._plan_queue.get_queue()
         running_item = await self._plan_queue.get_running_item_info()
+        plan_queue_uid = self._plan_queue.plan_queue_uid()
 
-        return {"success": True, "msg": "", "queue": plan_queue, "running_item": running_item}
+        return {
+            "success": True,
+            "msg": "",
+            "queue": plan_queue,
+            "running_item": running_item,
+            "plan_queue_uid": plan_queue_uid,
+        }
 
     def _get_item_from_request(self, *, request):
         item_type = None
@@ -1147,8 +1158,9 @@ class RunEngineManager(Process):
         """
         logger.info("Returning plan history ...")
         plan_history = await self._plan_queue.get_history()
+        plan_history_uid = self._plan_queue.plan_history_uid()
 
-        return {"success": True, "msg": "", "history": plan_history}
+        return {"success": True, "msg": "", "history": plan_history, "plan_history_uid": plan_history_uid}
 
     async def _history_clear_handler(self, request):
         """

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -885,9 +885,9 @@ class RunEngineManager(Process):
         Returns the contents of the current queue.
         """
         logger.info("Returning current queue and running plan ...")
+        plan_queue_uid = self._plan_queue.plan_queue_uid
         plan_queue = await self._plan_queue.get_queue()
         running_item = await self._plan_queue.get_running_item_info()
-        plan_queue_uid = self._plan_queue.plan_queue_uid
 
         return {
             "success": True,
@@ -1157,8 +1157,8 @@ class RunEngineManager(Process):
         Returns the contents of the plan history.
         """
         logger.info("Returning plan history ...")
-        plan_history = await self._plan_queue.get_history()
         plan_history_uid = self._plan_queue.plan_history_uid
+        plan_history = await self._plan_queue.get_history()
 
         return {"success": True, "msg": "", "history": plan_history, "plan_history_uid": plan_history_uid}
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1157,8 +1157,7 @@ class RunEngineManager(Process):
         Returns the contents of the plan history.
         """
         logger.info("Returning plan history ...")
-        plan_history_uid = self._plan_queue.plan_history_uid
-        plan_history = await self._plan_queue.get_history()
+        plan_history, plan_history_uid = await self._plan_queue.get_history()
 
         return {"success": True, "msg": "", "history": plan_history, "plan_history_uid": plan_history_uid}
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -788,8 +788,8 @@ class RunEngineManager(Process):
         worker_environment_exists = self._environment_exists
         re_state = self._worker_state_info["re_state"] if self._worker_state_info else None
         run_list_uid = self._re_run_list_uid
-        plan_queue_uid = self._plan_queue.plan_queue_uid()
-        plan_history_uid = self._plan_queue.plan_history_uid()
+        plan_queue_uid = self._plan_queue.plan_queue_uid
+        plan_history_uid = self._plan_queue.plan_history_uid
         # worker_state_info = self._worker_state_info
 
         # TODO: consider different levels of verbosity for ping or other command to
@@ -887,7 +887,7 @@ class RunEngineManager(Process):
         logger.info("Returning current queue and running plan ...")
         plan_queue = await self._plan_queue.get_queue()
         running_item = await self._plan_queue.get_running_item_info()
-        plan_queue_uid = self._plan_queue.plan_queue_uid()
+        plan_queue_uid = self._plan_queue.plan_queue_uid
 
         return {
             "success": True,
@@ -1158,7 +1158,7 @@ class RunEngineManager(Process):
         """
         logger.info("Returning plan history ...")
         plan_history = await self._plan_queue.get_history()
-        plan_history_uid = self._plan_queue.plan_history_uid()
+        plan_history_uid = self._plan_queue.plan_history_uid
 
         return {"success": True, "msg": "", "history": plan_history, "plan_history_uid": plan_history_uid}
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -885,9 +885,7 @@ class RunEngineManager(Process):
         Returns the contents of the current queue.
         """
         logger.info("Returning current queue and running plan ...")
-        plan_queue_uid = self._plan_queue.plan_queue_uid
-        plan_queue = await self._plan_queue.get_queue()
-        running_item = await self._plan_queue.get_running_item_info()
+        plan_queue, running_item, plan_queue_uid = await self._plan_queue.get_queue_full()
 
         return {
             "success": True,

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -64,7 +64,24 @@ class PlanQueueOperations:
         self._name_plan_queue = "plan_queue"
         self._name_plan_history = "plan_history"
 
+        self._plan_queue_uid = self.new_item_uid()
+        self._plan_history_uid = self.new_item_uid()
+
         self._lock = None
+
+    @property
+    def plan_queue_uid(self):
+        """
+        Get current plan queue UID (str).
+        """
+        return self._plan_queue_uid
+
+    @property
+    def plan_history_uid(self):
+        """
+        Get current plan history UID.
+        """
+        return self._plan_history_uid
 
     async def start(self):
         """

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -877,7 +877,7 @@ class PlanQueueOperations:
         See ``self.get_history()`` method.
         """
         all_plans_json = await self._r_pool.lrange(self._name_plan_history, 0, -1)
-        return [json.loads(_) for _ in all_plans_json]
+        return [json.loads(_) for _ in all_plans_json], self._plan_history_uid
 
     async def get_history(self):
         """
@@ -889,6 +889,8 @@ class PlanQueueOperations:
         list(dict)
             The list of items in the plan history. Each plan is represented as a dictionary.
             Empty list is returned if the queue is empty.
+        str
+            Plan history UID
         """
         async with self._lock:
             return await self._get_history()

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -550,7 +550,7 @@ class PlanQueueOperations:
 
         if (before_uid is not None) and (after_uid is not None):
             raise ValueError(
-                "Ambiguous parameters: request to insert " "the plan before and after the reference plan"
+                "Ambiguous parameters: request to insert the plan before and after the reference plan"
             )
 
         pos = pos if pos is not None else "back"
@@ -920,6 +920,7 @@ class PlanQueueOperations:
         if not await self._is_item_running():
             plan_json = await self._r_pool.lpop(self._name_plan_queue)
             if plan_json:
+                self._plan_queue_uid = self.new_item_uid()
                 plan = json.loads(plan_json)
                 await self._set_running_item_info(plan)
             else:

--- a/bluesky_queueserver/manager/tests/test_fixtures.py
+++ b/bluesky_queueserver/manager/tests/test_fixtures.py
@@ -1,5 +1,3 @@
-import pytest
-
 from bluesky_queueserver.manager.comms import zmq_single_request
 
 from ._common import re_manager_cmd, db_catalog  # noqa: F401
@@ -15,7 +13,6 @@ from ._common import (
 _user, _user_group = "Testing Script", "admin"
 
 
-@pytest.mark.xfail(reason="For some reason the test fails when run on CI, but expected to pass locally")
 def test_fixture_db_catalog(db_catalog):  # noqa F811
     """
     Basic test for the fixture `db_catalog`.
@@ -25,18 +22,16 @@ def test_fixture_db_catalog(db_catalog):  # noqa F811
     #   all the tests in the current session.
     list(db_catalog["catalog"])
 
-    # NOTE: For some reason, the following operations fail when run with GitHub Actions CI
-    #    with "KeyError: 'qserver_tests'"
-
-    # Try to access the catalog in 'standard' way
-    from databroker import catalog
-
-    assert list(catalog[db_catalog["catalog_name"]]) == list(db_catalog["catalog"])
-
     # Try to instantiate the Data Broker
     from databroker import Broker
 
     Broker.named(db_catalog["catalog_name"])
+
+    # Try to access the catalog in 'standard' way
+    from databroker import catalog
+
+    catalog.force_reload()
+    assert list(catalog[db_catalog["catalog_name"]]) == list(db_catalog["catalog"])
 
 
 def test_fixture_re_manager_cmd_1(re_manager_cmd):  # noqa F811

--- a/bluesky_queueserver/manager/tests/test_fixtures.py
+++ b/bluesky_queueserver/manager/tests/test_fixtures.py
@@ -1,3 +1,5 @@
+import pytest
+
 from bluesky_queueserver.manager.comms import zmq_single_request
 
 from ._common import re_manager_cmd, db_catalog  # noqa: F401
@@ -13,6 +15,7 @@ from ._common import (
 _user, _user_group = "Testing Script", "admin"
 
 
+@pytest.mark.xfail(reason="For some reason the test fails when run on CI, but expected to pass locally")
 def test_fixture_db_catalog(db_catalog):  # noqa F811
     """
     Basic test for the fixture `db_catalog`.

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -926,7 +926,8 @@ def test_add_to_history_functions(pq):
         assert pq.plan_history_uid != ph_uid
 
         ph_uid = pq.plan_history_uid
-        plan_history = await pq.get_history()
+        plan_history, plan_history_uid_1 = await pq.get_history()
+        assert pq.plan_history_uid == plan_history_uid_1
         assert pq.plan_history_uid == ph_uid
 
         assert len(plan_history) == 3
@@ -936,7 +937,7 @@ def test_add_to_history_functions(pq):
         await pq.clear_history()
         assert pq.plan_history_uid != ph_uid
 
-        plan_history = await pq.get_history()
+        plan_history, _ = await pq.get_history()
         assert plan_history == []
 
     asyncio.run(testing())
@@ -1022,7 +1023,7 @@ def test_set_processed_item_as_completed(pq):
         assert plan["result"]["exit_status"] == "completed"
         assert plan["result"]["run_uids"] == plans_run_uids[0]
 
-        plan_history = await pq.get_history()
+        plan_history, _ = await pq.get_history()
         plan_history_expected = add_status_to_plans(plans[0:1], plans_run_uids[0:1], "completed")
         assert plan_history == plan_history_expected
 
@@ -1036,7 +1037,7 @@ def test_set_processed_item_as_completed(pq):
         assert plan["result"]["exit_status"] == "completed"
         assert plan["result"]["run_uids"] == plans_run_uids[1]
 
-        plan_history = await pq.get_history()
+        plan_history, _ = await pq.get_history()
         plan_history_expected = add_status_to_plans(plans[0:2], plans_run_uids[0:2], "completed")
         assert plan_history == plan_history_expected
 
@@ -1089,7 +1090,7 @@ def test_set_processed_item_as_stopped(pq):
         assert plan["result"]["exit_status"] == "stopped"
         assert plan["result"]["run_uids"] == plans_run_uids[0]
 
-        plan_history = await pq.get_history()
+        plan_history, _ = await pq.get_history()
         plan_history_expected = add_status_to_plans([plans[0]], [plans_run_uids[0]], "stopped")
         assert plan_history == plan_history_expected
 
@@ -1103,7 +1104,7 @@ def test_set_processed_item_as_stopped(pq):
         assert plan["result"]["exit_status"] == "stopped"
         assert plan["result"]["run_uids"] == plans_run_uids[1]
 
-        plan_history = await pq.get_history()
+        plan_history, _ = await pq.get_history()
         plan_history_expected = add_status_to_plans(
             [plans[0].copy(), plans[0].copy()], [plans_run_uids[0], plans_run_uids[1]], "stopped"
         )

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1376,9 +1376,9 @@ class UidChecker:
 
 def test_zmq_api_queue_execution_2(re_manager):  # noqa: F811
     """
-    Execution of a queue that contains an instruction ('queue_stop').
+    Test if status fields ``plan_queue_uid`` and ``plan_history_uid`` are properly changed
+    during execution of common queue operations.
     """
-
     uid_checker = UidChecker()
 
     # Plan

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -168,6 +168,14 @@ Returns       **msg**: *str*
               **running_item_uid**: *str* or *None*
                  item UID of the currently running plan or *None* if no plan is currently running.
 
+              **plan_queue_uid**: *str*
+                 plan queue UID, which is updated each time the contents of the queue is changed.
+                 Monitor this parameter to determine when the queue data should be downloaded.
+
+              **plan_history_uid**: *str*
+                 plan history UID, which is updated each time the contents of the history is changed.
+                 Monitor this parameter to determine when the history data should be downloaded.
+
               **manager_state**: *str*
                   state of RE Manager. Supported states:
 
@@ -308,6 +316,9 @@ Returns       **success**: *boolean*
               **history**: *list*
                   list of items in the plan history, each item is represented by a dictionary of
                   item parameters. Currently the plan history may contain only plans.
+
+              **plan_history_uid**: *str*
+                  current plan history UID.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================
@@ -454,6 +465,9 @@ Returns       **success**: *boolean*
               **running_item**: *dict*
                   parameters of the item representing currently running plan, empty dictionary ({}) is
                   returned if no plan is currently running.
+
+              **plan_queue_uid**: *str*
+                  current plan queue UID.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================


### PR DESCRIPTION
Extension of functionality of RE Manager includes two new status fields returned by `status` request:

- `plan_queue_uid` - plan queue UID, which is changed each time plan queue is updated.
- `plan_history_uid` - plan history UID, which is changed each time plan queue is updated. 

Current value of `plan_queue_uid` is also returned as part of response to `queue_get` request and current value of `plan_history_uid` is returned as part of response to `history_get` request. The status fields may be used to detect changes in the queue and history by periodically requesting RE Manager status and download data from the server only when the queue or the history changes. This may allow to prevent unnecessary downloads and reduce network traffic. The changes are reflected in documentation for `status`, `queue_get` and `history_get` 0MQ API.