### PR TITLE
ENH: use 'bluesky.abc' to identify devices in the workspace

### DIFF
--- a/bluesky_queueserver/manager/_abc.py
+++ b/bluesky_queueserver/manager/_abc.py
@@ -1,0 +1,152 @@
+# ===============================================================================================
+#   This module is temporarily used by the Queue Server code.
+#   Do not import anything from this module!
+#
+#   The code in this file is vendored from 'bluesky.abc' module. This module will be removed
+#   once the respective Bluesky PR is merged and the new version of Bluesky that supporting
+#   'bluesky.abc' is released and widely deployed. It is not intended to replace 'bluesky.abc'.
+# ===============================================================================================
+
+try:
+    from typing import Protocol, runtime_checkable
+except ImportError:
+    from typing_extensions import Protocol, runtime_checkable
+
+from typing import Dict, Any, Optional, Callable, Generator, NoReturn
+
+
+Configuration = Dict[str, Dict[str, Any]]
+
+
+@runtime_checkable
+class Status(Protocol):
+    done: bool
+    success: bool
+
+    def add_callback(self, callback: Callable[["Status"], NoReturn]) -> NoReturn:
+        """Add a callback function to be called upon completion.
+        The function must take the status as an argument.
+        If the Status object is done when the function is added, it should be
+        called immediately.
+        """
+        ...
+
+
+@runtime_checkable
+class Readable(Protocol):
+    name: str
+
+    @property
+    def parent(self) -> Optional[Any]:
+        """``None``, or a reference to a parent device."""
+        ...
+
+    @property
+    def hints(self) -> Dict:
+        """A dictionary of suggestions for best-effort visualization and processing.
+        This does not affect what data is read or saved; it is only
+        a suggestion to enable automated tools to provide helpful information
+        with minimal guidance from the user. See :ref:`hints`.
+        """
+        ...
+
+    def trigger(self) -> Status:
+        """Return a ``Status`` that is marked done when the device is done triggering.
+        If the device does not need to be triggered, simply return a ``Status``
+        that is marked done immediately.
+        """
+        ...
+
+    def read(self) -> Configuration:
+        """Return an OrderedDict mapping field name(s) to values and timestamps.
+        The field names must be strings. The values can be any JSON-encodable
+        type or a numpy array, which the RunEngine will convert to (nested)
+        lists. The timestamps should be UNIX time (seconds since 1970).
+        Example return value:
+        .. code-block:: python
+            OrderedDict(('channel1',
+                         {'value': 5, 'timestamp': 1472493713.271991}),
+                         ('channel2',
+                         {'value': 16, 'timestamp': 1472493713.539238}))
+        """
+        ...
+
+    def describe(self) -> Configuration:
+        """Return an OrderedDict with exactly the same keys as the ``read``
+        method, here mapped to metadata about each field.
+        Example return value:
+        .. code-block:: python
+            OrderedDict(('channel1',
+                         {'source': 'XF23-ID:SOME_PV_NAME',
+                          'dtype': 'number',
+                          'shape': []}),
+                        ('channel2',
+                         {'source': 'XF23-ID:SOME_PV_NAME',
+                          'dtype': 'number',
+                          'shape': []}))
+        We refer to each entry as a "data key." These fields are required:
+        * source (a descriptive string --- e.g., an EPICS Process Variable)
+        * dtype: one of the JSON data types: {'number', 'string', 'array'}
+        * shape: list of integers (dimension sizes) --- e.g., ``[5, 5]`` for a
+          5x5 array. Use empty list ``[]`` to indicate a scalar.
+        Optional additional fields (precision, units, etc.) are allowed.
+        The optional field ``external`` should be used to provide information
+        about references to externally-stored data, such as large image arrays.
+        """
+        ...
+
+    def read_configuration(self) -> Configuration:
+        """Same API as ``read`` but for slow-changing fields related to configuration.
+        (e.g., exposure time)
+        These will typically be read only once per run.
+        Of course, for simple cases, you can effectively omit this complexity
+        by returning an empty dictionary.
+        """
+        ...
+
+    def describe_configuration(self) -> Configuration:
+        """Same API as ``describe``, but corresponding to the keys in ``read_configuration``."""
+        ...
+
+
+@runtime_checkable
+class Flyable(Protocol):
+    name: str
+
+    @property
+    def parent(self) -> Optional[Any]:
+        """``None``, or a reference to a parent device."""
+        ...
+
+    def kickoff(self) -> Status:
+        """Begin acculumating data.
+        Return a ``Status`` and mark it done when acqusition has begun.
+        """
+        ...
+
+    def complete(self) -> Status:
+        """Return a ``Status`` and mark it done when acquisition has completed."""
+        ...
+
+    def collect(self) -> Generator[Dict[str, Any], None, None]:
+        """Yield dictionaries that are partial Event documents.
+        They should contain the keys 'time', 'data', and 'timestamps'.
+        A 'uid' is added by the RunEngine.
+        """
+        ...
+
+    def describe_collect(self) -> Dict[str, Configuration]:
+        """This is like ``describe()`` on readable devices, but with an extra layer of nesting.
+        Since a flyer can potentially return more than one event stream, this is a dict
+        of stream names (strings) mapped to a ``describe()``-type output for each.
+        """
+        ...
+
+    # Remaining same as Readable
+    def read_configuration(self) -> Configuration:
+        """Same as for a Readable device."""
+        ...
+
+    def describe_configuration(self) -> Configuration:
+        """Same as for a Readable device."""
+        ...

