### PR TITLE
Consistent representation of items in 0MQ API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,9 +195,9 @@ Push a new plan to the back of the queue::
   qserver queue add plan '{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
   qserver queue add plan '{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
 
-  http POST http://localhost:60610/queue/item/add plan:='{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/item/add plan:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
-  http POST http://localhost:60610/queue/item/add plan:='{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}}'
+  http POST http://localhost:60610/queue/item/add item:='{"name":"count", "args":[["det1", "det2"]], "item_type": "plan"}'
+  http POST http://localhost:60610/queue/item/add item:='{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10], "item_type": "plan"}'
+  http POST http://localhost:60610/queue/item/add item:='{"name":"count", "args":[["det1", "det2"]], "kwargs":{"num":10, "delay":1}, "item_type": "plan"}'
 
 It takes 10 second to execute the third plan in the group above, so it is may be the most convenient for testing
 pausing/resuming/stopping of experimental plans.
@@ -206,7 +206,7 @@ API for queue operations is designed to work identically with items of all types
 instruction can be added to the queue `queue_item_add` API::
 
   qserver queue add instruction queue-stop
-  http POST http://localhost:60610/queue/item/add instruction:='{"action":"queue_stop"}'
+  http POST http://localhost:60610/queue/item/add item:='{"name":"queue_stop", "item_type": "instruction"}'
 
 An item can be added at any position of the queue. Push a plan to the front or the back of the queue::
 
@@ -214,31 +214,31 @@ An item can be added at any position of the queue. Push a plan to the front or t
   qserver queue add plan back '{"name":"count", "args":[["det1", "det2"]]}'
   qserver queue add plan 2 '{"name":"count", "args":[["det1", "det2"]]}'  # Inserted at pos #2 (0-based)
 
-  http POST http://localhost:60610/queue/item/add pos:='"front"' plan:='{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/item/add pos:='"back"' plan:='{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/item/add pos:=2 plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add pos:='"front"' item:='{"name":"count", "args":[["det1", "det2"]], "item_type": "plan"}'
+  http POST http://localhost:60610/queue/item/add pos:='"back"' item:='{"name":"count", "args":[["det1", "det2"]], "item_type": "plan"}'
+  http POST http://localhost:60610/queue/item/add pos:=2 item:='{"name":"count", "args":[["det1", "det2"]], "item_type": "plan"}'
 
 The following command will insert an item in place of the last item in the queue; the last item remains
 the last item in the queue::
 
   qserver queue add plan -1 '{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/item/add pos:=-1 plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add pos:=-1 item:='{"name":"count", "args":[["det1", "det2"]], "item_type": "plan"}'
 
 An item can be inserted before or after an existing item with given Item UID.
 Insert the plan before an existing item with <uid>::
 
   qserver queue add plan before_uid '<uid>' '{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/item/add before_uid:='<uid>' plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add before_uid:='<uid>' item:='{"name":"count", "args":[["det1", "det2"]], "item_type": "plan"}'
 
 Insert the plan after an existing item with <uid>::
 
   qserver queue add plan after_uid '<uid>' '{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/item/add after_uid:='<uid>' plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add after_uid:='<uid>' item:='{"name":"count", "args":[["det1", "det2"]], "item_type": "plan"}'
 
 If the queue has 5 items (0..4), then the following command pushes the new plan to the back of the queue::
 
   qserver queue add plan 5 '{"name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/item/add pos:=5 plan:='{"name":"count", "args":[["det1", "det2"]]}'
+  http POST http://localhost:60610/queue/item/add pos:=5 item:='{"name":"count", "args":[["det1", "det2"]], "item_type": "plan"}'
 
 The 'queue_item_add' request will accept any index value. If the index is out of range, then the item will
 be pushed to the front or the back of the queue. If the queue is currently running, then it is recommended
@@ -345,10 +345,10 @@ be set to the UID of the item to be updated. Additional API parameter 'replace' 
 is updated or replaced. If the parameter is skipped or set *false*, the item is updated. If the
 parameter is set *true*, the item is replaced (i.e. new item UID is generated)::
 
-  http POST http://localhost:60610/queue/item/update plan:='{"item_uid": "<existing-uid>", "name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/item/update instruction:='{"item_uid": "<existing-uid>", "action":"queue_stop"}'
-  http POST http://localhost:60610/queue/item/update replace:=true plan:='{"item_uid": "<existing-uid>", "name":"count", "args":[["det1", "det2"]]}'
-  http POST http://localhost:60610/queue/item/update replace:=true instruction:='{"item_uid": "<existing-uid>", "action":"queue_stop"}'
+  http POST http://localhost:60610/queue/item/update item:='{"item_uid": "<existing-uid>", "name":"count", "args":[["det1", "det2"]], "item_type": "plan"}'
+  http POST http://localhost:60610/queue/item/update item:='{"item_uid": "<existing-uid>", "name":"queue_stop", , "item_type": "instruction"}'
+  http POST http://localhost:60610/queue/item/update replace:=true item:='{"item_uid": "<existing-uid>", "name":"count", "args":[["det1", "det2"]], "item_type": "plan"}'
+  http POST http://localhost:60610/queue/item/update replace:=true item:='{"item_uid": "<existing-uid>", "name":"queue_stop", "item_type": "instruction"}'
 
 Remove all entries from the plan queue::
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -898,7 +898,7 @@ class RunEngineManager(Process):
         return {
             "success": True,
             "msg": "",
-            "queue": plan_queue,
+            "items": plan_queue,
             "running_item": running_item,
             "plan_queue_uid": plan_queue_uid,
         }

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -911,10 +911,12 @@ class RunEngineManager(Process):
         supported_item_types = ("plan", "instruction")
 
         # The following two error reports represent serious bug, which needs to be fixed
-        if (request is None) and (item is None):
-            raise Exception(f"Runtime error: neither 'request' nor 'item' is specfied in function call")
-        if (request is not None) and (item is not None):
-            raise Exception(f"Runtime error: both 'request' and 'item' are specfied in function call")
+        n_request_or_item = sum([(request is None), (item is None)])
+        if n_request_or_item != 1:
+            raise RuntimeError(
+                "Runtime error: Only one of 'request' or 'item' parameters "
+                f"may be not None: request={request}, item={item}"
+            )
 
         # Generate error message instead of raising exception: we still want to return
         #   'item' if it exists so that we could send it to the client with error message.
@@ -927,7 +929,7 @@ class RunEngineManager(Process):
                     f"type(request)='{type(request)}', expected type is 'dict'"
                 )
             if "item" not in request:
-                raise Exception(f"{msg_prefix}request contains no item info")
+                raise ValueError(f"{msg_prefix}request contains no item info")
             item = request["item"]
 
         if isinstance(item, dict):
@@ -950,16 +952,16 @@ class RunEngineManager(Process):
 
     def _get_user_info_from_request(self, *, request):
         if "user_group" not in request:
-            raise Exception("Incorrect request format: user group is not specified")
+            raise ValueError("Incorrect request format: user group is not specified")
 
         if "user" not in request:
-            raise Exception("Incorrect request format: user name is not specified")
+            raise ValueError("Incorrect request format: user name is not specified")
 
         user = request["user"]
         user_group = request["user_group"]
 
         if user_group not in self._allowed_plans:
-            raise Exception(f"Unknown user group: '{user_group}'")
+            raise ValueError(f"Unknown user group: '{user_group}'")
 
         return user, user_group
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1299,7 +1299,7 @@ class RunEngineManager(Process):
         logger.info("Returning plan history ...")
         plan_history, plan_history_uid = await self._plan_queue.get_history()
 
