### PR TITLE
0MQ API for adding a batch of items to the back of the queue ('queue_item_add_batch')

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1084,6 +1084,7 @@ class RunEngineManager(Process):
 
             user, user_group = self._get_user_info_from_request(request=request)
 
+            # First validate all the items
             for item_info in items:
                 item, item_type = {}, None
                 try:
@@ -1102,10 +1103,11 @@ class RunEngineManager(Process):
                     # If 'item_info' does not contain valid item, then do not return any item.
                     if item and item_type:
                         item["item_type"] = item_type
-                    items_prepared.append(item)
+                    items_prepared.append(item)  # Always add item even if it is '{}'
                     report.append({"success": False, "msg": f"Failed to add a plan: {ex}"})
 
             if len(report) != len(items) != len(items_prepared):
+                # This error should never happen, but it may be useful for debugging.
                 raise Exception("Error in data processing algorithm occurred")
 
             if success:
@@ -1134,12 +1136,11 @@ class RunEngineManager(Process):
 
         try:
             qsize = await self._plan_queue.get_queue_size()
-        except Exception as ex:
+        except Exception:
             qsize = None
 
-        rdict = {"success": success, "msg": msg, "qsize": qsize}
-        if result:
-            rdict["result"] = result
+        # Note, that 'result' may be an empty list []
+        rdict = {"success": success, "msg": msg, "qsize": qsize, "result": result}
 
         return rdict
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1073,7 +1073,7 @@ class RunEngineManager(Process):
         logger.info("Adding a batch of items to the queue ...")
         logger.debug("Request: %s", pprint.pformat(request))
 
-        success, msg, result, qsize = True, "", [], None
+        success, msg, item_list, qsize = True, "", [], None
 
         try:
             # Prepare items
@@ -1123,7 +1123,7 @@ class RunEngineManager(Process):
                 d = rep.copy()
                 if "item_type" in item:
                     d[item["item_type"]] = item
-                result.append(d)
+                item_list.append(d)
 
             if not success:
                 n_items = len(report)
@@ -1139,8 +1139,8 @@ class RunEngineManager(Process):
         except Exception:
             qsize = None
 
-        # Note, that 'result' may be an empty list []
-        rdict = {"success": success, "msg": msg, "qsize": qsize, "result": result}
+        # Note, that 'item_list' may be an empty list []
+        rdict = {"success": success, "msg": msg, "qsize": qsize, "item_list": item_list}
 
         return rdict
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1048,6 +1048,101 @@ class RunEngineManager(Process):
 
         return rdict
 