--- a/bluesky_queueserver/manager/_protocols.py
+++ b/bluesky_queueserver/manager/_protocols.py
@@ -2,9 +2,9 @@
 #   This module is temporarily used by the Queue Server code.
 #   Do not import anything from this module!
 #
-#   The code in this file is vendored from 'bluesky.abc' module. This module will be removed
+#   The code in this file is vendored from 'bluesky.protocols' module. This module will be removed
 #   once the respective Bluesky PR is merged and the new version of Bluesky that supporting
-#   'bluesky.abc' is released and widely deployed. It is not intended to replace 'bluesky.abc'.
+#   'bluesky.protocols' is released and widely deployed.
 # ===============================================================================================
 
 try:

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -440,11 +440,11 @@ def devices_from_nspace(nspace):
     dict(str: callable)
         Dictionary that maps device names to device objects.
     """
-    import ophyd
+    from bluesky import abc
 
     devices = {}
     for name, obj in nspace.items():
-        if isinstance(obj, ophyd.ophydobj.OphydObject):
+        if isinstance(obj, (abc.Readable, abc.Flyable)):
             devices[name] = obj
     return devices
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -440,7 +440,10 @@ def devices_from_nspace(nspace):
     dict(str: callable)
         Dictionary that maps device names to device objects.
     """