-        return {"success": True, "msg": "", "history": plan_history, "plan_history_uid": plan_history_uid}
+        return {"success": True, "msg": "", "items": plan_history, "plan_history_uid": plan_history_uid}
 
     async def _history_clear_handler(self, request):
         """

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -375,15 +375,17 @@ def msg_queue_add_update(params, *, cmd_opt):
                 raise CommandParameterError(f"Error occurred while parsing the plan '{p_item[0]}'")
             if update_uid:
                 plan["item_uid"] = update_uid
-            addr_param.update({"plan": plan})
+            plan["item_type"] = "plan"
+            addr_param.update({"item": plan})
         elif p_item_type == "instruction":
             if p_item[0] == "queue-stop":
-                instruction = {"action": "queue_stop"}
+                instruction = {"name": "queue_stop"}
             else:
                 raise CommandParameterError(f"Unsupported instruction type: {p_item[0]}")
             if update_uid:
                 instruction["item_uid"] = update_uid
-            addr_param.update({"instruction": instruction})
+            instruction["item_type"] = "instruction"
+            addr_param.update({"item": instruction})
         else:
             # This indicates a bug in the program.
             raise ValueError(f"Unknown item type: {p_item_type}")

--- a/bluesky_queueserver/manager/tests/test_fixtures.py
+++ b/bluesky_queueserver/manager/tests/test_fixtures.py
@@ -85,7 +85,7 @@ def test_fixture_re_manager_cmd_2(re_manager_cmd, db_catalog):  # noqa F811
     assert resp5["items_in_history"] == 1
 
     resp6, _ = zmq_single_request("history_get")
-    history = resp6["history"]
+    history = resp6["items"]
     assert len(history) == 1
 
     uid = history[-1]["result"]["run_uids"][0]

--- a/bluesky_queueserver/manager/tests/test_fixtures.py
+++ b/bluesky_queueserver/manager/tests/test_fixtures.py
@@ -59,10 +59,10 @@ def test_fixture_re_manager_cmd_2(re_manager_cmd, db_catalog):  # noqa F811
 
     cat = db_catalog["catalog"]
 
-    plan = {"name": "scan", "args": [["det1", "det2"], "motor", -1, 1, 10]}
+    plan = {"name": "scan", "args": [["det1", "det2"], "motor", -1, 1, 10], "item_type": "plan"}
 
     # Plan
-    params1 = {"plan": plan, "user": _user, "user_group": _user_group}
+    params1 = {"item": plan, "user": _user, "user_group": _user_group}
     resp1, _ = zmq_single_request("queue_item_add", params1)
     assert resp1["success"] is True, f"resp={resp1}"
 

--- a/bluesky_queueserver/manager/tests/test_manager_options.py
+++ b/bluesky_queueserver/manager/tests/test_manager_options.py
@@ -24,7 +24,7 @@ from ._common import re_manager_cmd  # noqa: F401
 # User name and user group name used throughout most of the tests.
 _user, _user_group = "Testing Script", "admin"
 
-_plan1 = {"name": "count", "args": [["det1", "det2"]]}
+_plan1 = {"name": "count", "args": [["det1", "det2"]], "item_type": "plan"}
 
 _sample_plan1 = """
 def simple_sample_plan():
