### PR TITLE
Function for formatting plan and plan parameter descriptions

### DIFF
--- a/bluesky_queueserver/__init__.py
+++ b/bluesky_queueserver/__init__.py
@@ -3,7 +3,11 @@ from ._version import get_versions
 __version__ = get_versions()["version"]
 del get_versions
 
-from .manager.comms import ZMQCommSendAsync, ZMQCommSendThreads  # noqa: E402, F401
-from .manager.profile_ops import validate_plan  # noqa: E402, F401
+from .manager.comms import ZMQCommSendAsync, ZMQCommSendThreads, CommTimeoutError  # noqa: E402, F401
 from .manager.annotation_decorator import parameter_annotation_decorator  # noqa: E402, F401
 from .manager.output_streaming import ReceiveConsoleOutput  # noqa: E402, F401
+
+from .manager.profile_ops import validate_plan  # noqa: E402, F401
+from .manager.profile_ops import bind_plan_arguments  # noqa: E402, F401
+from .manager.profile_ops import construct_parameters  # noqa: E402, F401
+from .manager.profile_ops import format_text_descriptions  # noqa: E402, F401

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2190,7 +2190,7 @@ def load_profile_collection_from_ipython(path=None):
     print("Profile collection was loaded successfully.")
 
 
-def format_text_descriptions(item_parameters, *, use_html=True):
+def format_text_descriptions(item_parameters, *, use_html=False):
     """
     Format parameter descriptions for a plan from the list of allowed plans.
     Returns description of the plan and each parameter represented as formatted strings
@@ -2212,9 +2212,9 @@ def format_text_descriptions(item_parameters, *, use_html=True):
     Parameters
     ----------
     item_parameters : dict
-        Item parameters represented using the schema for entries used for the list of allowed plans.
+        A dictionary of item parameters, e.g. an element from the list of existing or allowed plans.
     use_html : boolean
-        Select if the formatted text should be returned as HTML (default) or plain text.
+        Select if the formatted text should be returned as plain text (default) or HTML.
 
     Returns
     -------

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2251,9 +2251,14 @@ def format_text_descriptions(item_parameters, *, use_html=False):
         p_name = p.get("name", None) or "-"
 
         p_type = "-"
+        p_custom_types = []
         annotation = p.get("annotation", None)
         if annotation:
             p_type = str(annotation.get("type", "")) or "-"
+            for t in ("devices", "plans", "enums"):
+                if t in annotation:
+                    for ct in annotation[t]:
+                        p_custom_types.append((ct, tuple(annotation[t][ct])))
 
         p_default = p.get("default", None) or "-"
 
@@ -2267,17 +2272,28 @@ def format_text_descriptions(item_parameters, *, use_html=False):
         desc = (
             f"{start_it}Name:{stop_it} {start_bold}{p_name}{stop_bold}{new_line}"
             f"{start_it}Type:{stop_it} {start_bold}{p_type}{stop_bold}{new_line}"
-            f"{start_it}Default:{stop_it} {start_bold}{p_default}{stop_bold}"
         )
+
+        for ct, ct_items in p_custom_types:
+            desc += f"{start_bold}{ct}:{stop_bold} {ct_items}{new_line}"
+
+        desc += f"{start_it}Default:{stop_it} {start_bold}{p_default}{stop_bold}"
 
         if (p_min is not None) or (p_max is not None) or (p_step is not None):
             desc += f"{new_line}"
+            insert_space = False
             if p_min is not None:
-                desc += f"{start_it}Min:{stop_it} {start_bold}{p_min}{stop_bold} "
+                desc += f"{start_it}Min:{stop_it} {start_bold}{p_min}{stop_bold}"
+                insert_space = True
             if p_max is not None:
-                desc += f"{start_it}Max:{stop_it} {start_bold}{p_max}{stop_bold} "
+                if insert_space:
+                    desc += " "
+                desc += f"{start_it}Max:{stop_it} {start_bold}{p_max}{stop_bold}"
+                insert_space = True
             if p_step is not None:
-                desc += f"{start_it}Step:{stop_it} {start_bold}{p_step}{stop_bold} "
+                if insert_space:
+                    desc += " "
+                desc += f"{start_it}Step:{stop_it} {start_bold}{p_step}{stop_bold}"
 
         if p_description:
             desc += f"{new_line}{p_description}"

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -3531,12 +3531,82 @@ _desc_ftd1d_html = {
 }
 
 
+@parameter_annotation_decorator(
+    {
+        "parameters": {
+            "pa": {
+                "annotation": "int",
+                "default": "50",
+                "min": "1",
+                "max": "100.5",
+                "step": "0.001",
+            },
+        },
+    }
+)
+def _plan_ftd1e(pa=None):
+    yield from [pa]
+
+
+_desc_ftd1e_plain = {
+    "description": "Name: _plan_ftd1e",
+    "parameters": {
+        "pa": "Name: pa\nType: int\nDefault: 50\nMin: 1 Max: 100.5 Step: 0.001",
+    },
+}
+
+_desc_ftd1e_html = {
+    "description": "<i>Name:</i> <b>_plan_ftd1e</b>",
+    "parameters": {
+        "pa": "<i>Name:</i> <b>pa</b><br><i>Type:</i> <b>int</b><br><i>Default:</i> <b>50</b><br>"
+        "<i>Min:</i> <b>1</b> <i>Max:</i> <b>100.5</b> <i>Step:</i> <b>0.001</b>",
+    },
+}
+
+
+@parameter_annotation_decorator(
+    {
+        "parameters": {
+            "pa": {
+                "annotation": "typing.List[typing.Union[DeviceType1, PlanType1, PlanType2]]",
+                "devices": {"DeviceType1": ("det1", "det2", "det3")},
+                "plans": {"PlanType1": ("plan1", "plan2"), "PlanType2": ("plan3",)},
+                "default": "'det1'",
+            },
+        },
+    }
+)
+def _plan_ftd1f(pa=None):
+    yield from [pa]
+
+
+_desc_ftd1f_plain = {
+    "description": "Name: _plan_ftd1f",
+    "parameters": {
+        "pa": "Name: pa\nType: typing.List[typing.Union[DeviceType1, PlanType1, PlanType2]]\n"
+        "DeviceType1: ('det1', 'det2', 'det3')\nPlanType1: ('plan1', 'plan2')\nPlanType2: ('plan3',)\n"
+        "Default: 'det1'",
+    },
+}
+
+_desc_ftd1f_html = {
+    "description": "<i>Name:</i> <b>_plan_ftd1f</b>",
+    "parameters": {
+        "pa": "<i>Name:</i> <b>pa</b><br><i>Type:</i> <b>typing.List[typing.Union[DeviceType1, PlanType1, "
+        "PlanType2]]</b><br><b>DeviceType1:</b> ('det1', 'det2', 'det3')<br><b>PlanType1:</b> ('plan1', "
+        "'plan2')<br><b>PlanType2:</b> ('plan3',)<br><i>Default:</i> <b>'det1'</b>",
+    },
+}
+
+
 # fmt: off
 @pytest.mark.parametrize("plan, desc_plain, desc_html", [
     (_plan_ftd1a, _desc_ftd1a_plain, _desc_ftd1a_html),
     (_plan_ftd1b, _desc_ftd1b_plain, _desc_ftd1b_html),
     (_plan_ftd1c, _desc_ftd1c_plain, _desc_ftd1c_html),
     (_plan_ftd1d, _desc_ftd1d_plain, _desc_ftd1d_html),
+    (_plan_ftd1e, _desc_ftd1e_plain, _desc_ftd1e_html),
+    (_plan_ftd1f, _desc_ftd1f_plain, _desc_ftd1f_html),
 ])
 # fmt: on
 def test_format_text_descriptions_1(plan, desc_plain, desc_html):

--- a/docs/source/interacting_with_qs.rst
+++ b/docs/source/interacting_with_qs.rst
@@ -39,3 +39,17 @@ class parameters and code example.
 
     ReceiveConsoleOutput
     ReceiveConsoleOutput.recv
+
+
+Formatting Descriptions of Plans and Plan Parameters
+----------------------------------------------------
+
+``format_text_descriptions`` function may be used to generate formatted text descriptions of
+plans and plan parameters. The formatted descriptions are intended to be displayed to users
+by client applications. See the docstring for the function for more details.
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated
+
+    format_text_descriptions


### PR DESCRIPTION
Implementation of the function `format_text_descriptions` which returns complete formatted text descriptions for plans and plan parameters. The original code for the function was moved from `bluesky-widgets` projects. The code was also modified to reflect recent changes in schema used to represent plan parameter description. 

The function is intended for use in client GUI applications. It can be imported from `bluesky_queueserver` package:

```
from bluesky_queueserver import format_text_descriptions
```

Addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/179.