### PR TITLE
Implementation for a default spreadsheet processing function

### DIFF
--- a/bluesky_queueserver/server/conversions.py
+++ b/bluesky_queueserver/server/conversions.py
@@ -273,7 +273,7 @@ def spreadsheet_to_plan_list(*, spreadsheet_file, file_name, **kwargs):  # noqa:
                 plan["args"] = plan_args
             if plan_kwargs:
                 plan["kwargs"] = plan_kwargs
-            plan_list.append({"plan": plan})
+            plan_list.append(plan)
 
         except Exception as ex:
             logger.exception(f"{ex}")

--- a/bluesky_queueserver/server/conversions.py
+++ b/bluesky_queueserver/server/conversions.py
@@ -142,3 +142,8 @@ def filter_plan_descriptions(plans_source):
         plans_filtered.update({p_name: plan})
 
     return plans_filtered
+
+
+def spreadsheet_to_plan_list(*, spreadsheet_file, file_name, data_type, **kwargs):  # noqa: F821
+    # TODO: write implementation of default function for processing of 'universal' spreadsheets
+    raise NotImplementedError("Default function for converting spreadsheet to plan list is not implemented yet")

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, HTTPException, File, UploadFile, Form
 from typing import Optional
 
 from ..manager.comms import ZMQCommSendAsync
