### PR TITLE
Option to set custom 0MQ address for communication between HTTP Server and RE Manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,12 @@ The Web Server should be started from the second shell as follows::
 
   uvicorn bluesky_queueserver.server.server:app --host localhost --port 60610
 
+The Web Server connects to RE Manager using Zero MQ. The default ZMQ address is 'tcp://localhost:60615'.
+A different ZMQ address may be passed to the Web Server by setting *QSERVER_ZMQ_ADDRESS* environment
+variable before starting the server::
+
+  export QSERVER_ZMQ_ADDRESS='tcp://localhost:60615'
+
 The Web Server supports using external modules for processing some requests. Those modules
 are optional and may contain custom instrument-specific processing code. The name of the external
 module may be passed to HTTP server by setting **BLUESKY_HTTPSERVER_CUSTOM_MODULE** environment

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ The Web Server should be started from the second shell as follows::
   uvicorn bluesky_queueserver.server.server:app --host localhost --port 60610
 
 The Web Server connects to RE Manager using Zero MQ. The default ZMQ address is 'tcp://localhost:60615'.
-A different ZMQ address may be passed to the Web Server by setting *QSERVER_ZMQ_ADDRESS* environment
+A different ZMQ address may be passed to the Web Server by setting the *QSERVER_ZMQ_ADDRESS* environment
 variable before starting the server::
 
   export QSERVER_ZMQ_ADDRESS='tcp://localhost:60615'
@@ -460,4 +460,3 @@ is to test handling of communication timeouts, since RE Manager does not respond
 
   qserver manager kill test
   http POST http://localhost:60610/test/manager/kill
-

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -790,7 +790,8 @@ class RunEngineManager(Process):
         """
         Returns status of the manager.
         """
-        logger.info("Processing 'status' request ...")
+        # Status is expected to be requested very often. Print the message only in the debug mode.
+        logger.debug("Processing 'status' request ...")
 
         # Computed/retrieved data
         n_pending_items = await self._plan_queue.get_queue_size()

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -207,7 +207,7 @@ def start_manager():
         dest="zmq_addr",
         type=str,
         default="tcp://*:60615",
-        help="The address of ZMQ server (control connection).",
+        help="The address of ZMQ server (control connection), e.g. 'tcp://*:60615.'",
     )
 
     group = parser.add_mutually_exclusive_group()

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -207,7 +207,7 @@ def start_manager():
         dest="zmq_addr",
         type=str,
         default="tcp://*:60615",
-        help="The address of ZMQ server (control connection), e.g. 'tcp://*:60615.'",
+        help="The address of ZMQ server (control connection), e.g. 'tcp://*:60615'.",
     )
 
     group = parser.add_mutually_exclusive_group()

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -44,8 +44,12 @@ async def startup_event():
 
     # TODO: implement nicer exit with error reporting in case of failure
 
+    zmq_server_address = os.getenv("QSERVER_ZMQ_ADDRESS", None)
+
     # ZMQCommSendAsync should be created from the event loop of FastAPI server.
-    zmq_to_manager = ZMQCommSendAsync(raise_exceptions=False, server_public_key=zmq_public_key)
+    zmq_to_manager = ZMQCommSendAsync(
+        raise_exceptions=False, server_public_key=zmq_public_key, zmq_server_address=zmq_server_address
+    )
 
     # Import module with custom code
     module_name = os.getenv("BLUESKY_HTTPSERVER_CUSTOM_MODULE", None)


### PR DESCRIPTION
Implemented an option to pass custom RE Manager 0MQ address to HTTP Server by setting the environment variable `QSERVER_ZMQ_ADDRESS`, e.g.

```
export QSERVER_ZMQ_ADDRESS='tcp://localhost:60615'
```
Unit tests for operation of RE Manager and HTTP Server using 0MQ address different from default.

Additional changes:

- Changed log level for message acknowledging request of RE Manager status to `debug` (to clear the log).

Addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/148