### PR TITLE
Import `is/set/clear_re_worker_active()` API from `bluesky_queueserver` module.

### DIFF
--- a/bluesky_queueserver/__init__.py
+++ b/bluesky_queueserver/__init__.py
@@ -11,3 +11,6 @@ from .manager.profile_ops import validate_plan  # noqa: E402, F401
 from .manager.profile_ops import bind_plan_arguments  # noqa: E402, F401
 from .manager.profile_ops import construct_parameters  # noqa: E402, F401
 from .manager.profile_ops import format_text_descriptions  # noqa: E402, F401
+
+from .manager.profile_tools import is_re_worker_active  # noqa: E402, F401
+from .manager.profile_tools import set_re_worker_active, clear_re_worker_active  # noqa: E402, F401

--- a/bluesky_queueserver/manager/profile_tools.py
+++ b/bluesky_queueserver/manager/profile_tools.py
@@ -301,7 +301,7 @@ def set_re_worker_active():
     """
     Set the environment variable used to determine if the current process is RE Worker process.
     Subsequent calls to ``is_re_worker_active`` in the current process will return ``True``.
-    This function should not be used in the startup scripts.
+    THIS FUNCTION SHOULD NEVER BE CALLED IN STARTUP SCRIPTS.
     """
     os.environ[_env_re_worker_active] = "1"
 
@@ -310,7 +310,7 @@ def clear_re_worker_active():
     """
     Clear the environment variable used to determine if the current process is RE Worker process.
     Subsequent calls to ``is_re_worker_active`` in the current process will return ``False``.
-    This function should not be used in the startup scripts.
+    THIS FUNCTION SHOULD NEVER BE CALLED IN STARTUP SCRIPTS.
     """
     if _env_re_worker_active in os.environ:
         del os.environ[_env_re_worker_active]
@@ -324,7 +324,7 @@ def is_re_worker_active():
 
     .. code-block:: python
 
-        from bluesky_queueserver.manager.profile_tools import is_re_worker_active
+        from bluesky_queueserver import is_re_worker_active
 
         ...
 

--- a/docs/source/startup_code.rst
+++ b/docs/source/startup_code.rst
@@ -2,4 +2,43 @@
 Organizing Bluesky Startup Code
 ===============================
 
+.. currentmodule:: bluesky_queueserver
+
 Documentation is coming soon ...
+
+Detecting if the Code is Executed by RE Worker
+----------------------------------------------
+
+Calling the ``is_re_worker_active()`` API anywhere in the startup code or an imported module
+allows to detect if the code is executed by RE Worker. The function returns ``True`` if
+the code is running in RE Worker environment and ``False`` otherwise.
+
+The API may be used to conditionally avoid execution of some code (e.g. the code that interacts
+with the user) when experiments are controlled remotely:
+
+.. code-block:: python
+
+    from bluesky_queueserver import is_re_worker_active
+
+    ...
+
+    if is_re_worker_active():
+        <code without interactive features, e.g. reading data from a file>
+    else:
+        <code with interactive features, e.g. manual data input>
+
+    ...
+
+.. note::
+
+    Queue Server provides additional ``set_re_worker_active()`` and ``clear_re_worker_active()`` API,
+    which modify the value returned by subsequent calls to ``is_re_worker_active()`` in the current process.
+    These API are intended for implementation of tests and **should never be used in startup scripts**.
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
+    is_re_worker_active
+    set_re_worker_active
+    clear_re_worker_active


### PR DESCRIPTION
Changes in this PR:

- add imports of `is_re_worker_active()`, `set_re_worker_active()` and `clear_re_worker_active()` API to `bluesky_queueserver/__init__.py` so that they could be imported from `bluesky_queueserver` module.

- documentation on `is_re_worker_active()`, `set_re_worker_active()` and `clear_re_worker_active()` API