+    async def _queue_item_add_batch_handler(self, request):
+        """
+        Adds a batch of items to the end of the queue. The request is expected to contain the following
+        elements: ``user`` and ``user_group`` have the same meaning as for ``queue_item_add`` request;
+        ``items`` contains a list of items, each item is a dictionary that contains a key corresponding
+        to one of currently supported types (``plan`` or ``instruction``) with the value representing
+        properly formatted item parameters (dictionary with ``name`` (required), ``args``, ``kwargs``
+        and ``meta`` keys).
+
+        The function is validating all items in the batch and adds the batch to the queue only if
+        all items were validated successfully. Otherwise, the function returns ``success=False``
+        and ``msg`` contains error message. The function also returns the list of items. For each
+        item, ``success`` indicates if the item was validated successfully and ``msg`` contains
+        error message showing the reason of validation failure for the item. The elements ``plan``
+        or ``instruction`` contain item parameters that were extracted from the submitted item (if any).
+        If items are inserted in the queue, the item parameters will also contain ``item_uid`` of
+        the items.
+
+        If 'global' value ``success`` is ``True`` for the message, then ``success`` values for all items
+        are ``True`` and the items are inserted in the queue. There is no need to verify ``success``
+        status of each item if 'global' ``success`` is ``True``.
+        """
+        logger.info("Adding a batch of items to the queue ...")
+        logger.debug("Request: %s", pprint.pformat(request))
+
+        success, msg, result, qsize = True, "", [], None
+
+        try:
+            # Prepare items
+            if "items" not in request:
+                raise Exception("Invalid request format: the list of items is not found")
+            items = request["items"]
+            items_prepared, items_added, report, success = [], [], [], True
+
+            user, user_group = self._get_user_info_from_request(request=request)
+
+            for item_info in items:
+                item, item_type = {}, None
+                try:
+                    item, item_type = self._get_item_from_request(request=item_info)
+
+                    # Always generate a new UID for the added plan!!!
+                    item_prepared, _ = self._prepare_item(
+                        item=item, item_type=item_type, user=user, user_group=user_group, generate_new_uid=True
+                    )
+
+                    items_prepared.append(item_prepared)
+                    report.append({"success": True, "msg": ""})
+
+                except Exception as ex:
+                    success = False
+                    # If 'item_info' does not contain valid item, then do not return any item.
+                    if item and item_type:
+                        item["item_type"] = item_type
+                    items_prepared.append(item)
+                    report.append({"success": False, "msg": f"Failed to add a plan: {ex}"})
+
+            if len(report) != len(items) != len(items_prepared):
+                raise Exception("Error in data processing algorithm occurred")
+
+            if success:
+                # Adding plan to queue may still raise an exception
+                for item in items_prepared:
+                    item_added, _ = await self._plan_queue.add_item_to_queue(item)
+                    items_added.append(item_added)
+            else:
+                items_added = items_prepared
+
+            # Prepare the list of added items with error messages
+            for item, rep in zip(items_added, report):
+                d = rep.copy()
+                if "item_type" in item:
+                    d[item["item_type"]] = item
+                result.append(d)
+
+            if not success:
+                n_items = len(report)
+                n_failed = sum([not _["success"] for _ in report])
+                msg = f"Failed to add all items: validation of {n_failed} out of {n_items} submitted items failed"
+
+        except Exception as ex:
+            success = False
+            msg = f"Failed to add an item: {str(ex)}"
+
+        try:
+            qsize = await self._plan_queue.get_queue_size()
+        except Exception as ex:
+            qsize = None
+
+        rdict = {"success": success, "msg": msg, "qsize": qsize}
+        if result:
+            rdict["result"] = result
+
+        return rdict
+
     async def _queue_item_update_handler(self, request):
         """
         Updates the existing item in the queue. Item may be a plan or an instruction. The request
@@ -1379,6 +1474,7 @@ class RunEngineManager(Process):
             "environment_close": "_environment_close_handler",
             "environment_destroy": "_environment_destroy_handler",
             "queue_item_add": "_queue_item_add_handler",
+            "queue_item_add_batch": "_queue_item_add_batch_handler",
             "queue_item_update": "_queue_item_update_handler",
             "queue_item_get": "_queue_item_get_handler",
             "queue_item_remove": "_queue_item_remove_handler",

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1051,20 +1051,22 @@ class RunEngineManager(Process):
     async def _queue_item_add_batch_handler(self, request):
         """
         Adds a batch of items to the end of the queue. The request is expected to contain the following
-        elements: ``user`` and ``user_group`` have the same meaning as for ``queue_item_add`` request;
-        ``items`` contains a list of items, each item is a dictionary that contains a key corresponding
-        to one of currently supported types (``plan`` or ``instruction``) with the value representing
-        properly formatted item parameters (dictionary with ``name`` (required), ``args``, ``kwargs``
-        and ``meta`` keys).
+        elements: ``user`` and ``user_group`` (have the same meaning as for ``queue_item_add`` request);
+        ``items`` contains a list of items, each item is a dictionary that contains an element with
+        the key corresponding to one of currently supported types (``plan`` or ``instruction``) and
+        the value representing properly formatted item parameters (dictionary with ``name`` (required),
+        ``args``, ``kwargs`` and ``meta`` keys).
 
         The function is validating all items in the batch and adds the batch to the queue only if
         all items were validated successfully. Otherwise, the function returns ``success=False``