-    from bluesky import abc
+    try:
+        from bluesky import abc
+    except ImportError:
+        import bluesky_queueserver.manager._abc as abc
 
     devices = {}
     for name, obj in nspace.items():

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -441,13 +441,13 @@ def devices_from_nspace(nspace):
         Dictionary that maps device names to device objects.
     """
     try:
-        from bluesky import abc
+        from bluesky import protocols
     except ImportError:
-        import bluesky_queueserver.manager._abc as abc
+        import bluesky_queueserver.manager._protocols as protocols
 
     devices = {}
     for name, obj in nspace.items():
-        if isinstance(obj, (abc.Readable, abc.Flyable)):
+        if isinstance(obj, (protocols.Readable, protocols.Flyable)):
             devices[name] = obj
     return devices
 

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -7,7 +7,11 @@ import typing
 import subprocess
 import pprint
 import sys
-from bluesky import abc
+
+try:
+    from bluesky import abc
+except ImportError:
+    import bluesky_queueserver.manager._abc as abc
 
 import ophyd
 

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -9,9 +9,9 @@ import pprint
 import sys
 
 try:
-    from bluesky import abc
+    from bluesky import protocols
 except ImportError:
-    import bluesky_queueserver.manager._abc as abc
+    import bluesky_queueserver.manager._protocols as protocols
 
 import ophyd
 
@@ -1036,7 +1036,9 @@ def test_devices_from_nspace():
     nspace = load_profile_collection(pc_path)
     devices = devices_from_nspace(nspace)
     for name, device in devices.items():
-        assert isinstance(device, (abc.Readable, abc.Flyable)), f"The object '{device}' is not a device"
+        assert isinstance(
+            device, (protocols.Readable, protocols.Flyable)
+        ), f"The object '{device}' is not a device"
 
     # Check that both devices and signals are recognized by the function
     assert "custom_test_device" in devices

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -7,6 +7,7 @@ import typing
 import subprocess
 import pprint
 import sys
+from bluesky import abc
 
 import ophyd
 
@@ -1031,7 +1032,7 @@ def test_devices_from_nspace():
     nspace = load_profile_collection(pc_path)
     devices = devices_from_nspace(nspace)
     for name, device in devices.items():
-        assert isinstance(device, ophyd.ophydobj.OphydObject), f"The object '{device}' is not an Ophyd Object"
+        assert isinstance(device, (abc.Readable, abc.Flyable)), f"The object '{device}' is not a device"
 
     # Check that both devices and signals are recognized by the function
     assert "custom_test_device" in devices

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -1037,6 +1037,7 @@ def test_devices_from_nspace():
     # Check that both devices and signals are recognized by the function
     assert "custom_test_device" in devices
     assert "custom_test_signal" in devices
+    assert "custom_test_flyer" in devices
 
 
 @pytest.mark.parametrize(

--- a/bluesky_queueserver/profile_collection_sim/99-custom.py
+++ b/bluesky_queueserver/profile_collection_sim/99-custom.py
@@ -7,10 +7,10 @@ import bluesky.plan_stubs as bps
 from bluesky_queueserver.manager.annotation_decorator import parameter_annotation_decorator
 
 
-# Ophyd Device and Signal: Used in unit tests.
+# Some useless devices for unit tests.
 custom_test_device = ophyd.Device(name="custom_test_device")
 custom_test_signal = ophyd.Signal(name="custom_test_signal")
-
+custom_test_flyer = ophyd.sim.MockFlyer('custom_test_flyer', ophyd.sim.det, ophyd.sim.motor, 1, 5, 20)
 
 @parameter_annotation_decorator(
     {

--- a/bluesky_queueserver/profile_collection_sim/99-custom.py
+++ b/bluesky_queueserver/profile_collection_sim/99-custom.py
@@ -10,7 +10,8 @@ from bluesky_queueserver.manager.annotation_decorator import parameter_annotatio
 # Some useless devices for unit tests.
 custom_test_device = ophyd.Device(name="custom_test_device")
 custom_test_signal = ophyd.Signal(name="custom_test_signal")
-custom_test_flyer = ophyd.sim.MockFlyer('custom_test_flyer', ophyd.sim.det, ophyd.sim.motor, 1, 5, 20)
+custom_test_flyer = ophyd.sim.MockFlyer("custom_test_flyer", ophyd.sim.det, ophyd.sim.motor, 1, 5, 20)
+
 
 @parameter_annotation_decorator(
     {

--- a/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
+++ b/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
@@ -56,6 +56,14 @@ existing_devices:
     classname: DirectImage
     is_movable: false
     module: ophyd.sim
+  flyer1:
+    classname: MockFlyer
+    is_movable: false
+    module: ophyd.sim
+  flyer2:
+    classname: MockFlyer
+    is_movable: false
+    module: ophyd.sim
   identical_det:
     classname: SynGauss
     is_movable: false
@@ -104,17 +112,13 @@ existing_devices:
     classname: SynAxisEmptyHints
     is_movable: true
     module: ophyd.sim
-  motor_no_hints1:
-    classname: SynAxisNoHints
-    is_movable: true
-    module: ophyd.sim
-  motor_no_hints2:
-    classname: SynAxisNoHints
-    is_movable: true
-    module: ophyd.sim
   motor_no_pos:
     classname: SynAxisNoPosition
     is_movable: true
+    module: ophyd.sim
+  new_trivial_flyer:
+    classname: NewTrivialFlyer
+    is_movable: false
     module: ophyd.sim
   noisy_det:
     classname: SynGauss
@@ -143,6 +147,10 @@ existing_devices:
   signal:
     classname: SynSignal
     is_movable: true
+    module: ophyd.sim
+  trivial_flyer:
+    classname: TrivialFlyer
+    is_movable: false
     module: ophyd.sim
 existing_plans:
   _sim_plan_inner:

--- a/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
+++ b/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
@@ -12,6 +12,10 @@ existing_devices:
     classname: Device
     is_movable: false
     module: ophyd.device
+  custom_test_flyer:
+    classname: MockFlyer
+    is_movable: false
+    module: ophyd.sim
   custom_test_signal:
     classname: Signal
     is_movable: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ python-multipart
 pyyaml
 pyzmq
 requests
+typing-extensions;python_version<'3.8'
 uvicorn


### PR DESCRIPTION
Changes include the updated method identification of devices in the worker namespace. Old approach required the devices to be inherited from `ophyd.ophydobj.OphydObject`. The new approach is using `bluesky.abc` to check if the object is `abc.Readable` or `abc.Flyable`.

The PR requires https://github.com/bluesky/bluesky/pull/1446, which must be merged before this PR is merged. Unit tests are expected to pass then. 

Addresses issue https://github.com/bluesky/bluesky-queueserver/issues/162