@@ -81,8 +81,8 @@ def test_manager_options_startup_profile(re_manager_cmd, tmp_path, monkeypatch, 
     assert wait_for_condition(time=10, condition=condition_environment_created)
 
     # Add the plan to the queue (will fail if incorrect environment is loaded)
-    plan = {"name": "simple_sample_plan"}
-    params = {"plan": plan, "user": _user, "user_group": _user_group}
+    plan = {"name": "simple_sample_plan", "item_type": "plan"}
+    params = {"item": plan, "user": _user, "user_group": _user_group}
     resp2, _ = zmq_single_request("queue_item_add", params)
     assert resp2["success"] is True, f"resp={resp2}"
 
@@ -146,7 +146,7 @@ def test_manager_acq_with_0MQ_proxy(re_manager_cmd, zmq_proxy, zmq_dispatcher): 
     assert wait_for_condition(time=10, condition=condition_environment_created)
 
     # Add the plan to the queue (will fail if incorrect environment is loaded)
-    params = {"plan": _plan1, "user": _user, "user_group": _user_group}
+    params = {"item": _plan1, "user": _user, "user_group": _user_group}
     resp2, _ = zmq_single_request("queue_item_add", params)
     assert resp2["success"] is True, f"resp={resp2}"
 

--- a/bluesky_queueserver/manager/tests/test_profile_tools.py
+++ b/bluesky_queueserver/manager/tests/test_profile_tools.py
@@ -568,7 +568,7 @@ def test_is_re_worker_active_2(re_manager_cmd, tmp_path, monkeypatch, option):  
     # Make sure that plan was completed successfully
     resp5, _ = zmq_single_request("history_get")
     assert resp5["success"] is True
-    history = resp5["history"]
+    history = resp5["items"]
     assert history[-1]["result"]["exit_status"] == "completed"
 
     # Close the environment

--- a/bluesky_queueserver/manager/tests/test_profile_tools.py
+++ b/bluesky_queueserver/manager/tests/test_profile_tools.py
@@ -537,7 +537,7 @@ def test_is_re_worker_active_2(re_manager_cmd, tmp_path, monkeypatch, option):  
     assert resp1["success"] is True, f"resp={resp1}"
 
     # Add plan to the queue
-    params = {"plan": {"name": "sim_plan_1"}, "user": _user, "user_group": _user_group}
+    params = {"item": {"name": "sim_plan_1", "item_type": "plan"}, "user": _user, "user_group": _user_group}
     resp2, _ = zmq_single_request("queue_item_add", params)
     assert resp2["success"] is True, f"resp={resp2}"
 

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -605,11 +605,11 @@ def test_queue_item_add_1(re_manager, pos, pos_result, success):  # noqa F811
         assert res == PARAM_ERROR
 
     resp = get_queue()
-    assert len(resp["queue"]) == (3 if success else 2)
+    assert len(resp["items"]) == (3 if success else 2)
 
     if success:
-        assert resp["queue"][pos_result]["args"] == [["det1", "det2"]]
-        assert "item_uid" in resp["queue"][pos_result]
+        assert resp["items"][pos_result]["args"] == [["det1", "det2"]]
+        assert "item_uid" in resp["items"][pos_result]
 
 
 def test_queue_item_add_2(re_manager):  # noqa F811
@@ -652,7 +652,7 @@ def test_queue_item_add_3(re_manager, before, target_pos, result_order):  # noqa
     assert subprocess.call(["qserver", "queue", "add", "plan", plan2]) == SUCCESS
 
     # Read queue.
-    queue_1 = get_queue()["queue"]
+    queue_1 = get_queue()["items"]
     assert len(queue_1) == 2
     uids_1 = [_["item_uid"] for _ in queue_1]
 
@@ -660,7 +660,7 @@ def test_queue_item_add_3(re_manager, before, target_pos, result_order):  # noqa
     assert subprocess.call(["qserver", "queue", "add", "plan", *params]) == SUCCESS
 
     # Check if the element was inserted in the right plance
-    queue_2 = get_queue()["queue"]
+    queue_2 = get_queue()["items"]
     assert len(queue_2) == 3
     uids_2 = [_["item_uid"] for _ in queue_2]
     for n, uid in enumerate(uids_2):
@@ -681,7 +681,7 @@ def test_queue_item_add_4(re_manager):  # noqa F811
     assert subprocess.call(["qserver", "queue", "add", "instruction", instruction]) == SUCCESS
     assert subprocess.call(["qserver", "queue", "add", "plan", plan2]) == SUCCESS
 
-    queue_1 = get_queue()["queue"]
+    queue_1 = get_queue()["items"]
     assert len(queue_1) == 3
     assert queue_1[0]["item_type"] == "plan", str(queue_1[0])
     assert queue_1[1]["item_type"] == "instruction", str(queue_1[1])
@@ -757,7 +757,7 @@ def test_queue_item_update_1(re_manager, replace, item_type):  # noqa F811
 
     assert subprocess.call(["qserver", "queue", "add", "plan", plan1]) == SUCCESS
 
-    queue_1 = get_queue()["queue"]
+    queue_1 = get_queue()["items"]
     assert len(queue_1) == 1
     item_1 = queue_1[0]
     uid_to_replace = item_1["item_uid"]
@@ -772,7 +772,7 @@ def test_queue_item_update_1(re_manager, replace, item_type):  # noqa F811
 
     assert subprocess.call(["qserver", "queue", option, item_type, uid_to_replace, item]) == SUCCESS
 
-    queue_2 = get_queue()["queue"]
+    queue_2 = get_queue()["items"]
     assert len(queue_2) == 1
     item_2 = queue_2[0]
 
@@ -797,7 +797,7 @@ def test_queue_item_update_2_fail(re_manager, replace, item_type):  # noqa F811
 
     assert subprocess.call(["qserver", "queue", "add", "plan", plan1]) == SUCCESS
 
-    queue_1 = get_queue()["queue"]
+    queue_1 = get_queue()["items"]
     assert len(queue_1) == 1
     uid_to_replace = "non-existent-UID"
 
@@ -811,7 +811,7 @@ def test_queue_item_update_2_fail(re_manager, replace, item_type):  # noqa F811
 
     assert subprocess.call(["qserver", "queue", option, item_type, uid_to_replace, item]) == REQ_FAILED
 
-    queue_2 = get_queue()["queue"]
+    queue_2 = get_queue()["items"]
     assert queue_1 == queue_2
 
 
@@ -851,7 +851,7 @@ def test_queue_item_get_remove(re_manager, pos, uid_ind, pos_result, success):  
     for plan in plans:
         assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == SUCCESS
 
-    queue_1 = get_queue()["queue"]
+    queue_1 = get_queue()["items"]
     assert len(queue_1) == 3
     uids_1 = [_["item_uid"] for _ in queue_1]
     uids_1.append("unknown_uid")  # Extra element (for one of the tests)
@@ -877,7 +877,7 @@ def test_queue_item_get_remove(re_manager, pos, uid_ind, pos_result, success):  
     else:
         assert res == REQ_FAILED
 
-    queue_2 = get_queue()["queue"]
+    queue_2 = get_queue()["items"]
     assert len(queue_2) == (2 if success else 3)
     if success:
         ind = [0, 1, 2]
@@ -922,7 +922,7 @@ def test_queue_item_get_move(re_manager, params, result_order, exit_code):  # no
     for plan in plans:
         assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == SUCCESS
 
-    queue_1 = get_queue()["queue"]
+    queue_1 = get_queue()["items"]
     assert len(queue_1) == 3
     uids_1 = [_["item_uid"] for _ in queue_1]
     uids_1.append("unknown_uid")  # Extra element (for one of the tests)
@@ -936,7 +936,7 @@ def test_queue_item_get_move(re_manager, params, result_order, exit_code):  # no
     # Testing 'queue_item_move'.
     assert subprocess.call(["qserver", "queue", "item", "move", *params]) == exit_code
 
-    queue_2 = get_queue()["queue"]
+    queue_2 = get_queue()["items"]
     assert len(queue_2) == 3
     uids_2 = [_["item_uid"] for _ in queue_2]
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -655,7 +655,7 @@ def test_zmq_api_queue_item_add_7(db_catalog, re_manager_cmd, meta_param, meta_s
     assert resp5["items_in_history"] == 1
 
     resp6, _ = zmq_single_request("history_get")
-    history = resp6["history"]
+    history = resp6["items"]
     assert len(history) == 1
 
     # Check if metadata was recorded in the start document.
@@ -1392,7 +1392,7 @@ def test_re_runs_1(re_manager_pc_copy, tmp_path, test_with_manager_restart):  # 
     # Make sure that history contains correct data.
     resp5b, _ = zmq_single_request("history_get")
     assert resp5b["success"] is True
-    history = resp5b["history"]
+    history = resp5b["items"]
     assert len(history) == 1, str(resp5b)
     # Check that correct number of UIDs are saved in the history
     history_run_uids = history[0]["result"]["run_uids"]

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -755,16 +755,16 @@ def test_zmq_api_queue_item_update_1(re_manager, replace):  # noqa F811
     Basic test for `queue_item_update` method.
     """
 
-    resp1, _ = zmq_single_request("queue_item_add", {"plan": _plan1, "user": _user, "user_group": _user_group})
+    resp1, _ = zmq_single_request("queue_item_add", {"item": _plan1, "user": _user, "user_group": _user_group})
     assert resp1["success"] is True
     assert resp1["qsize"] == 1
-    assert resp1["plan"]["name"] == _plan1["name"]
-    assert resp1["plan"]["args"] == _plan1["args"]
-    assert resp1["plan"]["user"] == _user
-    assert resp1["plan"]["user_group"] == _user_group
-    assert "item_uid" in resp1["plan"]
+    assert resp1["item"]["name"] == _plan1["name"]
+    assert resp1["item"]["args"] == _plan1["args"]
+    assert resp1["item"]["user"] == _user
+    assert resp1["item"]["user_group"] == _user_group
+    assert "item_uid" in resp1["item"]
 
-    plan = resp1["plan"]
+    plan = resp1["item"]
     uid = plan["item_uid"]
 
     plan_changed = plan.copy()
@@ -772,7 +772,7 @@ def test_zmq_api_queue_item_update_1(re_manager, replace):  # noqa F811
     plan_changed["args"] = plan_new_args
 
     user_replaced = "Different User"
-    params = {"plan": plan_changed, "user": user_replaced, "user_group": _user_group}
+    params = {"item": plan_changed, "user": user_replaced, "user_group": _user_group}
     if replace is not None:
         params["replace"] = replace
 
@@ -781,15 +781,15 @@ def test_zmq_api_queue_item_update_1(re_manager, replace):  # noqa F811
     resp2, _ = zmq_single_request("queue_item_update", params)
     assert resp2["success"] is True
     assert resp2["qsize"] == 1
-    assert resp2["plan"]["name"] == _plan1["name"]
-    assert resp2["plan"]["args"] == plan_new_args
-    assert resp2["plan"]["user"] == user_replaced
-    assert resp2["plan"]["user_group"] == _user_group
-    assert "item_uid" in resp2["plan"]
+    assert resp2["item"]["name"] == _plan1["name"]
+    assert resp2["item"]["args"] == plan_new_args
+    assert resp2["item"]["user"] == user_replaced
+    assert resp2["item"]["user_group"] == _user_group
+    assert "item_uid" in resp2["item"]
     if replace:
-        assert resp2["plan"]["item_uid"] != uid
+        assert resp2["item"]["item_uid"] != uid
     else:
-        assert resp2["plan"]["item_uid"] == uid
+        assert resp2["item"]["item_uid"] == uid
 
     status2 = get_queue_state()
     assert status2["plan_queue_uid"] != status1["plan_queue_uid"]
@@ -798,7 +798,7 @@ def test_zmq_api_queue_item_update_1(re_manager, replace):  # noqa F811
     resp3, _ = zmq_single_request("queue_get")
     assert resp3["items"] != []
     assert len(resp3["items"]) == 1
-    assert resp3["items"][0] == resp2["plan"]
+    assert resp3["items"][0] == resp2["item"]
     assert resp3["running_item"] == {}
     assert resp3["plan_queue_uid"] == status2["plan_queue_uid"]
 
@@ -810,23 +810,23 @@ def test_zmq_api_queue_item_update_2_fail(re_manager, replace):  # noqa F811
     """
     Failing cases for `queue_item_update`: submitted item UID does not match any UID in the queue.
     """
-    resp1, _ = zmq_single_request("queue_item_add", {"plan": _plan1, "user": _user, "user_group": _user_group})
+    resp1, _ = zmq_single_request("queue_item_add", {"item": _plan1, "user": _user, "user_group": _user_group})
     assert resp1["success"] is True
     assert resp1["qsize"] == 1
-    assert resp1["plan"]["name"] == _plan1["name"]
-    assert resp1["plan"]["args"] == _plan1["args"]
-    assert resp1["plan"]["user"] == _user
-    assert resp1["plan"]["user_group"] == _user_group
-    assert "item_uid" in resp1["plan"]
+    assert resp1["item"]["name"] == _plan1["name"]
+    assert resp1["item"]["args"] == _plan1["args"]
+    assert resp1["item"]["user"] == _user
+    assert resp1["item"]["user_group"] == _user_group
+    assert "item_uid" in resp1["item"]
 
-    plan = resp1["plan"]
+    plan = resp1["item"]
 
     plan_changed = plan.copy()
     plan_changed["args"] = [["det1"]]
     plan_changed["item_uid"] = "incorrect_uid"
 
     user_replaced = "Different User"
-    params = {"plan": plan_changed, "user": user_replaced, "user_group": _user_group}
+    params = {"item": plan_changed, "user": user_replaced, "user_group": _user_group}
     if replace is not None:
         params["replace"] = replace
 
@@ -858,7 +858,7 @@ def test_zmq_api_queue_item_update_3_fail(re_manager, replace):  # noqa F811
     plan_changed["item_uid"] = "incorrect_uid"
 
     user_replaced = "Different User"
-    params = {"plan": plan_changed, "user": user_replaced, "user_group": _user_group}
+    params = {"item": plan_changed, "user": user_replaced, "user_group": _user_group}
     if replace is not None:
         params["replace"] = replace
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -64,9 +64,9 @@ def test_zmq_api_thread_based(re_manager):  # noqa F811
     assert "item_uid" in resp1["plan"]
 
     resp2 = client.send_message(method="queue_get")
-    assert resp2["queue"] != []
-    assert len(resp2["queue"]) == 1
-    assert resp2["queue"][0] == resp1["plan"]
+    assert resp2["items"] != []
+    assert len(resp2["items"]) == 1
+    assert resp2["items"][0] == resp1["plan"]
     assert resp2["running_item"] == {}
 
     with pytest.raises(CommTimeoutError, match="timeout occurred"):
@@ -106,9 +106,9 @@ def test_zmq_api_asyncio_based(re_manager):  # noqa F811
         assert "item_uid" in resp1["plan"]
 
         resp2 = await client.send_message(method="queue_get")
-        assert resp2["queue"] != []
-        assert len(resp2["queue"]) == 1
-        assert resp2["queue"][0] == resp1["plan"]
+        assert resp2["items"] != []
+        assert len(resp2["items"]) == 1
+        assert resp2["items"][0] == resp1["plan"]
         assert resp2["running_item"] == {}
 
         with pytest.raises(CommTimeoutError, match="timeout occurred"):
@@ -256,9 +256,9 @@ def test_zmq_api_queue_item_add_1(re_manager):  # noqa F811
     assert status1["plan_history_uid"] == status0["plan_history_uid"]
 
     resp2, _ = zmq_single_request("queue_get")
-    assert resp2["queue"] != []
-    assert len(resp2["queue"]) == 1
-    assert resp2["queue"][0] == resp1["plan"]
+    assert resp2["items"] != []
+    assert len(resp2["items"]) == 1
+    assert resp2["items"][0] == resp1["plan"]
     assert resp2["running_item"] == {}
     assert resp2["plan_queue_uid"] == status1["plan_queue_uid"]
 
@@ -309,11 +309,11 @@ def test_zmq_api_queue_item_add_2(re_manager, pos, pos_result, success):  # noqa
 
     resp2, _ = zmq_single_request("queue_get")
 
-    assert len(resp2["queue"]) == (3 if success else 2)
+    assert len(resp2["items"]) == (3 if success else 2)
     assert resp2["running_item"] == {}
 
     if success:
-        assert resp2["queue"][pos_result]["args"] == plan2["args"]
+        assert resp2["items"][pos_result]["args"] == plan2["args"]
 
 
 def test_zmq_api_queue_item_add_3(re_manager):  # noqa F811
@@ -328,7 +328,7 @@ def test_zmq_api_queue_item_add_3(re_manager):  # noqa F811
     resp0b, _ = zmq_single_request("queue_item_add", params)
     assert resp0b["success"] is True
 
-    base_plans = zmq_single_request("queue_get")[0]["queue"]
+    base_plans = zmq_single_request("queue_get")[0]["items"]
 
     params = {"plan": plan3, "after_uid": base_plans[0]["item_uid"], "user": _user, "user_group": _user_group}
     resp1, _ = zmq_single_request("queue_item_add", params)
@@ -336,8 +336,8 @@ def test_zmq_api_queue_item_add_3(re_manager):  # noqa F811
     assert resp1["qsize"] == 3
     uid1 = resp1["plan"]["item_uid"]
     resp1a, _ = zmq_single_request("queue_get")
-    assert len(resp1a["queue"]) == 3
-    assert resp1a["queue"][1]["item_uid"] == uid1
+    assert len(resp1a["items"]) == 3
+    assert resp1a["items"][1]["item_uid"] == uid1
     resp1b, _ = zmq_single_request("queue_item_remove", {"uid": uid1})
     assert resp1b["success"] is True
 
@@ -346,8 +346,8 @@ def test_zmq_api_queue_item_add_3(re_manager):  # noqa F811
     assert resp2["success"] is True
     uid2 = resp2["plan"]["item_uid"]
     resp2a, _ = zmq_single_request("queue_get")
-    assert len(resp2a["queue"]) == 3
-    assert resp2a["queue"][1]["item_uid"] == uid2
+    assert len(resp2a["items"]) == 3
+    assert resp2a["items"][1]["item_uid"] == uid2
     resp2b, _ = zmq_single_request("queue_item_remove", {"uid": uid2})
     assert resp2b["success"] is True
 
@@ -381,7 +381,7 @@ def test_zmq_api_queue_item_add_4(re_manager):  # noqa F811
     resp0b, _ = zmq_single_request("queue_item_add", params)
     assert resp0b["success"] is True
 
-    base_plans = zmq_single_request("queue_get")[0]["queue"]
+    base_plans = zmq_single_request("queue_get")[0]["items"]
     uid = base_plans[0]["item_uid"]
 
     # Start the first plan (this removes it from the queue)
@@ -458,10 +458,10 @@ def test_zmq_api_queue_item_add_6(re_manager):  # noqa: F811
     assert resp1c["success"] is True, f"resp={resp1c}"
 
     resp2, _ = zmq_single_request("queue_get")
-    assert len(resp2["queue"]) == 3
-    assert resp2["queue"][0]["item_type"] == "plan"
-    assert resp2["queue"][1]["item_type"] == "instruction"
-    assert resp2["queue"][2]["item_type"] == "plan"
+    assert len(resp2["items"]) == 3
+    assert resp2["items"][0]["item_type"] == "plan"
+    assert resp2["items"][1]["item_type"] == "instruction"
+    assert resp2["items"][2]["item_type"] == "plan"
 
 
 def test_zmq_api_queue_item_add_batch_1(re_manager):  # noqa: F811
@@ -728,9 +728,9 @@ def test_zmq_api_queue_item_add_8_fail(re_manager):  # noqa F811
     assert "item_uid" in resp7["plan"]
 
     resp8, _ = zmq_single_request("queue_get")
-    assert resp8["queue"] != []
-    assert len(resp8["queue"]) == 1
-    assert resp8["queue"][0] == resp7["plan"]
+    assert resp8["items"] != []
+    assert len(resp8["items"]) == 1
+    assert resp8["items"][0] == resp7["plan"]
     assert resp8["running_item"] == {}
 
 
@@ -786,9 +786,9 @@ def test_zmq_api_queue_item_update_1(re_manager, replace):  # noqa F811
     assert status2["plan_history_uid"] == status1["plan_history_uid"]
 
     resp3, _ = zmq_single_request("queue_get")
-    assert resp3["queue"] != []
-    assert len(resp3["queue"]) == 1
-    assert resp3["queue"][0] == resp2["plan"]
+    assert resp3["items"] != []
+    assert len(resp3["items"]) == 1
+    assert resp3["items"][0] == resp2["plan"]
     assert resp3["running_item"] == {}
     assert resp3["plan_queue_uid"] == status2["plan_queue_uid"]
 
@@ -826,9 +826,9 @@ def test_zmq_api_queue_item_update_2_fail(re_manager, replace):  # noqa F811
                            "Item with UID 'incorrect_uid' is not in the queue"
 
     resp3, _ = zmq_single_request("queue_get")
-    assert resp3["queue"] != []
-    assert len(resp3["queue"]) == 1
-    assert resp3["queue"][0] == plan
+    assert resp3["items"] != []
+    assert len(resp3["items"]) == 1
+    assert resp3["items"][0] == plan
     assert resp3["running_item"] == {}
 
 
@@ -841,7 +841,7 @@ def test_zmq_api_queue_item_update_3_fail(re_manager, replace):  # noqa F811
     (the case of empty queue - expected to work the same as for non-empty queue)
     """
     resp1, _ = zmq_single_request("queue_get")
-    assert resp1["queue"] == []
+    assert resp1["items"] == []
     assert resp1["running_item"] == {}
 
     plan_changed = _plan1
@@ -858,7 +858,7 @@ def test_zmq_api_queue_item_update_3_fail(re_manager, replace):  # noqa F811
                            "Item with UID 'incorrect_uid' is not in the queue"
 
     resp3, _ = zmq_single_request("queue_get")
-    assert resp3["queue"] == []
+    assert resp3["items"] == []
     assert resp3["running_item"] == {}
 
 
@@ -954,8 +954,8 @@ def test_zmq_api_queue_item_get_remove_1(re_manager):  # noqa F811
     status0 = get_queue_state()
 
     resp1, _ = zmq_single_request("queue_get")
-    assert resp1["queue"] != []
-    assert len(resp1["queue"]) == 3
+    assert resp1["items"] != []
+    assert len(resp1["items"]) == 3
     assert resp1["running_item"] == {}
     assert resp1["plan_queue_uid"] == status0["plan_queue_uid"]
 
@@ -1039,7 +1039,7 @@ def test_zmq_api_queue_item_get_remove_2(re_manager, pos, pos_result, success): 
         assert "Failed to remove an item" in resp2["msg"]
 
     resp3, _ = zmq_single_request("queue_get")
-    assert len(resp3["queue"]) == (2 if success else 3)
+    assert len(resp3["items"]) == (2 if success else 3)
     assert resp3["running_item"] == {}
 
 
@@ -1053,7 +1053,7 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
         assert resp0["success"] is True
 
     resp1, _ = zmq_single_request("queue_get")
-    plans_in_queue = resp1["queue"]
+    plans_in_queue = resp1["items"]
     assert len(plans_in_queue) == 3
 
     # Get and then remove plan 2 from the queue
@@ -1170,7 +1170,7 @@ def test_zmq_api_move_plan_1(re_manager, params, src, order, success, msg):  # n
         assert resp0["success"] is True
 
     resp1, _ = zmq_single_request("queue_get")
-    queue = resp1["queue"]
+    queue = resp1["items"]
     pq_uid = resp1["plan_queue_uid"]
     assert len(queue) == 3
 
@@ -1196,7 +1196,7 @@ def test_zmq_api_move_plan_1(re_manager, params, src, order, success, msg):  # n
         # Compare the order of UIDs in the queue with the expected order
         item_uids_reordered = [item_uids[_] for _ in order]
         resp3, _ = zmq_single_request("queue_get")
-        item_uids_from_queue = [_["item_uid"] for _ in resp3["queue"]]
+        item_uids_from_queue = [_["item_uid"] for _ in resp3["items"]]
 
         assert item_uids_from_queue == item_uids_reordered
 

--- a/bluesky_queueserver/server/conversions.py
+++ b/bluesky_queueserver/server/conversions.py
@@ -334,7 +334,7 @@ def spreadsheet_to_plan_list(*, spreadsheet_file, file_name, **kwargs):  # noqa:
                 if not _is_nan(kwarg):
                     plan_kwargs[key] = kwarg
 
-            plan = {"name": plan_name}
+            plan = {"name": plan_name, "item_type": "plan"}
             if plan_args:
                 plan["args"] = plan_args
             if plan_kwargs:

--- a/bluesky_queueserver/server/tests/_common.py
+++ b/bluesky_queueserver/server/tests/_common.py
@@ -16,7 +16,7 @@ def create_excel_file_from_plan_list(tmp_path, *, plan_list, ss_filename="spread
     tmp_path : str
         temporary path
     plan_list : list(dict)
-        list of plan parameters
+        list of plan parameters. Plan parameters may contain "item_type", but it will be ignored.
     ss_filename : str
         spreadsheet file name without extension
     ss_ext : str
@@ -132,12 +132,12 @@ def create_excel_file_from_plan_list(tmp_path, *, plan_list, ss_filename="spread
 # Sample list that contains working plans. May be used to create a spreadsheet.
 # Plan with '"name": math.nan' will generate an empty line in the spreadsheet.
 plan_list_sample = [
-    {"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 10}},
-    {"name": "count", "args": [["det1"]], "kwargs": {"delay": 0.5}},
-    {"name": "count", "kwargs": {"detectors": ["det1"], "delay": 0.5}},
+    {"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 10}, "item_type": "plan"},
+    {"name": "count", "args": [["det1"]], "kwargs": {"delay": 0.5}, "item_type": "plan"},
+    {"name": "count", "kwargs": {"detectors": ["det1"], "delay": 0.5}, "item_type": "plan"},
     {"name": math.nan},
-    {"name": "scan", "args": [["det1", "det2"], "motor", -1, 1], "kwargs": {"num": 10}},
-    {"name": "scan", "args": [["det1", "det2"], "motor", -1, 1, 10]},
-    {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "delay": 0.7}},
-    {"name": "count", "args": [["det2"]], "kwargs": {"num": 2}},
+    {"name": "scan", "args": [["det1", "det2"], "motor", -1, 1], "kwargs": {"num": 10}, "item_type": "plan"},
+    {"name": "scan", "args": [["det1", "det2"], "motor", -1, 1, 10], "item_type": "plan"},
+    {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "delay": 0.7}, "item_type": "plan"},
+    {"name": "count", "args": [["det2"]], "kwargs": {"num": 2}, "item_type": "plan"},
 ]

--- a/bluesky_queueserver/server/tests/conftest.py
+++ b/bluesky_queueserver/server/tests/conftest.py
@@ -53,10 +53,10 @@ def add_plans_to_queue():
 
     user_group = "admin"
     user = "HTTP unit test setup"
-    plan1 = {"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 10, "delay": 1}}
-    plan2 = {"name": "count", "args": [["det1", "det2"]]}
+    plan1 = {"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 10, "delay": 1}, "item_type": "plan"}
+    plan2 = {"name": "count", "args": [["det1", "det2"]], "item_type": "plan"}
     for plan in (plan1, plan2, plan2):
-        resp2, _ = zmq_single_request("queue_item_add", {"plan": plan, "user": user, "user_group": user_group})
+        resp2, _ = zmq_single_request("queue_item_add", {"item": plan, "user": user, "user_group": user_group})
         assert resp2["success"] is True, str(resp2)
 
 

--- a/bluesky_queueserver/server/tests/http_custom_proc_functions.py
+++ b/bluesky_queueserver/server/tests/http_custom_proc_functions.py
@@ -10,6 +10,11 @@ def spreadsheet_to_plan_list(*, spreadsheet_file, data_type, file_name, **kwargs
     0   count  5     1
     1   count  6     0.5
 
+    NOTE: this function returns item (plan) parameters without setting 'item_type'.
+    Those items are considered plans (equivalent to ``item_type`` set as ``plan``).
+    The items in the list may also be instructions (or other item types when they
+    are supported). In this case each item should include ``item_type`` set explicitly.
+
     Parameters
     ----------
     spreadsheet_file : file

--- a/bluesky_queueserver/server/tests/test_conversions.py
+++ b/bluesky_queueserver/server/tests/test_conversions.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 import os
 import pytest
@@ -178,19 +179,25 @@ def test_spreadsheet_to_plan_list_1(tmp_path, ext):
     #   Check if types will be restored correctly (pandas write/read functions don't like columns
     #   with mixed types). Also check if all possible types are handled correctly.
     extra_plans = [
-        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": 50}},
-        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": "some_str"}},
-        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": 50.256}},
-        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": None}},
-        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": ""}},
-        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": [10, 20, 30]}},
+        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": 50}, "item_type": "plan"},
+        {"name": "count", "args": [["det2"]], "kwargs": {
+            "num": 2, "extra_param": "some_str"}, "item_type": "plan"},
+        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": 50.256}, "item_type": "plan"},
+        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": None}, "item_type": "plan"},
+        {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": ""}, "item_type": "plan"},
+        {"name": "count", "args": [["det2"]], "kwargs": {
+            "num": 2, "extra_param": [10, 20, 30]}, "item_type": "plan"},
         {"name": "count", "args": [["det2"]], "kwargs": {"num": 2, "extra_param": {
-            "p1": 10, "p2": "10", "p3": 50}}},
+            "p1": 10, "p2": "10", "p3": 50}}, "item_type": "plan"},
     ]
 
-    plan_list = plan_list_sample.copy()
+    plan_list = copy.deepcopy(plan_list_sample)  # We are going to change the plans
     for plan in extra_plans:
         plan_list.append(plan)
+
+    for plan in plan_list:
+        if isinstance(plan["name"], str):
+            plan["item_type"] = "plan"
 
     ss_path = create_excel_file_from_plan_list(tmp_path, plan_list=plan_list, ss_ext=ext)
     with open(ss_path, "rb") as f:

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -661,14 +661,14 @@ def test_http_server_plan_history(re_manager, fastapi_server):  # noqa F811
     ttime.sleep(5)
 
     resp1 = request_to_json("get", "/history/get")
-    assert len(resp1["history"]) == 3
-    assert resp1["history"][0]["name"] == "count"
+    assert len(resp1["items"]) == 3
+    assert resp1["items"][0]["name"] == "count"
 
     resp2 = request_to_json("post", "/history/clear")
     assert resp2["success"] is True
 
     resp3 = request_to_json("get", "/history/get")
-    assert resp3["history"] == []
+    assert resp3["items"] == []
 
 
 def test_http_server_manager_kill(re_manager, fastapi_server):  # noqa F811

--- a/bluesky_queueserver/server/tests/test_http_server.py
+++ b/bluesky_queueserver/server/tests/test_http_server.py
@@ -51,7 +51,7 @@ def test_http_server_status_handler(re_manager, fastapi_server):  # noqa F811
 
 def test_http_server_queue_get_handler(re_manager, fastapi_server):  # noqa F811
     resp = request_to_json("get", "/queue/get")
-    assert resp["queue"] == []
+    assert resp["items"] == []
     assert resp["running_item"] == {}
 
 
@@ -75,9 +75,9 @@ def test_http_server_queue_item_add_handler_1(re_manager, fastapi_server):  # no
     assert "item_uid" in resp1["plan"]
 
     resp2 = request_to_json("get", "/queue/get")
-    assert resp2["queue"] != []
-    assert len(resp2["queue"]) == 1
-    assert resp2["queue"][0] == resp1["plan"]
+    assert resp2["items"] != []
+    assert len(resp2["items"]) == 1
+    assert resp2["items"][0] == resp1["plan"]
     assert resp2["running_item"] == {}
 
 
@@ -121,11 +121,11 @@ def test_http_server_queue_item_add_handler_2(re_manager, fastapi_server, pos, p
 
     resp2 = request_to_json("get", "/queue/get")
 
-    assert len(resp2["queue"]) == (3 if success else 2)
+    assert len(resp2["items"]) == (3 if success else 2)
     assert resp2["running_item"] == {}
 
     if success:
-        assert resp2["queue"][pos_result]["args"] == plan2["args"]
+        assert resp2["items"][pos_result]["args"] == plan2["args"]
 
 
 def test_http_server_queue_item_add_handler_3(re_manager, fastapi_server):  # noqa F811
@@ -154,9 +154,9 @@ def test_http_server_queue_item_add_handler_3(re_manager, fastapi_server):  # no
     assert "item_uid" in resp3["plan"]
 
     resp4 = request_to_json("get", "/queue/get")
-    assert resp4["queue"] != []
-    assert len(resp4["queue"]) == 1
-    assert resp4["queue"][0] == resp3["plan"]
+    assert resp4["items"] != []
+    assert len(resp4["items"]) == 1
+    assert resp4["items"][0] == resp3["plan"]
     assert resp4["running_item"] == {}
 
 
@@ -178,10 +178,10 @@ def test_http_server_queue_item_add_handler_4(re_manager, fastapi_server):  # no
     assert resp3["success"] is True, f"resp={resp3}"
 
     resp4 = request_to_json("get", "/queue/get")
-    assert len(resp4["queue"]) == 3
-    assert resp4["queue"][0]["item_type"] == "plan"
-    assert resp4["queue"][1]["item_type"] == "instruction"
-    assert resp4["queue"][2]["item_type"] == "plan"
+    assert len(resp4["items"]) == 3
+    assert resp4["items"][0]["item_type"] == "plan"
+    assert resp4["items"][1]["item_type"] == "instruction"
+    assert resp4["items"][2]["item_type"] == "plan"
 
 
 def test_http_server_queue_item_add_handler_6_fail(re_manager, fastapi_server):  # noqa F811
@@ -233,9 +233,9 @@ def test_http_server_queue_item_update_1(re_manager, fastapi_server, replace):  
         assert resp2["plan"]["item_uid"] == uid
 
     resp3 = request_to_json("get", "/queue/get")
-    assert resp3["queue"] != []
-    assert len(resp3["queue"]) == 1
-    assert resp3["queue"][0] == resp2["plan"]
+    assert resp3["items"] != []
+    assert len(resp3["items"]) == 1
+    assert resp3["items"][0] == resp2["plan"]
     assert resp3["running_item"] == {}
 
 
@@ -269,9 +269,9 @@ def test_http_server_queue_item_update_2_fail(re_manager, fastapi_server, replac
                            "Item with UID 'incorrect_uid' is not in the queue"
 
     resp3 = request_to_json("get", "/queue/get")
-    assert resp3["queue"] != []
-    assert len(resp3["queue"]) == 1
-    assert resp3["queue"][0] == plan
+    assert resp3["items"] != []
+    assert len(resp3["items"]) == 1
+    assert resp3["items"][0] == plan
     assert resp3["running_item"] == {}
 
 
@@ -280,8 +280,8 @@ def test_http_server_queue_item_get_remove_handler_1(re_manager, fastapi_server)
     add_plans_to_queue()
 
     resp1 = request_to_json("get", "/queue/get")
-    assert resp1["queue"] != []
-    assert len(resp1["queue"]) == 3
+    assert resp1["items"] != []
+    assert len(resp1["items"]) == 3
     assert resp1["running_item"] == {}
 
     resp2 = request_to_json("post", "/queue/item/get", json={})
@@ -354,7 +354,7 @@ def test_http_server_queue_item_get_remove_handler_2(
         assert "Failed to remove an item" in resp2["msg"]
 
     resp3 = request_to_json("get", "/queue/get")
-    assert len(resp3["queue"]) == (2 if success else 3)
+    assert len(resp3["items"]) == (2 if success else 3)
     assert resp3["running_item"] == {}
 
 
@@ -368,7 +368,7 @@ def test_http_server_queue_item_get_remove_3(re_manager, fastapi_server):  # noq
     request_to_json("post", "/queue/item/add", json={"plan": _plan1})
 
     resp1 = request_to_json("get", "/queue/get")
-    plans_in_queue = resp1["queue"]
+    plans_in_queue = resp1["items"]
     assert len(plans_in_queue) == 3
 
     # Get and then remove plan 2 from the queue
@@ -474,7 +474,7 @@ def test_http_server_move_plan_1(re_manager, fastapi_server, params, src, order,
         request_to_json("post", "/queue/item/add", json={"plan": plan})
 
     resp1 = request_to_json("get", "/queue/get")
-    queue = resp1["queue"]
+    queue = resp1["items"]
     assert len(queue) == 3
 
     item_uids = [_["item_uid"] for _ in queue]
@@ -499,7 +499,7 @@ def test_http_server_move_plan_1(re_manager, fastapi_server, params, src, order,
         # Compare the order of UIDs in the queue with the expected order
         item_uids_reordered = [item_uids[_] for _ in order]
         resp3 = request_to_json("get", "/queue/get")
-        item_uids_from_queue = [_["item_uid"] for _ in resp3["queue"]]
+        item_uids_from_queue = [_["item_uid"] for _ in resp3["items"]]
 
         assert item_uids_from_queue == item_uids_reordered
 
@@ -543,7 +543,7 @@ def test_http_server_queue_start_handler(re_manager, fastapi_server):  # noqa F8
     resp2 = request_to_json("post", "/environment/open")
     assert resp2 == {"success": True, "msg": ""}
     resp2a = request_to_json("get", "/queue/get")
-    assert len(resp2a["queue"]) == 3
+    assert len(resp2a["items"]) == 3
     assert resp2a["running_item"] == {}
 
     assert wait_for_environment_to_be_created(10), "Timeout"
@@ -554,13 +554,13 @@ def test_http_server_queue_start_handler(re_manager, fastapi_server):  # noqa F8
     ttime.sleep(1)
     # The plan is currently being executed. 'get_queue' is expected to return currently executed plan.
     resp4 = request_to_json("get", "/queue/get")
-    assert len(resp4["queue"]) == 2
+    assert len(resp4["items"]) == 2
     assert resp4["running_item"]["name"] == "count"  # Check name of the running plan
 
     ttime.sleep(25)  # Wait until all plans are executed
 
     resp4 = request_to_json("get", "/queue/get")
-    assert len(resp4["queue"]) == 0
+    assert len(resp4["items"]) == 0
     assert resp2a["running_item"] == {}
 
 
@@ -599,7 +599,7 @@ def test_http_server_re_pause_continue_handlers(
     assert resp3a == {"msg": "", "success": True}
     ttime.sleep(2)  # TODO: API is needed
     resp3b = request_to_json("get", "/queue/get")
-    assert len(resp3b["queue"]) == 0  # The plan is paused, but it is not in the queue
+    assert len(resp3b["items"]) == 0  # The plan is paused, but it is not in the queue
     assert resp3b["running_item"] != {}  # Running plan is set
 
     resp4 = request_to_json("post", f"/re/{option_continue}")
@@ -609,7 +609,7 @@ def test_http_server_re_pause_continue_handlers(
 
     resp4a = request_to_json("get", "/queue/get")
     # The plan returns to the queue if it is stopped
-    assert len(resp4a["queue"]) == 0 if option_continue == "resume" else 1
+    assert len(resp4a["items"]) == 0 if option_continue == "resume" else 1
     assert resp4a["running_item"] == {}
 
 
@@ -628,7 +628,7 @@ def test_http_server_close_print_db_uids_handler(re_manager, fastapi_server):  #
     ttime.sleep(15)
 
     resp2a = request_to_json("get", "/queue/get")
-    assert len(resp2a["queue"]) == 0
+    assert len(resp2a["items"]) == 0
     assert resp2a["running_item"] == {}
 
 
@@ -637,14 +637,14 @@ def test_http_server_clear_queue_handler(re_manager, fastapi_server):  # noqa F8
     add_plans_to_queue()
 
     resp1 = request_to_json("get", "/queue/get")
-    assert len(resp1["queue"]) == 3
+    assert len(resp1["items"]) == 3
 
     resp2 = request_to_json("post", "/queue/clear")
     assert resp2["success"] is True
     assert resp2["msg"] == ""
 
     resp3 = request_to_json("get", "/queue/get")
-    assert len(resp3["queue"]) == 0
+    assert len(resp3["items"]) == 0
 
 
 def test_http_server_plan_history(re_manager, fastapi_server):  # noqa F811

--- a/bluesky_queueserver/server/tests/test_http_server_func_scope.py
+++ b/bluesky_queueserver/server/tests/test_http_server_func_scope.py
@@ -81,7 +81,7 @@ def test_http_server_queue_upload_spreasheet_1(re_manager, fastapi_server_fs, tm
     resp2 = request_to_json("get", "/queue/get")
     assert resp2["success"] is True
     assert resp2["running_item"] == {}
-    queue = resp2["queue"]
+    queue = resp2["items"]
     assert len(queue) == len(plans_expected), str(queue)
     for p, p_exp in zip(queue, plans_expected):
         for k, v in p_exp.items():
@@ -196,7 +196,7 @@ def test_http_server_queue_upload_spreasheet_4(
     resp2 = request_to_json("get", "/queue/get")
     assert resp2["success"] is True
     assert resp2["running_item"] == {}
-    queue = resp2["queue"]
+    queue = resp2["items"]
     assert len(queue) == len(plans_expected), str(queue)
     for p, p_exp in zip(queue, plans_expected):
         for k, v in p_exp.items():

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -571,8 +571,8 @@ Returns       **success**: *boolean*
                   queue size may be returned even if the operation fails. In rare failing cases
                   the parameter may return *None*.
 
-              **item_list** : *list*
-                  the list of processed items inserted item. Each item represents the dictionary
+              **item_list**: *list*
+                  the list of processed items. Each item represents the dictionary
                   with the following keys:
 
                 - **success** - boolean value indicating if the validation of the item was successful.

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -314,7 +314,7 @@ Returns       **success**: *boolean*
               **msg**: *str*
                   error message in case of failure, empty string ('') otherwise.
 
-              **history**: *list*
+              **items**: *list*
                   list of items in the plan history, each item is represented by a dictionary of
                   item parameters. Currently the plan history may contain only plans.
 
@@ -460,7 +460,7 @@ Returns       **success**: *boolean*
               **msg**: *str*
                   error message in case of failure, empty string ('') otherwise.
 
-              **queue**: *list*
+              **items**: *list*
                   list of queue items
 
               **running_item**: *dict*
@@ -486,9 +486,10 @@ Description   Add item to the queue. The item may be a plan or an instruction. B
               item is added to the back of the queue. Alternatively the item can be placed at
               the desired position in the queue or before or after one of the existing items.
 ------------  -----------------------------------------------------------------------------------------
-Parameters    **plan or instruction**: *dict*
+Parameters    **item**: *dict*
                   the dictionary of plan or instruction parameters. Plans are distinguished from
-                  instructions based on whether 'plan' or 'instruction' parameter is included.
+                  instructions based the value of the required parameter 'item_type'. Currently
+                  supported item types are 'plan' and 'instruction'.
 
               **user_group**: *str*
                   the name of the user group (e.g. 'admin').
@@ -519,9 +520,11 @@ Returns       **success**: *boolean*
                   the number of items in the plan queue after the plan was added if
                   the operation was successful, *None* otherwise
 
-              **plan** or **instruction**: *dict* (optional)
-                  the inserted item. The item contains the assigned item UID. The parameter
-                  may not be returned in case of error in processing the request.
+              **item**: *dict* or *None* (optional)
+                  the inserted item. The item contains the assigned item UID. If there is an error
+                  in processing of the parameters, the item passed with the request may be returned
+                  without modification. The value *None* may be returned if item is not contained
+                  in the request.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================
@@ -537,17 +540,16 @@ Method        **'queue_item_add_batch'**
 ------------  -----------------------------------------------------------------------------------------
 Description   Add a batch of items to the back of the queue. The batch may consist of any number
               of supported items (see **queue_item_add** method). The batch is treated as a single
-              unit. Each item in the queue must successfully pass validation before any items are added
+              unit: each item in the queue must successfully pass validation before any items are added
               to the queue. If any item fails validation, the whole batch is rejected. In case the
               batch is rejected, the function returns the detailed report for each item, including
               *success* status indicating if the item passed validation and error message in case
               validation failed.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **items**: *list*
-                  the list containing a batch of items. Each element is a dictionary representing
-                  a valid item. The dictionary must contain a key-value pair with the key representing
-                  one of the supported item types (*'plan'* or *'instruction'*) and the value being
-                  a dictionary of item parameters. An empty item list will also be accepted.
+                  the list containing a batch of items. Each element is a dictionary containing
+                  valid set of item parameters (see instructions for *queue_item_add* API).
+                  An empty item list will also be accepted.
 
               **user_group**: *str*
                   the name of the user group (e.g. 'admin').
@@ -571,18 +573,20 @@ Returns       **success**: *boolean*
                   queue size may be returned even if the operation fails. In rare failing cases
                   the parameter may return *None*.
 
-              **item_list**: *list*
-                  the list of processed items. Each item represents the dictionary
-                  with the following keys:
+              **items**: *list*
+                  the list of processed items. Each item contains inserted item (in case of success),
+                  passed item or None (in case of error). See notes for return *item* parameter
+                  for *queue_add_item* API.
+
+              **results**: *list*
+                  the list of reports for each processed item. The size of the list is equal to the
+                  size of the list returned as *items* parameter. Each element of the list is
+                  a dictionary containing the following keys:
 
                 - **success** - boolean value indicating if the validation of the item was successful.
 
                 - **msg** - error message in case validation of the item failed.
 
-                - **plan** or **instruction** (optional) - item parameters in the same form as
-                  in **queue_item_add** method. If the batch was added to the queue, the parameters for
-                  each item will contain the assigned *'item_uid'*. The item parameters may be missing
-                  if there is an error in processing of the item.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================
@@ -600,16 +604,17 @@ Description   Update the existing item in the queue. The method is intended for 
               but may be used for replacing the existing items with completely different ones.
               The updated item may be a plan or an instruction. The item parameter 'item_uid' must
               be set to a UID of an existing queue item that is expected to be replaced. The method
-              fails if the item is not found. By default, the UID of the updated item is not changed
+              fails if the item UID is not found. By default, the UID of the updated item is not changed
               and 'user' and 'user_group' parameters are set to the values provided in the request.
               The 'user_group' is also used for validation of submitted item. If it is preferable
               to replace the item UID with a new random UID (e.g. if the item is replaced with
               completely different item), the method should be called with the optional parameter
               'replace=True'.
 ------------  -----------------------------------------------------------------------------------------
-Parameters    **plan or instruction**: *dict*
+Parameters    **item**: *dict*
                   the dictionary of plan or instruction parameters. Plans are distinguished from
-                  instructions based on whether 'plan' or 'instruction' parameter is included.
+                  instructions based the value of the required parameter 'item_type'. Currently
+                  supported item types are 'plan' and 'instruction'.
 
               **user_group**: *str*
                   the name of the user group (e.g. 'admin').
@@ -633,10 +638,11 @@ Returns       **success**: *boolean*
                   the number of items in the plan queue after the plan was added if
                   the operation was successful, *None* otherwise
 
-              **plan** or **instruction**: *dict* (optional)
-                  the updated item. The item contains the new item UID if the method was called with
-                  'replace=True'. The parameter may not be returned in case of error in processing
-                  the request.
+              **item**: *dict* or *None* (optional)
+                  the inserted item. The item contains the assigned item UID. If there is an error
+                  in processing of the parameters, the item passed with the request may be returned
+                  without modification. The value *None* may be returned if item is not contained
+                  in the request.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -521,10 +521,9 @@ Returns       **success**: *boolean*
                   the operation was successful, *None* otherwise
 
               **item**: *dict* or *None* (optional)
-                  the inserted item. The item contains the assigned item UID. If there is an error
-                  in processing of the parameters, the item passed with the request may be returned
-                  without modification. The value *None* may be returned if item is not contained
-                  in the request.
+                  the inserted item. The item contains the assigned item UID. In case of error
+                  the item may be returned without modification (with assigned UID). *None* will be
+                  returned if request does not contain item parameters.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================
@@ -569,7 +568,7 @@ Returns       **success**: *boolean*
                   error message in case of failure, empty string ('') otherwise.
 
               **qsize**: *int* or *None*
-                  the number of items in the plan queue after processing of the request. The correct
+                  the number of items in the plan queue after processing the request. The correct
                   queue size may be returned even if the operation fails. In rare failing cases
                   the parameter may return *None*.
 
@@ -639,10 +638,9 @@ Returns       **success**: *boolean*
                   the operation was successful, *None* otherwise
 
               **item**: *dict* or *None* (optional)
-                  the inserted item. The item contains the assigned item UID. If there is an error
-                  in processing of the parameters, the item passed with the request may be returned
-                  without modification. The value *None* may be returned if item is not contained
-                  in the request.
+                  the inserted item. The item contains the assigned item UID. In case of error
+                  the item may be returned without modification (with assigned UID). *None* will be
+                  returned if request does not contain item parameters.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================


### PR DESCRIPTION
Modification to 0MQ API functions to improve consistency of names and representation API parameters. See issue https://github.com/bluesky/bluesky-queueserver/issues/143 for details.

The PR contains changes that will break existing code:

- `queue_get` returns the list of items in the queue as parameter `items` instead of  `queue`;

- `history_get` returns the list of items in history as parameter `items` instead of  `history`;

- `queue_item_add` and `queue_item_update` accept items of all types as parameter `item` (used to be parameter name `plan` and `instruction` depending on the item type;

- item parameters accepted by functions `queue_item_add`, `queue_item_update` and `queue_item_add_batch` now include required parameter `item_type` which can take values `plan` or `instruction` depending on the item type.

- `queue_item_add` and `queue_item_update` return the inserted item as `item` instead of `plan` or `instruction`. The functions may return `item` value `None` if item parameters are not detected in the request.

- `queue_item_add_batch` accepts the list of items (dictionaries of item parameters) as the value of parameter `items` and return the list of inserted parameters as parameter `items` and the list of validation reports (`"success"` and `"msg"`) as the value of parameter `results`.

- `qserver` CLI interface was not changed. `item_type` may be included with the items added using CLI tool, but it will be ignored. The returned parameter names (printed in the terminal) reflect changes to API.

Addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/143