-        and ``msg`` contains error message. The function also returns the list of items. For each
-        item, ``success`` indicates if the item was validated successfully and ``msg`` contains
+        and ``msg`` contains error message. The function also returns the list of items (``item_list``).
+        For each item, ``success`` indicates if the item was validated successfully and ``msg`` contains
         error message showing the reason of validation failure for the item. The elements ``plan``
         or ``instruction`` contain item parameters that were extracted from the submitted item (if any).
         If items are inserted in the queue, the item parameters will also contain ``item_uid`` of
-        the items.
+        the items. The returned item list may be empty if no items were submitted (still considered
+        successful operation) or input parameters are invalid and the request could not be processed
+        (operation failed).
 
         If 'global' value ``success`` is ``True`` for the message, then ``success`` values for all items
         are ``True`` and the items are inserted in the queue. There is no need to verify ``success``

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -464,6 +464,134 @@ def test_zmq_api_queue_item_add_6(re_manager):  # noqa: F811
     assert resp2["queue"][2]["item_type"] == "plan"
 
 
+def test_zmq_api_queue_item_add_batch_1(re_manager):  # noqa: F811
+    """
+    Basic test for ``queue_item_add_batch`` API.
+    """
+    items = [{"plan": _plan1}, {"plan": _plan2}, {"instruction": _instruction_stop}, {"plan": _plan3}]
+
+    params = {"items": items, "user": _user, "user_group": _user_group}
+    resp1a, _ = zmq_single_request("queue_item_add_batch", params)
+    assert resp1a["success"] is True, f"resp={resp1a}"
+    assert resp1a["msg"] == ""
+    assert resp1a["qsize"] == 4
+    result = resp1a["result"]
+    assert len(result) == len(items)
+
+    for item, item_res in zip(items, result):
+        assert item_res["success"] is True, str(item)
+        assert item_res["msg"] == "", str(item)
+
+        if "instruction" in item:
+            key, name = "instruction", "action"
+        elif "plan" in item:
+            key, name = "plan", "name"
+        else:
+            assert False, f"Unsupported item {item}"
+
+        assert key in item_res, str(item_res)
+        assert name in item_res[key], str(item_res)
+        assert item_res[key][name] == item[key][name]
+        assert isinstance(item_res[key]["item_uid"], str)
+        assert item_res[key]["item_uid"]
+
+        if key == "plan":
+            if "args" in item[key]:
+                assert item_res[key]["args"] == item[key]["args"]
+            else:
+                assert item_res[key]["args"] == []
+            if "kwargs" in item[key]:
+                assert item_res[key]["kwargs"] == item[key]["kwargs"]
+        else:
+            assert item_res[key]["action"] == item[key]["action"]
+
+    state = get_queue_state()
+    assert state["items_in_queue"] == 4
+    assert state["items_in_history"] == 0
+
+    resp2, _ = zmq_single_request("environment_open")
+    assert resp2["success"] is True
+    assert wait_for_condition(time=3, condition=condition_environment_created)
+
+    resp3, _ = zmq_single_request("queue_start")
+    assert resp3["success"] is True
+    assert wait_for_condition(time=30, condition=condition_manager_idle)
+
+    state = get_queue_state()
+    assert state["items_in_queue"] == 1
+    assert state["items_in_history"] == 2
+
+    resp4, _ = zmq_single_request("queue_start")
+    assert resp4["success"] is True
+    assert wait_for_condition(time=10, condition=condition_queue_processing_finished)
+
+    state = get_queue_state()
+    assert state["items_in_queue"] == 0
+    assert state["items_in_history"] == 3
+
+    resp5, _ = zmq_single_request("environment_close")
+    assert resp5["success"] is True
+    assert wait_for_condition(time=5, condition=condition_manager_idle)
+
+
+def test_zmq_api_queue_item_add_batch_2(re_manager):  # noqa: F811
+    """
+    Basic test for ``queue_item_add_batch`` API.
+    """
+    _plan2_corrupt = _plan2.copy()
+    _plan2_corrupt["name"] = "nonexisting_name"
+    items = [{"plan": _plan1}, {"plan": _plan2_corrupt}, {"instruction": _instruction_stop}, {}, {"plan": _plan3}]
+    success_expected = [True, False, True, False, True]
+    msg_expected = ["", "is not in the list of allowed plans", "", "request contains no item info", ""]
+
+    params = {"items": items, "user": _user, "user_group": _user_group}
+    resp1a, _ = zmq_single_request("queue_item_add_batch", params)
+    assert resp1a["success"] is False, f"resp={resp1a}"
+    assert resp1a["msg"] == "Failed to add all items: validation of 2 out of 5 submitted items failed"
+    result = resp1a["result"]
+    assert len(result) == len(items)
+
+    for n, item in enumerate(items):
+        item_res = result[n]
+        scs = success_expected[n]
+        msg = msg_expected[n]
+        assert item_res["success"] == scs, str(item)
+        if not msg:
+            assert item_res["msg"] == "", str(item)
+        else:
+            assert msg in item_res["msg"], str(item)
+
+        key = ""
+        if "instruction" in item:
+            key, name = "instruction", "action"
+        elif "plan" in item:
+            key, name = "plan", "name"
+
+        if key:
+            assert key in item_res, str(item_res)
+            assert name in item_res[key], str(item_res)
+            assert item_res[key][name] == item[key][name]
+            if scs:
+                assert isinstance(item_res[key]["item_uid"], str)
+                assert item_res[key]["item_uid"]
+            else:
+                assert "item_uid" not in item_res[key]
+
+            if key == "plan":
+                if "args" in item[key]:
+                    assert item_res[key]["args"] == item[key]["args"]
+                else:
+                    assert item_res[key]["args"] == []
+                if "kwargs" in item[key]:
+                    assert item_res[key]["kwargs"] == item[key]["kwargs"]
+            else:
+                assert item_res[key]["action"] == item[key]["action"]
+
+    state = get_queue_state()
+    assert state["items_in_queue"] == 0
+    assert state["items_in_history"] == 0
+
+
 # fmt: off
 @pytest.mark.parametrize("meta_param, meta_saved", [
     # 'meta' is dictionary, all keys are saved

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -198,6 +198,80 @@ async def queue_item_add_handler(payload: dict):
     return msg
 
 
+@app.post("/queue/upload/spreadsheet")
+async def queue_upload_spreadsheet(spreadsheet: UploadFile = File(...), data_type: Optional[str] = Form(None)):
+
+    """
+    The endpoint receives uploaded spreadsheet, converts it to the list of plans and adds
+    the plans to the queue.
+
+    Parameters
+    ----------
+    spreadsheet : File
+        uploaded excel file
+    data_type : str
+        user defined spreadsheet type, which determines which processing function is used to
+        process the spreadsheet.
+
+    Returns
+    -------
+    success : boolean
+        Indicates if the spreadsheet was successfully converted to a sequence of plans.
+        ``True`` value does not indicate that the plans were accepted by the RE Manager and
+        successfully added to the queue.
+    msg : str
+        Error message in case of failure to process the spreadsheet
+    result : list(dict)
+        The list of parameter dictionaries returned by RE Manager in response to requests
+        to add each plan in the list. Check ``success`` parameter in each dictionary to
+        see if the plan was accepted and ``msg`` parameter for an error message in case
+        the plan was rejected.
+    """
+    try:
+        # Create fully functional file object. The file object returned by FastAPI is not fully functional.
+        f = io.BytesIO(spreadsheet.file.read())
+        # File name is also passed to the processing function (may be useful in user created
+        #   processing code, since processing may differ based on extension or file name)
+        f_name = spreadsheet.filename
+
+        # Determine which processing function should be used
+        plan_list = []
+        processed = False
+        if custom_code_module and ("spreadsheet_to_plan_list" in custom_code_module.__dict__):
+            logger.info("Processing spreadsheet using function from external module ...")
+            # Try applying  the custom processing function. Some additional useful data is passed to
+            #   the function. Unnecessary parameters can be ignored.
+            plan_list = custom_code_module.spreadsheet_to_plan_list(
+                spreadsheet_file=f, file_name=f_name, data_type=data_type, user=_login_data["user"]
+            )
+            # The function is expected to return None if it rejects the file (based on 'data_type').
+            #   Then try to apply the default processing function.
+            processed = plan_list is not None
+
+        if not processed:
+            # Apply default spreadsheet processing function.
+            logger.info("Processing spreadsheet using default function ...")
+            plan_list = spreadsheet_to_plan_list(
+                spreadsheet_file=f, file_name=f_name, data_type=data_type, user=_login_data["user"]
+            )
+
+        if plan_list is None:
+            raise RuntimeError("Failed to process the spreadsheet: unsupported data type or format")
+
+        logger.debug("The following plans were created: %s", pprint.pformat(plan_list))
+
+        params = dict()
+        params["user"] = _login_data["user"]
+        params["user_group"] = _login_data["user_group"]
+        params["items"] = [{"plan": _} for _ in plan_list]
+        msg = await zmq_to_manager.send_message(method="queue_item_add_batch", params=params)
+
+    except Exception as ex:
+        msg = {"success": False, "msg": str(ex), "result": []}
+
+    return msg
+
+
 @app.post("/queue/item/update")
 async def queue_item_update_handler(payload: dict):
     """
@@ -427,77 +501,3 @@ async def test_manager_kill_handler():
 def spreadsheet_to_plan_list(*, spreadsheet_file, file_name, data_type, **kwargs):  # noqa: F821
     # TODO: write implementation of default function for processing of 'universal' spreadsheets
     raise NotImplementedError("Default function for converting spreadsheet to plan list is not implemented yet")
-
-
-@app.post("/queue/upload/spreadsheet")
-async def queue_upload_spreadsheet(spreadsheet: UploadFile = File(...), data_type: Optional[str] = Form(None)):
-
-    """
-    The endpoint receives uploaded spreadsheet, converts it to the list of plans and adds
-    the plans to the queue.
-
-    Parameters
-    ----------
-    spreadsheet : File
-        uploaded excel file
-    data_type : str
-        user defined spreadsheet type, which determines which processing function is used to
-        process the spreadsheet.
-
-    Returns
-    -------
-    success : boolean
-        Indicates if the spreadsheet was successfully converted to a sequence of plans.
-        ``True`` value does not indicate that the plans were accepted by the RE Manager and
-        successfully added to the queue.
-    msg : str
-        Error message in case of failure to process the spreadsheet
-    result : list(dict)
-        The list of parameter dictionaries returned by RE Manager in response to requests
-        to add each plan in the list. Check ``success`` parameter in each dictionary to
-        see if the plan was accepted and ``msg`` parameter for an error message in case
-        the plan was rejected.
-    """
-    try:
-        # Create fully functional file object. The file object returned by FastAPI is not fully functional.
-        f = io.BytesIO(spreadsheet.file.read())
-        # File name is also passed to the processing function (may be useful in user created
-        #   processing code, since processing may differ based on extension or file name)
-        f_name = spreadsheet.filename
-
-        # Determine which processing function should be used
-        plan_list = []
-        processed = False
-        if custom_code_module and ("spreadsheet_to_plan_list" in custom_code_module.__dict__):
-            logger.info("Processing spreadsheet using function from external module ...")
-            # Try applying  the custom processing function. Some additional useful data is passed to
-            #   the function. Unnecessary parameters can be ignored.
-            plan_list = custom_code_module.spreadsheet_to_plan_list(
-                spreadsheet_file=f, file_name=f_name, data_type=data_type, user=_login_data["user"]
-            )
-            # The function is expected to return None if it rejects the file (based on 'data_type').
-            #   Then try to apply the default processing function.
-            processed = plan_list is not None
-
-        if not processed:
-            # Apply default spreadsheet processing function.
-            logger.info("Processing spreadsheet using default function ...")
-            plan_list = spreadsheet_to_plan_list(
-                spreadsheet_file=f, file_name=f_name, data_type=data_type, user=_login_data["user"]
-            )
-
-        if plan_list is None:
-            raise RuntimeError("Failed to process the spreadsheet: unsupported data type or format")
-
-        logger.debug("The following plans were created: %s", pprint.pformat(plan_list))
-
-        params = dict()
-        params["user"] = _login_data["user"]
-        params["user_group"] = _login_data["user_group"]
-        params["items"] = [{"plan": _} for _ in plan_list]
-        msg = await zmq_to_manager.send_message(method="queue_item_add_batch", params=params)
-
-    except Exception as ex:
-        msg = {"success": False, "msg": str(ex), "result": []}
-
-    return msg

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -221,11 +221,12 @@ async def queue_upload_spreadsheet(spreadsheet: UploadFile = File(...), data_typ
         successfully added to the queue.
     msg : str
         Error message in case of failure to process the spreadsheet
-    result : list(dict)
+    item_list : list(dict)
         The list of parameter dictionaries returned by RE Manager in response to requests
         to add each plan in the list. Check ``success`` parameter in each dictionary to
         see if the plan was accepted and ``msg`` parameter for an error message in case
-        the plan was rejected.
+        the plan was rejected. The list may be empty if the spreadsheet contains no items
+        or processing of the spreadsheet failed.
     """
     try:
         # Create fully functional file object. The file object returned by FastAPI is not fully functional.
@@ -267,7 +268,7 @@ async def queue_upload_spreadsheet(spreadsheet: UploadFile = File(...), data_typ
         msg = await zmq_to_manager.send_message(method="queue_item_add_batch", params=params)
 
     except Exception as ex:
-        msg = {"success": False, "msg": str(ex), "result": []}
+        msg = {"success": False, "msg": str(ex), "item_list": []}
 
     return msg
 

--- a/bluesky_queueserver/server/tests/test_http_server_func_scope.py
+++ b/bluesky_queueserver/server/tests/test_http_server_func_scope.py
@@ -126,6 +126,7 @@ def test_http_server_queue_upload_spreasheet_2(re_manager, fastapi_server_fs, tm
     resp1 = request_to_json("post", "/queue/upload/spreadsheet", files=files, data=data)
     assert resp1["success"] is False, str(resp1)
     assert resp1["msg"] == "Unsupported data type: 'unsupported'"
+    assert resp1["item_list"] == []
 
 
 def test_http_server_queue_upload_spreasheet_3(re_manager, fastapi_server_fs, tmp_path, monkeypatch):  # noqa F811
@@ -213,7 +214,7 @@ def test_http_server_queue_upload_spreasheet_5(re_manager, fastapi_server_fs, tm
     assert resp1["success"] is False, str(resp1)
     assert resp1["msg"] == "Failed to add all items: validation of 1 out of 3 submitted items failed"
 
-    result = resp1["result"]
+    result = resp1["item_list"]
     assert len(result) == len(plans_expected), str(result)
     for p, p_exp in zip(result, plans_expected):
         for k, v in p_exp.items():

--- a/bluesky_queueserver/server/tests/test_http_server_func_scope.py
+++ b/bluesky_queueserver/server/tests/test_http_server_func_scope.py
@@ -211,7 +211,7 @@ def test_http_server_queue_upload_spreasheet_5(re_manager, fastapi_server_fs, tm
     files = {"spreadsheet": open(ss_path, "rb")}
     resp1 = request_to_json("post", "/queue/upload/spreadsheet", files=files)
     assert resp1["success"] is False, str(resp1)
-    assert resp1["msg"] == "The batch of plans is rejected by RE Manager"
+    assert resp1["msg"] == "Failed to add all items: validation of 1 out of 3 submitted items failed"
 
     result = resp1["result"]
     assert len(result) == len(plans_expected), str(result)
@@ -224,3 +224,8 @@ def test_http_server_queue_upload_spreasheet_5(re_manager, fastapi_server_fs, tm
                 assert p["success"] is True
                 assert k in p["plan"]
                 assert v == p["plan"][k]
+
+    # No plans are expected to be added to the queue
+    resp2 = request_to_json("get", "/status")
+    assert resp2["items_in_queue"] == 0
+    assert resp2["items_in_history"] == 0

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -90,6 +90,7 @@ Operations with the plan queue:
 
 - :ref:`method_queue_get`
 - :ref:`method_queue_item_add`
+- :ref:`method_queue_item_add_batch`
 - :ref:`method_queue_item_update`
 - :ref:`method_queue_item_get`
 - :ref:`method_queue_item_remove`
@@ -518,9 +519,70 @@ Returns       **success**: *boolean*
                   the number of items in the plan queue after the plan was added if
                   the operation was successful, *None* otherwise
 
-              **plan** or **instruction**: *dict*, optional
+              **plan** or **instruction**: *dict* (optional)
                   the inserted item. The item contains the assigned item UID. The parameter
                   may not be returned in case of error in processing the request.
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
+============  =========================================================================================
+
+
+.. _method_queue_item_add_batch:
+
+**'queue_item_add_batch'**
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'queue_item_add_batch'**
+------------  -----------------------------------------------------------------------------------------
+Description   Add a batch of items to the back of the queue. The batch may consist of any number
+              of supported items (see **queue_item_add** method). The batch is treated as a single
+              unit. Each item in the queue must successfully pass validation before any items are added
+              to the queue. If any item fails validation, the whole batch is rejected. In case the
+              batch is rejected, the function returns the detailed report for each item, including
+              *success* status indicating if the item passed validation and error message in case
+              validation failed.
+------------  -----------------------------------------------------------------------------------------
+Parameters    **items**: *list*
+                  the list containing a batch of items. Each element is a dictionary representing
+                  a valid item. The dictionary must contain a key-value pair with the key representing
+                  one of the supported item types (*'plan'* or *'instruction'*) and the value being
+                  a dictionary of item parameters. An empty item list will also be accepted.
+
+              **user_group**: *str*
+                  the name of the user group (e.g. 'admin').
+
+              **user**: *str*
+                  the name of the user (e.g. 'John Doe'). The name is included in the item metadata
+                  and may be used to identify the user who added the item to the queue. It is not
+                  passed to the Run Engine or included in run metadata.
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully. The request fails if any item
+                  fails validation. The queue is not expected to be modified if the request fails.
+                  If the parameter is *True*, then validation of all items succeeded: there is no
+                  need to verify *success* status for each item returned in *item_list* parameter.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+
+              **qsize**: *int* or *None*
+                  the number of items in the plan queue after processing of the request. The correct
+                  queue size may be returned even if the operation fails. In rare failing cases
+                  the parameter may return *None*.
+
+              **item_list** : *list*
+                  the list of processed items inserted item. Each item represents the dictionary
+                  with the following keys:
+
+                - **success** - boolean value indicating if the validation of the item was successful.
+
+                - **msg** - error message in case validation of the item failed.
+
+                - **plan** or **instruction** (optional) - item parameters in the same form as
+                  in **queue_item_add** method. If the batch was added to the queue, the parameters for
+                  each item will contain the assigned *'item_uid'*. The item parameters may be missing
+                  if there is an error in processing of the item.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================
@@ -571,7 +633,7 @@ Returns       **success**: *boolean*
                   the number of items in the plan queue after the plan was added if
                   the operation was successful, *None* otherwise
 
-              **plan** or **instruction**: *dict*, optional
+              **plan** or **instruction**: *dict* (optional)
                   the updated item. The item contains the new item UID if the method was called with
                   'replace=True'. The parameter may not be returned in case of error in processing
                   the request.


### PR DESCRIPTION
Implementation of `queue_item_add_batch` 0MQ API. Each item in the batch is validated and the the batch is added to the queue only if each item successfully passes validation. The returned item list contains `success` status for and error message for each item. The returned information is sufficient for generating detailed reports that could be displayed to the user.

The handler for `/queue/upload/spreadsheet` is modified to use `queue_item_add_batch`. The return parameter `result` was renamed to `item_list` (I don't think the parameter was used in any code yet).

The API documentation is added to 0MQ API section.

The PR addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/139