### PR TITLE
Generate new item UIDs for failed and stopped items that are pushed back into the plan queue

### DIFF
--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -68,7 +68,16 @@ class PlanQueueOperations:
 
         # The list of allowed item parameters. The new inserted items are filtered and
         #   only the parameters from this list are left.
-        self._allowed_item_parameters = ("item_uid", "item_type", "name", "args", "kwargs", "meta")
+        self._allowed_item_parameters = (
+            "item_uid",
+            "item_type",
+            "name",
+            "args",
+            "kwargs",
+            "meta",
+            "user",
+            "user_group",
+        )
 
         # Plan queue UID is expected to change each time the contents of the queue is changed.
         #   Since `self._uid_dict` is modified each time the queue is updated, it is sufficient
@@ -692,7 +701,7 @@ class PlanQueueOperations:
         """
         Remove parameters that are not in the list of allowed parameters.
         Current parameter list includes parameters ``item_type``, ``item_uid``,
-        ``name``, ``args``, ``kwargs``, ``meta``.
+        ``name``, ``args``, ``kwargs``, ``meta``, ``user``, ``user_group``.
 
         The list does not include ``result`` parameter, i.e. ``result`` will
         be removed from the list of parameters.

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -346,15 +346,15 @@ class PlanQueueOperations:
         """
         return uid in self._uid_dict
 
-    def _uid_dict_add(self, plan):
+    def _uid_dict_add(self, item):
         """
         Add UID to ``self._uid_dict``.
         """
-        uid = plan["item_uid"]
+        uid = item["item_uid"]
         if self._is_uid_in_dict(uid):
             raise RuntimeError(f"Trying to add plan with UID '{uid}', which is already in the queue")
         self._plan_queue_uid = self.new_item_uid()
-        self._uid_dict.update({uid: plan})
+        self._uid_dict.update({uid: item})
 
     def _uid_dict_remove(self, uid):
         """
@@ -365,15 +365,15 @@ class PlanQueueOperations:
         self._plan_queue_uid = self.new_item_uid()
         self._uid_dict.pop(uid)
 
-    def _uid_dict_update(self, plan):
+    def _uid_dict_update(self, item):
         """
         Update a plan with UID that is already in the dictionary.
         """
-        uid = plan["item_uid"]
+        uid = item["item_uid"]
         if not self._is_uid_in_dict(uid):
             raise RuntimeError(f"Trying to update plan with UID '{uid}', which is not in the queue")
         self._plan_queue_uid = self.new_item_uid()
-        self._uid_dict.update({uid: plan})
+        self._uid_dict.update({uid: item})
 
     def _uid_dict_get_item(self, uid):
         """

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -1339,4 +1339,10 @@ def test_set_processed_item_as_stopped(pq):
         plan_history_expected[1]["item_uid"] = plan_modified_uid
         assert plan_history == plan_history_expected
 
+        # Verify that `_uid_dict` still has correct size. `_uid_dict` should never be accessed directly.
+        assert len(pq._uid_dict) == 3
+        # Also it should not contain UIDs of already executed plans.
+        for plan in plan_history:
+            assert plan["item_uid"] not in pq._uid_dict
+
     asyncio.run(testing())


### PR DESCRIPTION
Change the queue behavior so that new UID is generated for the item before it is pushed into the queue in case a plan is stopped or failed. This prevents multiple execution attempts of a plan with the same item UID and guarantees that the plan history contains items with unique UIDs. 

Additional changes:
- Filtering of plan parameters: all added queue items are passed through the filter that removes all item parameters that are not included in the list. The purpose of the filtering is to make sure that the items do not contain unsupported parameters and to remove 'result' parameter that may be present in the items that are copied from history or were pushed back into the queue after they were stopped or if their execution failed. All operations on the items except `move` operations within the queue are expected to include filtering. Already existing items are moved within the queue without filtering (i.e. `result` parameter will be preserved). The work on the feature is incomplete: unit tests will be done in the next PR.

Addresses issue https://github.com/bluesky/bluesky-queueserver/issues/154
Partially addresses issue https://github.com/bluesky/bluesky-queueserver/issues/153