### PR TITLE
Include all items of types inherited from `OphydObject` into the list of devices

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -427,24 +427,25 @@ def plans_from_nspace(nspace):
 
 def devices_from_nspace(nspace):
     """
-    Extract devices from the namespace. Currently the function returns the dict of ophyd.Device objects.
+    Extract signals and devices from the namespace. Currently the function returns the dict of
+    namespace items of types inherited from ophyd.ophydobj.OphydObject objects.
 
     Parameters
     ----------
     nspace: dict
-        Namespace that may contain plans.
+        Namespace that may contain plans and devices.
 
     Returns
     -------
     dict(str: callable)
-        Dictionary of devices.
+        Dictionary that maps device names to device objects.
     """
     import ophyd
 
     devices = {}
-    for item in nspace.items():
-        if isinstance(item[1], ophyd.Device):
-            devices[item[0]] = item[1]
+    for name, obj in nspace.items():
+        if isinstance(obj, ophyd.ophydobj.OphydObject):
+            devices[name] = obj
     return devices
 
 

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -1031,7 +1031,11 @@ def test_devices_from_nspace():
     nspace = load_profile_collection(pc_path)
     devices = devices_from_nspace(nspace)
     for name, device in devices.items():
-        assert isinstance(device, ophyd.Device), f"The object '{device}' is not an Ophyd device"
+        assert isinstance(device, ophyd.ophydobj.OphydObject), f"The object '{device}' is not an Ophyd Object"
+
+    # Check that both devices and signals are recognized by the function
+    assert "custom_test_device" in devices
+    assert "custom_test_signal" in devices
 
 
 @pytest.mark.parametrize(

--- a/bluesky_queueserver/profile_collection_sim/99-custom.py
+++ b/bluesky_queueserver/profile_collection_sim/99-custom.py
@@ -7,6 +7,11 @@ import bluesky.plan_stubs as bps
 from bluesky_queueserver.manager.annotation_decorator import parameter_annotation_decorator
 
 
+# Ophyd Device and Signal: Used in unit tests.
+custom_test_device = ophyd.Device(name="custom_test_device")
+custom_test_signal = ophyd.Signal(name="custom_test_signal")
+
+
 @parameter_annotation_decorator(
     {
         "description": "Move motors into positions; then count dets.",

--- a/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
+++ b/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
@@ -4,6 +4,18 @@ existing_devices:
     classname: ABDetector
     is_movable: false
     module: ophyd.sim
+  bool_sig:
+    classname: Signal
+    is_movable: true
+    module: ophyd.signal
+  custom_test_device:
+    classname: Device
+    is_movable: false
+    module: ophyd.device
+  custom_test_signal:
+    classname: Signal
+    is_movable: true
+    module: ophyd.signal
   det:
     classname: SynGauss
     is_movable: false
@@ -47,6 +59,18 @@ existing_devices:
   identical_det:
     classname: SynGauss
     is_movable: false
+    module: ophyd.sim
+  img:
+    classname: SynSignalWithRegistry
+    is_movable: true
+    module: ophyd.sim
+  invariant1:
+    classname: InvariantSignal
+    is_movable: true
+    module: ophyd.sim
+  invariant2:
+    classname: InvariantSignal
+    is_movable: true
     module: ophyd.sim
   jittery_motor1:
     classname: SynAxis
@@ -102,6 +126,22 @@ existing_devices:
     module: ophyd.sim
   pseudo3x3:
     classname: SPseudo3x3
+    is_movable: true
+    module: ophyd.sim
+  rand:
+    classname: SynPeriodicSignal
+    is_movable: true
+    module: ophyd.sim
+  rand2:
+    classname: SynPeriodicSignal
+    is_movable: true
+    module: ophyd.sim
+  sig:
+    classname: Signal
+    is_movable: true
+    module: ophyd.signal
+  signal:
+    classname: SynSignal
     is_movable: true
     module: ophyd.sim
 existing_plans:


### PR DESCRIPTION
In the original code the list of devices was generated by picking objects that are subclasses of `ophyd.Device`. In this PR, the criteria for selection of devices is changed to include all types inherited from `OphydObject`. The list of devices will include all objects that are subclassed from `ophyd.Device` and `ophyd.Signal`. Any objects of custom types inherited from `OphydObject` will be also included.