### PR TITLE
API extension: new 0MQ API 'queue_item_remove_batch'

### DIFF
--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1398,6 +1398,114 @@ def test_zmq_api_queue_item_get_remove_4_failing(re_manager):  # noqa F811
     assert "Ambiguous parameters" in resp1["msg"]
 
 
+# fmt: off
+@pytest.mark.parametrize("batch_params, queue_seq, selection_seq, batch_seq, expected_seq, success, msg", [
+    ({}, "0123456", "", "", "0123456", True, ""),
+    ({}, "0123456", "23", "23", "01456", True, ""),
+    ({}, "0123456", "32", "32", "01456", True, ""),
+    ({}, "0123456", "06", "06", "12345", True, ""),
+    ({}, "0123456", "283", "23", "01456", True, ""),
+    ({}, "0123456", "2893", "23", "01456", True, ""),
+    ({}, "0123456", "2443", "243", "0156", True, ""),
+    ({"ignore_missing": True}, "0123456", "2443", "243", "0156", True, ""),
+    ({"ignore_missing": True}, "0123456", "283", "23", "01456", True, ""),
+    ({"ignore_missing": False}, "0123456", "2443", "", "0123456", False, "The list of contains repeated UIDs"),
+    ({"ignore_missing": False}, "0123456", "283", "", "0123456", False,
+     "The queue does not contain items with the following UIDs"),
+    ({"ignore_missing": False}, "0123456", "2883", "", "0123456", False, "The list of contains repeated UIDs"),
+    ({}, "0123456", "", "", "0123456", True, ""),
+    ({}, "", "", "", "", True, ""),
+    ({}, "", "23", "", "", True, ""),
+    ({"ignore_missing": False}, "", "", "", "", True, ""),
+    ({"ignore_missing": False}, "", "23", "", "", False,
+     "The queue does not contain items with the following UIDs"),
+])
+# fmt: on
+def test_zmq_api_item_remove_batch_1(
+    re_manager, batch_params, queue_seq, selection_seq, batch_seq, expected_seq, success, msg  # noqa: F811
+):
+    """
+    Tests for ``queue_item_remove_batch`` API.
+    """
+    plan_template = {
+        "name": "count",
+        "args": [["det1"]],
+        "kwargs": {"num": 50, "delay": 0.01},
+        "item_type": "plan",
+    }
+
+    # Fill the queue with the initial set of plans
+    for item_code in queue_seq:
+        item = copy.deepcopy(plan_template)
+        item["kwargs"]["num"] = int(item_code)
+        params = {"item": item, "user": _user, "user_group": _user_group}
+        resp1a, _ = zmq_single_request("queue_item_add", params)
+        assert resp1a["success"] is True
+
+    state = get_queue_state()
+    assert state["items_in_queue"] == len(queue_seq)
+    assert state["items_in_history"] == 0
+
+    resp1b, _ = zmq_single_request("queue_get")
+    assert resp1b["success"] is True
+    queue_initial = resp1b["items"]
+
+    def find_uid(dummy_uid):
+        """If item is not found, then return ``dummy_uid``"""
+        try:
+            ind = queue_seq.index(dummy_uid)
+            return queue_initial[ind]["item_uid"]
+        except Exception:
+            return dummy_uid
+
+    # Create a list of UIDs of items to be moved
+    uids_of_items_to_remove = []
+    for item_code in selection_seq:
+        uids_of_items_to_remove.append(find_uid(item_code))
+
+    # Move the batch
+    params = {"uids": uids_of_items_to_remove}
+    params.update(batch_params)
+    resp2a, _ = zmq_single_request("queue_item_remove_batch", params)
+
+    if success:
+        assert resp2a["success"] is True, pprint.pformat(resp2a)
+        assert resp2a["msg"] == ""
+        assert resp2a["qsize"] == len(expected_seq)
+        items_moved = resp2a["items"]
+        assert len(items_moved) == len(batch_seq)
+        added_seq = [str(_["kwargs"]["num"]) for _ in items_moved]
+        added_seq = "".join(added_seq)
+        assert added_seq == batch_seq
+    else:
+        assert resp2a["success"] is False, pprint.pformat(resp2a)
+        assert re.search(msg, resp2a["msg"]), pprint.pformat(resp2a)
+        assert resp2a["qsize"] is None
+        assert resp2a["items"] == []
+
+    resp2b, _ = zmq_single_request("queue_get")
+    assert resp2b["success"] is True
+    queue_final = resp2b["items"]
+    queue_final_seq = [str(_["kwargs"]["num"]) for _ in queue_final]
+    queue_final_seq = "".join(queue_final_seq)
+    assert queue_final_seq == expected_seq
+
+    state = get_queue_state()
+    assert state["items_in_queue"] == len(expected_seq)
+    assert state["items_in_history"] == 0
+
+
+def test_zmq_api_item_remove_batch_2_fail(re_manager):  # noqa: F811
+    """
+    Test for ``queue_item_move_batch`` API
+    """
+    resp1, _ = zmq_single_request("queue_item_remove_batch", params={})
+    assert resp1["success"] is False
+    assert "Request does not contain the list of UIDs" in resp1["msg"]
+    assert resp1["qsize"] is None
+    assert resp1["items"] == []
+
+
 # =======================================================================================
 #                              Method `queue_item_move`
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1497,7 +1497,7 @@ def test_zmq_api_item_remove_batch_1(
 
 def test_zmq_api_item_remove_batch_2_fail(re_manager):  # noqa: F811
     """
-    Test for ``queue_item_move_batch`` API
+    Test for ``queue_item_remove_batch`` API
     """
     resp1, _ = zmq_single_request("queue_item_remove_batch", params={})
     assert resp1["success"] is False

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -353,6 +353,15 @@ async def queue_item_remove_handler(payload: dict):
     return msg
 
 
+@app.post("/queue/item/remove/batch")
+async def queue_item_remove_batch_handler(payload: dict):
+    """
+    Remove a batch of plans from the queue
+    """
+    msg = await zmq_to_manager.send_message(method="queue_item_remove_batch", params=payload)
+    return msg
+
+
 @app.post("/queue/item/move")
 async def queue_item_move_handler(payload: dict):
     """

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -95,6 +95,7 @@ Operations with the plan queue:
 - :ref:`method_queue_item_update`
 - :ref:`method_queue_item_get`
 - :ref:`method_queue_item_remove`
+- :ref:`method_queue_item_remove_batch`
 - :ref:`method_queue_item_move`
 - :ref:`method_queue_item_move_batch`
 - :ref:`method_queue_clear`
@@ -771,6 +772,50 @@ Returns       **success**: *boolean*
               **qsize**: *int* or *None*
                   the number of items in the plan queue after the plan was added if
                   the operation was successful, *None* otherwise
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
+============  =========================================================================================
+
+
+.. _method_queue_item_remove_batch:
+
+**'queue_item_remove_batch'**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'queue_item_remove_batch'**
+------------  -----------------------------------------------------------------------------------------
+Description   Remove a batch of items from the queue. The batch of items is defined as a list
+              of item UIDs and passed as the parameter *'uids'*. The list of UIDs may be empty.
+              By default, the function does not validate the batch and deletes all batch items
+              found in the queue. Batch validation may be enabled by setting *'ignore_missing=False'*.
+              In this case the method succeeds only if the batch does not contain repeated items
+              and all items are found in the queue. If validation fails then no items are removed
+              from the queue.
+------------  -----------------------------------------------------------------------------------------
+Parameters    **uids**: *list(str)* (*required*)
+                  list of UIDs of the items in the batch. The list may not contain repeated UIDs.
+                  All UIDs must be present in the queue. The list may be empty.
+
+              **ignore_missing**: *boolean* (*optional, default: True*)
+                  if the value is *'False'*, then the method fails if the batch contains repeating
+                  items or some of the batch items are not found in the queue. If *'True'* (default),
+                  then the method attempts to remove all items in the batch and ignores missing items.
+                  The method returns the list of items that were removed from the queue.
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+
+              **items**: *list(dict)*
+                  the list of items that were removed during the operation. The items in the list are
+                  arranged in the order in which they were removed. Returns empty list if the operation
+                  fails.
+
+              **qsize**: *int* or *None*
+                  the size of the queue or *None* if operation fails.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================


### PR DESCRIPTION
Implementation of 0MQ API `queue_item_remove_batch` and REST API `/queue/item/remove/batch`. The new API are important for supporting 'atomic' batch operations on the queue.

Addresses issue https://github.com/bluesky/bluesky-queueserver/issues/157