-from .conversions import filter_plan_descriptions
+from .conversions import filter_plan_descriptions, spreadsheet_to_plan_list
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -497,8 +497,3 @@ async def test_manager_kill_handler():
     """
     msg = await zmq_to_manager.send_message(method="manager_kill")
     return msg
-
-
-def spreadsheet_to_plan_list(*, spreadsheet_file, file_name, data_type, **kwargs):  # noqa: F821
-    # TODO: write implementation of default function for processing of 'universal' spreadsheets
-    raise NotImplementedError("Default function for converting spreadsheet to plan list is not implemented yet")

--- a/bluesky_queueserver/server/tests/_common.py
+++ b/bluesky_queueserver/server/tests/_common.py
@@ -1,0 +1,131 @@
+import math
+import numpy as np
+import os
+import pandas as pd
+
+
+def create_excel_file_from_plan_list(tmp_path, *, plan_list, ss_filename="spreadsheet", ss_ext=".xlsx"):
+    """
+    Create test spreadsheet file in temporary directory. Return full path to the spreadsheet
+    and the expected list of plans with parameters. Supporting '.xlsx' and '.csv' extensions.
+    The idea was to also write tests for '.xls' file support, but Pandas writer does not seem to
+    support writing ".xls" files.
+
+    Parameters
+    ----------
+    tmp_path : str
+        temporary path
+    plan_list : list(dict)
+        list of plan parameters
+    ss_filename : str
+        spreadsheet file name without extension
+    ss_ext : str
+        spreadsheet extension ('.xlsx' and '.csv' extensions are supported)
+
+    Returns
+    -------
+    str
+        full path to spreadsheet file
+    """
+    # Create sample Excel file
+    ss_filename = ss_filename + ss_ext
+    ss_path = os.path.join(tmp_path, ss_filename)
+
+    def format_cell(val):
+        if isinstance(val, (np.integer, int)):
+            return int(val)
+        elif isinstance(val, (np.floating, float)):
+            return float(val)
+        elif isinstance(val, str):
+            return f"'{val}'"
+        else:
+            return str(val)
+
+    plan_params = []
+    kwarg_names = []
+    for plan in plan_list:
+        pp = [format_cell(plan["name"])]
+        if "args" in plan:
+            pp.append(format_cell(plan["args"]))
+        else:
+            pp.append(math.nan)
+        if "kwargs" in plan:
+            plan_kwargs = plan["kwargs"].copy()
+            for kw in kwarg_names:
+                if kw in plan_kwargs:
+                    pp.append(format_cell(plan_kwargs[kw]))
+                    del plan_kwargs[kw]
+                else:
+                    pp.append(math.nan)
+            for kw in plan_kwargs.keys():
+                kwarg_names.append(kw)
+                pp.append(format_cell(plan_kwargs[kw]))
+        plan_params.append(pp)
+
+    # Make all parameter lists equal length
+    max_params = max([len(_) for _ in plan_params])
+    for pp in plan_params:
+        for _ in range(len(pp), max_params):
+            pp.append(math.nan)
+
+    col_names = ["plan_name", "args"] + kwarg_names
+
+    def create_excel(ss_path, plan_params, col_names):
+        df = pd.DataFrame(plan_params)
+        df = df.set_axis(col_names, axis=1)
+
+        _, ext = os.path.splitext(ss_path)
+        if ext == ".xlsx":
+            df.to_excel(ss_path, index=False, engine="openpyxl")
+        elif ext == ".csv":
+            df.to_csv(ss_path, index=False)
+        return df
+
+    def str_to_number(v):
+        v = float(v)
+        if int(v) == v:
+            v = int(v)
+        return v
+
+    def fix_dataframe_types(df):
+        """
+        Fix types in dataframes loaded from .csv files: if any element in a column is 'str',
+        the whole column is interpreted as 'str'. Convert strings that are numbers to 'int' and 'float' types.
+        Correct types are important here to compare saved and restored dataframes.
+        """
+        # If any number in the column has type string, then the whole column is a string
+        for key in df.keys():
+            for n in range(len(df[key])):
+                try:
+                    df[key][n] = str_to_number(df[key][n])
+                except Exception:
+                    pass
+        return df
+
+    def verify_excel(ss_path, df):
+        _, ext = os.path.splitext(ss_path)
+        if ext == ".xlsx":
+            df_read = pd.read_excel(ss_path, engine="openpyxl")
+        elif ext == ".csv":
+            df_read = pd.read_csv(ss_path)
+            df_read = fix_dataframe_types(df_read)
+        assert df_read.equals(df), str(df_read)
+
+    df = create_excel(ss_path, plan_params, col_names)
+    verify_excel(ss_path, df)
+
+    return ss_path
+
+
+# Sample list that contains working plans. May be used to create a spreadsheet.
+# Plan with '"name": math.nan' will generate an empty line in the spreadsheet.
+plan_list_sample = [
+    {"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 10}},
+    {"name": "count", "args": [["det1"]], "kwargs": {"delay": 0.5}},
+    {"name": "count", "kwargs": {"detectors": ["det1"], "delay": 0.5}},
+    {"name": math.nan},
+    {"name": "scan", "args": [["det1", "det2"], "motor", -1, 1], "kwargs": {"num": 10}},
+    {"name": "scan", "args": [["det1", "det2"], "motor", -1, 1, 10]},
+    {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "delay": 0.7}},
+    {"name": "count", "args": [["det2"]], "kwargs": {"num": 2}},
+]

--- a/bluesky_queueserver/server/tests/_common.py
+++ b/bluesky_queueserver/server/tests/_common.py
@@ -45,9 +45,21 @@ def create_excel_file_from_plan_list(tmp_path, *, plan_list, ss_filename="spread
     kwarg_names = []
     for plan in plan_list:
         pp = [format_cell(plan["name"])]
+        args_appended = False
         if "args" in plan:
-            pp.append(format_cell(plan["args"]))
-        else:
+            # Args are typically going to be represented as a printed list not enclosed in []
+            plan_args = plan["args"]
+            if not isinstance(plan_args, (tuple, list)):
+                raise ValueError(
+                    f"Plan args must be a tuple or a list: type(plan_args)={type(plan_args)} plan={plan}"
+                )
+            plan_args = list(plan_args)  # In case 'plan_args' is a tuple
+            if plan_args:  # Do not
+                plan_args_format = format_cell(plan_args)
+                plan_args_format = plan_args_format[1:-1]  # Remove [ and ]
+                pp.append(plan_args_format)
+                args_appended = True
+        if not args_appended:
             pp.append(math.nan)
         if "kwargs" in plan:
             plan_kwargs = plan["kwargs"].copy()

--- a/bluesky_queueserver/server/tests/test_conversions.py
+++ b/bluesky_queueserver/server/tests/test_conversions.py
@@ -1,8 +1,8 @@
-import math
 import numpy as np
 import os
-import pandas as pd
 import pytest
+
+from ._common import plan_list_sample, create_excel_file_from_plan_list
 
 from bluesky_queueserver.server.conversions import (
     filter_plan_descriptions,
@@ -164,141 +164,74 @@ def test_read_cell_parameter(val_in, val_out, val_type, success, errmsg):
             _read_cell_parameter(val_in)
 
 
-def create_excel_file_from_plan_list(tmp_path, *, plan_list, ss_filename="spreadsheet", ss_ext=".xlsx"):
-    """
-    Create test spreadsheet file in temporary directory. Return full path to the spreadsheet
-    and the expected list of plans with parameters. Supporting '.xlsx' and '.csv' extensions.
-    The idea was to also write tests for '.xls' file support, but Pandas writer does not seem to
-    support writing ".xls" files.
-
-    Parameters
-    ----------
-    tmp_path : str
-        temporary path
-    plan_list : list(dict)
-        list of plan parameters
-    ss_filename : str
-        spreadsheet file name without extension
-    ss_ext : str
-        spreadsheet extension ('.xlsx' and '.csv' extensions are supported)
-
-    Returns
-    -------
-    str
-        full path to spreadsheet file
-    """
-    # Create sample Excel file
-    ss_filename = ss_filename + ss_ext
-    ss_path = os.path.join(tmp_path, ss_filename)
-
-    def format_cell(val):
-        if isinstance(val, (np.integer, int)):
-            return int(val)
-        elif isinstance(val, (np.floating, float)):
-            return float(val)
-        elif isinstance(val, str):
-            return f"'{val}'"
-        else:
-            return str(val)
-
-    plan_params = []
-    kwarg_names = []
-    for plan in plan_list:
-        pp = [format_cell(plan["name"])]
-        if "args" in plan:
-            pp.append(format_cell(plan["args"]))
-        else:
-            pp.append(math.nan)
-        if "kwargs" in plan:
-            plan_kwargs = plan["kwargs"].copy()
-            for kw in kwarg_names:
-                if kw in plan_kwargs:
-                    pp.append(format_cell(plan_kwargs[kw]))
-                    del plan_kwargs[kw]
-                else:
-                    pp.append(math.nan)
-            for kw in plan_kwargs.keys():
-                kwarg_names.append(kw)
-                pp.append(format_cell(plan_kwargs[kw]))
-        plan_params.append(pp)
-
-    # Make all parameter lists equal length
-    max_params = max([len(_) for _ in plan_params])
-    for pp in plan_params:
-        for _ in range(len(pp), max_params):
-            pp.append(math.nan)
-
-    col_names = ["plan_name", "args"] + kwarg_names
-
-    def create_excel(ss_path, plan_params, col_names):
-        df = pd.DataFrame(plan_params)
-        df = df.set_axis(col_names, axis=1)
-
-        _, ext = os.path.splitext(ss_path)
-        if ext == ".xlsx":
-            df.to_excel(ss_path, index=False, engine="openpyxl")
-        elif ext == ".csv":
-            df.to_csv(ss_path, index=False)
-        return df
-
-    def verify_excel(ss_path, df):
-        _, ext = os.path.splitext(ss_path)
-        if ext == ".xlsx":
-            df_read = pd.read_excel(ss_path, engine="openpyxl")
-        elif ext == ".csv":
-            df_read = pd.read_csv(ss_path)
-
-        assert df_read.equals(df), str(df_read)
-
-    df = create_excel(ss_path, plan_params, col_names)
-    verify_excel(ss_path, df)
-
-    return ss_path
-
-
-_plan_list = [
-    {"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 10}},
-    {"name": "count", "args": [["det1"]], "kwargs": {"delay": 0.5}},
-    {"name": "count", "kwargs": {"detectors": ["det1"], "delay": 0.5}},
-    {"name": math.nan},
-    {"name": "scan", "args": [["det1", "det2"], "motor", -1, 1, 10], "kwargs": {"num": 3}},
-    {"name": "scan", "args": [["det1", "det2"], "motor", -1, 1, 10]},
-    {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "delay": 0.7}},
-    {"name": "count", "args": [["det2"]], "kwargs": {"num": 2}},
-]
-
-
 # fmt: on
 @pytest.mark.parametrize("ext", [".xlsx", ".csv"])
 # fmt: off
 def test_spreadsheet_to_plan_list_1(tmp_path, ext):
+    """
+    Basic test for ``spreadsheet_to_plan_list()`` function. Check that the list of
+    plans could be saved and then restored from the spreadsheet without change.
+    Check that the restored parameters have correct types.
+    """
+    # Add plans with a kwarg that accepts values of different types (int, float and str)
+    #   Those values are going to be placed in the same column of the spreadsheet.
+    #   Check if types will be restored correctly (pandas write/read functions don't like columns
+    #   with mixed types). Also check if all possible types are handled correctly.
+    extra_plans = [
+        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": 50}},
+        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": "some_str"}},
+        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": 50.256}},
+        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": None}},
+        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": ""}},
+        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": [10, 20, 30]}},
+        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": {
+            "p1": 10, "p2": "10", "p3": 50}}},
+    ]
 
-    ss_path = create_excel_file_from_plan_list(tmp_path, plan_list=_plan_list, ss_ext=ext)
+    plan_list = plan_list_sample.copy()
+    for plan in extra_plans:
+        plan_list.append(plan)
+
+    ss_path = create_excel_file_from_plan_list(tmp_path, plan_list=plan_list, ss_ext=ext)
     with open(ss_path, "rb") as f:
         plans = spreadsheet_to_plan_list(spreadsheet_file=f, file_name=os.path.split(ss_path)[-1])
 
     # Remove the case when name == None before comparing dictionaries
-    assert plans == [{"plan": _} for _ in _plan_list if isinstance(_["name"], str)]
+    assert plans == [_ for _ in plan_list if isinstance(_["name"], str)]
 
 
 # fmt: on
 @pytest.mark.parametrize("ext", [".xlsx", ".csv"])
-@pytest.mark.parametrize("extra_plan, errmsg", [
-    # Invalid plan name (wrong type - not str)
-    # ({"name": 10, "args": [["det1", "det2"]], "kwargs": {"num": 10}},
-    #  "Plan name .*row 9.* has incorrect type"),
-    ({"name": [10, 20], "args": [["det1", "det2"]], "kwargs": {"num": 10}},
-     "Plan name .*row 9.* has incorrect type"),
-    # Invalid plan name (can not be a Python identifier)
-    ({"name": "10", "args": [["det1", "det2"]], "kwargs": {"num": 10}},
-     "Plan name .*10.*row 9.* is not a valid plan name"),
-    ({"name": "co unt", "args": [["det1", "det2"]], "kwargs": {"num": 10}},
-     "Plan name .*co unt.*row 9.* is not a valid plan name"),
-])
+@pytest.mark.parametrize(
+    "extra_plan, errmsg",
+    [
+        # Invalid plan name (wrong type - not str)
+        (
+            {"name": 10, "args": [["det1", "det2"]], "kwargs": {"num": 10}},
+            "Plan name .*row 9.* has incorrect type",
+        ),
+        (
+            {"name": [10, 20], "args": [["det1", "det2"]], "kwargs": {"num": 10}},
+            "Plan name .*row 9.* has incorrect type",
+        ),
+        # Invalid plan name (can not be a Python identifier)
+        (
+            {"name": "10", "args": [["det1", "det2"]], "kwargs": {"num": 10}},
+            "Plan name .*10.*row 9.* is not a valid plan name",
+        ),
+        (
+            {"name": "co unt", "args": [["det1", "det2"]], "kwargs": {"num": 10}},
+            "Plan name .*co unt.*row 9.* is not a valid plan name",
+        ),
+    ],
+)
 # fmt: off
 def test_spreadsheet_to_plan_list_2_fail(tmp_path, ext, extra_plan, errmsg):
-
-    _plan_list_modified = _plan_list.copy()
+    """
+    Test if ``spreadsheet_to_plan_list()`` function is correctly processing the main issues
+    with the spreadsheet and raises exception with correct error messages.
+    """
+    _plan_list_modified = plan_list_sample.copy()
     _plan_list_modified.append(extra_plan)
     ss_path = create_excel_file_from_plan_list(tmp_path, plan_list=_plan_list_modified, ss_ext=ext)
     with open(ss_path, "rb") as f:

--- a/bluesky_queueserver/server/tests/test_http_server_func_scope.py
+++ b/bluesky_queueserver/server/tests/test_http_server_func_scope.py
@@ -180,9 +180,6 @@ def test_http_server_queue_upload_spreasheet_4(
         )
     fastapi_server_fs()
 
-    # plan_params = [["count", 5, 1], ["count", 6, 0.5]]
-    # col_names = ["name", "num", "delay"]
-
     ss_path = create_excel_file_from_plan_list(tmp_path, plan_list=plan_list_sample)
     plans_expected = [_ for _ in plan_list_sample if isinstance(_["name"], str)]
 

--- a/bluesky_queueserver/server/tests/test_http_server_func_scope.py
+++ b/bluesky_queueserver/server/tests/test_http_server_func_scope.py
@@ -2,6 +2,8 @@ import os
 import pandas as pd
 import pytest
 
+from ._common import plan_list_sample, create_excel_file_from_plan_list
+
 from bluesky_queueserver.manager.tests._common import (  # noqa F401
     re_manager,
     re_manager_pc_copy,
@@ -178,17 +180,47 @@ def test_http_server_queue_upload_spreasheet_4(
         )
     fastapi_server_fs()
 
-    plan_params = [["count", 5, 1], ["count", 6, 0.5]]
-    col_names = ["name", "num", "delay"]
-    ss_path, plans_expected = _create_test_excel_file1(tmp_path, plan_params=plan_params, col_names=col_names)
+    # plan_params = [["count", 5, 1], ["count", 6, 0.5]]
+    # col_names = ["name", "num", "delay"]
+
+    ss_path = create_excel_file_from_plan_list(tmp_path, plan_list=plan_list_sample)
+    plans_expected = [_ for _ in plan_list_sample if isinstance(_["name"], str)]
 
     # Send the Excel file to the server
     params = {"files": {"spreadsheet": open(ss_path, "rb")}}
     if use_custom:
         params["data"] = {"data_type": "process_with_default_function"}
     resp1 = request_to_json("post", "/queue/upload/spreadsheet", **params)
-    assert resp1["success"] is False, str(resp1)
-    assert resp1["msg"] == "Default function for converting spreadsheet to plan list is not implemented yet"
+    assert resp1["success"] is True, str(resp1)
+    assert "item_list" in resp1, str(resp1)
+    assert len(resp1["item_list"]) == len(plans_expected), str(resp1)
+
+    # Verify that the queue contains correct plans
+    resp2 = request_to_json("get", "/queue/get")
+    assert resp2["success"] is True
+    assert resp2["running_item"] == {}
+    queue = resp2["queue"]
+    assert len(queue) == len(plans_expected), str(queue)
+    for p, p_exp in zip(queue, plans_expected):
+        for k, v in p_exp.items():
+            assert k in p
+            assert v == p[k]
+
+    resp3 = request_to_json("post", "/environment/open")
+    assert resp3["success"] is True
+    assert wait_for_environment_to_be_created(10)
+
+    resp4 = request_to_json("post", "/queue/start")
+    assert resp4["success"] is True
+    assert wait_for_queue_execution_to_complete(60)
+
+    resp5 = request_to_json("get", "/status")
+    assert resp5["items_in_queue"] == 0
+    assert resp5["items_in_history"] == len(plans_expected)
+
+    resp6 = request_to_json("post", "/environment/close")
+    assert resp6 == {"success": True, "msg": ""}
+    assert wait_for_manager_state_idle(10)
 
 
 def test_http_server_queue_upload_spreasheet_5(re_manager, fastapi_server_fs, tmp_path, monkeypatch):  # noqa F811


### PR DESCRIPTION
Implementation for default (built-in) function for converting a spreadsheet to a list of plans. The plan parameters are expected to be represented as a table in straightforward way following guidelines. Users that require support for more sophisticated or custom spreadsheets may write their own processing function. The function supports `.xlsx` (Excel) and `.csv` files. Only the first sheet of an Excel workbook will be loaded.

The screenshot of an Excel spreadsheet with sample simulated plans:

![Spreadsheet with sample plans 2021-03-25 13-15-19](https://user-images.githubusercontent.com/46980826/112515188-6d9e3000-8d6c-11eb-8dbf-ba4ecf1a78de.png)

```
    Guidelines:

    - The first row contains column names. The names of columns 1 and 2 can be
      arbitrary, but should be kept informative. It is recommended to name column 2 as
      'args'. The remaining column names should strictly match names of plan kwargs.

    - Each of the remaining rows contains parameters of a single plan. Empty rows
      are permitted. The row is considered empty if the cell containing plan name
      is empty. In this case the remaining row cells are ignored.

    - Column 1 contains plan names. Plan names should be enclosed in quotation marks.
      (Plan name will be accepted without quotation marks but it is recommended to use
      quatation marks for consistency.) Plan names must satisfy requirements for Python
      identifiers, otherwise the exception will be raised. (The plan with the respective
      name should also exist in the RE Worker environment, but this function doesn't
      verify it.)

    - Column 2 contains plan args. The args should be comma-separated. The list of args
      should not be enclosed in ``[]`` (e.g. ['det1', 'det2'] is considered as one arg
      containing a list of detectors. The names of the devices (motors or detectors)
      should be enclosed in quotation marks. The cell may be left empty if the plan
      is not using args. NOTE: column 2 is reserved for args and it should be present
      even if no plans in the list accepts args.

    - Columns 3,4... contain values of kwargs. Each column is reserved for kwarg with
      the name listed in row 1. If a kwarg is not used for a given plan, the cell should
      be empty.

    The contents of the cells are evaluated using Python expression ``eval(<cell_value>, {}, {}``,
    therefore the expressions may not contain variable names or function calls. But they may
    represent arbitrary expressions containing numbers and strings (numbers and strings
    can be organized in lists, dictionaries, lists of dictionaries etc. If a cell contains
    unquoted device name (e.g. ``motor``), the name will be interpreted by ``eval()`` as
    a variable and an exception will be raised.

```

Example of `.xlsx` file:
[spreadsheet.xlsx](https://github.com/bluesky/bluesky-queueserver/files/6206636/spreadsheet.xlsx)

Example of `.csv` file (generated by Pandas from a DataFrame with plan parameters):
```
plan_name,args,num,delay,detectors
'count',"['det1', 'det2']",10.0,,
'count',['det1'],,0.5,
'count',,,0.5,['det1']
,,,,
'scan',"['det1', 'det2'], 'motor', -1, 1",10.0,,
'scan',"['det1', 'det2'], 'motor', -1, 1, 10",,,
'count',['det2'],2.0,0.7,
'count',['det2'],2.0,,
```

Addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/138