### PR TITLE
ENH: filtering of parameters during operations with queue items

### DIFF
--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -66,8 +66,8 @@ class PlanQueueOperations:
         self._name_plan_history = "plan_history"
         self._name_plan_queue_mode = "plan_queue_mode"
 
-        # The list of allowed item parameters. The new inserted items are filtered and
-        #   only the parameters from this list are left.
+        # The list of allowed item parameters used for parameter filtering. Filtering operation
+        #   involves removing all parameters that are not in the list.
         self._allowed_item_parameters = (
             "item_uid",
             "item_type",

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -68,7 +68,16 @@ class PlanQueueOperations:
 
         # The list of allowed item parameters. The new inserted items are filtered and
         #   only the parameters from this list are left.
-        self._allowed_item_parameters = ("item_uid", "item_type", "name", "args", "kwargs", "meta")
+        self._allowed_item_parameters = (
+            "item_uid",
+            "item_type",
+            "name",
+            "args",
+            "kwargs",
+            "meta",
+            "user",
+            "user_group",
+        )
 
         # Plan queue UID is expected to change each time the contents of the queue is changed.
         #   Since `self._uid_dict` is modified each time the queue is updated, it is sufficient
@@ -692,7 +701,7 @@ class PlanQueueOperations:
         """
         Remove parameters that are not in the list of allowed parameters.
         Current parameter list includes parameters ``item_type``, ``item_uid``,
-        ``name``, ``args``, ``kwargs``, ``meta``.
+        ``name``, ``args``, ``kwargs``, ``meta``, ``user``, ``user_group``.
 
         The list does not include ``result`` parameter, i.e. ``result`` will
         be removed from the list of parameters.

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -346,15 +346,15 @@ class PlanQueueOperations:
         """
         return uid in self._uid_dict
 
-    def _uid_dict_add(self, plan):
+    def _uid_dict_add(self, item):
         """
         Add UID to ``self._uid_dict``.
         """
-        uid = plan["item_uid"]
+        uid = item["item_uid"]
         if self._is_uid_in_dict(uid):
             raise RuntimeError(f"Trying to add plan with UID '{uid}', which is already in the queue")
         self._plan_queue_uid = self.new_item_uid()
-        self._uid_dict.update({uid: plan})
+        self._uid_dict.update({uid: item})
 
     def _uid_dict_remove(self, uid):
         """
@@ -365,15 +365,15 @@ class PlanQueueOperations:
         self._plan_queue_uid = self.new_item_uid()
         self._uid_dict.pop(uid)
 
-    def _uid_dict_update(self, plan):
+    def _uid_dict_update(self, item):
         """
         Update a plan with UID that is already in the dictionary.
         """
-        uid = plan["item_uid"]
+        uid = item["item_uid"]
         if not self._is_uid_in_dict(uid):
             raise RuntimeError(f"Trying to update plan with UID '{uid}', which is not in the queue")
         self._plan_queue_uid = self.new_item_uid()
-        self._uid_dict.update({uid: plan})
+        self._uid_dict.update({uid: item})
 
     def _uid_dict_get_item(self, uid):
         """

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -2,6 +2,7 @@ import asyncio
 import pytest
 import json
 import copy
+import pprint
 from bluesky_queueserver.manager.plan_queue_ops import PlanQueueOperations
 
 
@@ -22,8 +23,9 @@ def pq():
 # fmt: off
 @pytest.mark.parametrize("item_in, item_out", [
     ({"name": "plan1", "item_uid": "abcde"}, {"name": "plan1", "item_uid": "abcde"}),
+    ({"user": "user1", "user_group": "group1"}, {"user": "user1", "user_group": "group1"}),
     ({"args": [1, 2], "kwargs": {"a": 1, "b": 2}}, {"args": [1, 2], "kwargs": {"a": 1, "b": 2}}),
-    ({"name": "plan1", "meta": {"md1": 1, "md2": 2}}, {"name": "plan1", "meta": {"md1": 1, "md2": 2}}),
+    ({"item_type": "plan", "meta": {"md1": 1, "md2": 2}}, {"item_type": "plan", "meta": {"md1": 1, "md2": 2}}),
     ({"name": "plan1", "result": {}}, {"name": "plan1"}),
 ])
 # fmt: on
@@ -596,10 +598,9 @@ def test_add_item_to_queue_2(pq):
 
 @pytest.mark.parametrize("filter_params", [False, True])
 def test_add_item_to_queue_3(pq, filter_params):
-    async def add_plan(plan, n, **kwargs):
-        plan_added, qsize = await pq.add_item_to_queue(plan, **kwargs)
-        assert plan_added["name"] == plan["name"], f"plan: {plan}"
-        assert qsize == n, f"plan: {plan}"
+    """
+    Test if parameter filtering works as expected with `add_item_to_queue` function.
+    """
 
     async def testing():
 
@@ -743,7 +744,71 @@ def test_replace_item_2(pq):
     asyncio.run(testing())
 
 
-def test_replace_item_3_failing(pq):
+# fmt: off
+@pytest.mark.parametrize("mode", ["exact_copy", "change_uid", "change_plan"])
+# fmt: on
+def test_replace_item_3(pq, mode):
+    """
+    ``PlanQueueOperations.replace_item()`` function: make sure that filtering
+      is applied to the parameters of edited plan if the plan was changed
+    """
+
+    async def testing():
+        plans = [{"name": "a", "result": {}}, {"name": "b"}, {"name": "c"}]
+
+        for n, plan in enumerate(plans):
+            await pq.add_item_to_queue(plan, filter_parameters=False)
+
+        assert await pq.get_queue_size() == 3
+
+        queue, _ = await pq.get_queue()
+        plan0_before = queue[0]
+        assert "result" in plan0_before
+
+        if mode == "exact_copy":
+            # Replace the plan with the exact copy of it. Filtering is not be applied.
+            plan_new = plan0_before
+            plan_replaced, qsize = await pq.replace_item(plan_new, item_uid=plan_new["item_uid"])
+
+            queue, _ = await pq.get_queue()
+            plan0_after = queue[0]
+
+            assert plan_replaced == plan0_after
+            assert "result" in plan_replaced, pprint.pformat(plan_replaced)
+
+        elif mode == "change_uid":
+            # Modify plan UID. Filtering is applied
+            plan_new = plan0_before
+            item_uid_to_replace = plan_new["item_uid"]
+            plan_new = pq.set_new_item_uuid(plan_new)
+            plan_replaced, qsize = await pq.replace_item(plan_new, item_uid=item_uid_to_replace)
+
+            queue, _ = await pq.get_queue()
+            plan0_after = queue[0]
+
+            assert plan_replaced == plan0_after
+            assert "result" not in plan_replaced, pprint.pformat(plan_replaced)
+
+        elif mode == "change_plan":
+            # Modify plan, keep UID the same. Filtering is applied
+            plan_new = plan0_before
+            new_name = "h"
+            plan_new["name"] = new_name
+            plan_replaced, qsize = await pq.replace_item(plan_new, item_uid=plan_new["item_uid"])
+
+            queue, _ = await pq.get_queue()
+            plan0_after = queue[0]
+
+            assert plan_replaced == plan0_after
+            assert "result" not in plan_replaced, pprint.pformat(plan_replaced)
+
+        else:
+            raise Exception(f"Test mode '{mode}' does not exist.")
+
+    asyncio.run(testing())
+
+
+def test_replace_item_4_failing(pq):
     """
     ``PlanQueueOperations.replace_item()`` - failing cases
     """

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -1339,4 +1339,10 @@ def test_set_processed_item_as_stopped(pq):
         plan_history_expected[1]["item_uid"] = plan_modified_uid
         assert plan_history == plan_history_expected
 
+        # Verify that `_uid_dict` still has correct size. `_uid_dict` should never be accessed directly.
+        assert len(pq._uid_dict) == 3
+        # Also it should not contain UIDs of already executed plans.
+        for plan in plan_history:
+            assert plan["item_uid"] not in pq._uid_dict
+
     asyncio.run(testing())

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -951,6 +951,41 @@ def test_move_item_1(pq, params, src, order, success, pquid_changed, msg):
     asyncio.run(testing())
 
 
+def test_move_item_2(pq):
+    """
+    ``move_item``: test if the item is moved 'as is', i.e. no parameter filtering is applied to it.
+    """
+
+    async def testing():
+        plans = [
+            {"item_uid": "p1", "name": "a", "result": {}},
+            {"item_uid": "p2", "name": "b"},
+            {"item_uid": "p3", "name": "c"},
+        ]
+
+        for plan in plans:
+            await pq.add_item_to_queue(plan, filter_parameters=False)
+
+        queue, _ = await pq.get_queue()
+        assert await pq.get_queue_size() == 3
+        assert "result" in queue[0]
+
+        uid_src = queue[0]["item_uid"]
+        uid_dest = queue[1]["item_uid"]
+
+        await pq.move_item(uid=uid_src, after_uid=uid_dest)
+
+        queue, _ = await pq.get_queue()
+        assert await pq.get_queue_size() == 3
+        # Make sure that the items were rearranged
+        assert queue[0]["item_uid"] == uid_dest, pprint.pformat(queue)
+        assert queue[1]["item_uid"] == uid_src, pprint.pformat(queue)
+        # Make sure that the 'result' parameter was not removed
+        assert "result" in queue[1]
+
+    asyncio.run(testing())
+
+
 # fmt: off
 @pytest.mark.parametrize("pos, name", [
     ("front", "a"),


### PR DESCRIPTION
Modifications to the code that controls the item queue so that all operations except moving items within the queue involve the step of filtering of parameters. The filtering involves removing of all parameters that are not in the list of allowed parameters. The list of allowed parameters is an attribute of the `PlanQueueOperations._allowed_item_parameters`:

```
        # The list of allowed item parameters used for parameter filtering. Filtering operation
        #   involves removing all parameters that are not in the list.
        self._allowed_item_parameters = (
            "item_uid",
            "item_type",
            "name",
            "args",
            "kwargs",
            "meta",
            "user",
            "user_group",
        )
```
The function `PlanQueueOperations._add_item_to_queue()` has additional optional parameter `filter_parameters` with default value of `True`. If the function is called with `filter_parameters=False`, the parameter filtering is skipped. Currently it is not expected that the option of skipping the parameter filtering step will be used outside the class.

Most of the functionality is implemented as part of PR https://github.com/bluesky/bluesky-queueserver/pull/158. This PR includes additional unit tests and minor code modifications.

Addresses issue https://github.com/bluesky/bluesky-queueserver/issues/153