### PR TITLE
New 0MQ API: `queue_item_execute`

### DIFF
--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -67,6 +67,9 @@ qserver queue replace plan <uid> '<plan-params>'        #  Replace item with <ui
 qserver queue update instruction <uid> '<instruction>'  #  Update item with <uid> with an instruction
 qserver queue replace instruction <uid> '<instruction>' #  Replace item with <uid> with an instruction
 
+qserver queue execute plan '<plan-params>'              # Immediately execute the plan
+qserver queue execute instruction <instruction>         # Immediately execute an instruction
+
 Example of JSON specification of a plan:
     '{"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 10, "delay": 1}}'
 
@@ -366,6 +369,9 @@ def msg_queue_add_update(params, *, cmd_opt):
         elif params[0] in ("update", "replace"):
             update_uid = params[2]  # Next parameter is UID
             addr_param, p_item = {}, params[3:]
+        elif params[0] == "execute":
+            update_uid = None
+            addr_param, p_item = {}, params[2:]
         else:
             raise CommandParameterError(f"Option '{params[0]}' is not supported: '{command} {params[0]}'")
 
@@ -719,9 +725,9 @@ def create_msg(params):
     elif command == "queue":
         if len(params) < 1:
             raise CommandParameterError(f"Request '{command}' must include at least one parameter")
-        supported_params = ("add", "update", "replace", "get", "clear", "item", "start", "stop", "mode")
+        supported_params = ("add", "update", "replace", "execute", "get", "clear", "item", "start", "stop", "mode")
         if params[0] in supported_params:
-            if params[0] in ("add", "update", "replace"):
+            if params[0] in ("add", "update", "replace", "execute"):
                 method, prms = msg_queue_add_update(params, cmd_opt=params[0])
 
             elif params[0] in ("get", "clear", "start"):

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -1594,6 +1594,22 @@ def test_process_next_item_2(pq, loop_mode):
     asyncio.run(testing())
 
 
+# fmt: off
+@pytest.mark.parametrize("item_in, item_out", [
+    ({"name": "count"}, {"name": "count"}),
+    ({"name": "count", "properties": {}}, {"name": "count"}),
+    ({"name": "count", "properties": {"nonexisting": 10}}, {"name": "count", "properties": {"nonexisting": 10}}),
+    ({"name": "count", "properties": {"immediate_execution": True}}, {"name": "count"}),
+])
+# fmt: on
+def test_clean_item_properties_1(pq, item_in, item_out):
+    """
+    Basic test for `_clean_item_properties` function.
+    """
+    item_cleaned = pq._clean_item_properties(item_in)
+    assert item_cleaned == item_out
+
+
 def test_set_processed_item_as_completed_1(pq):
     """
     Test for ``PlanQueueOperations.set_processed_item_as_completed()`` function.

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -1742,8 +1742,6 @@ def test_set_processed_item_as_completed_2(pq):
     asyncio.run(testing())
 
 
-
-
 def test_set_processed_item_as_stopped(pq):
     """
     Test for ``PlanQueueOperations.set_processed_item_as_stopped()`` function.

--- a/bluesky_queueserver/server/server.py
+++ b/bluesky_queueserver/server/server.py
@@ -224,6 +224,19 @@ async def queue_item_add_handler(payload: dict):
     return msg
 
 
+@app.post("/queue/item/execute")
+async def queue_item_execute_handler(payload: dict):
+    """
+    Immediately execute an item
+    """
+    # TODO: validate inputs!
+    params = payload
+    params["user"] = _login_data["user"]
+    params["user_group"] = _login_data["user_group"]
+    msg = await zmq_to_manager.send_message(method="queue_item_execute", params=params)
+    return msg
+
+
 @app.post("/queue/item/add/batch")
 async def queue_item_add_batch_handler(payload: dict):
     """

--- a/bluesky_queueserver/server/tests/conftest.py
+++ b/bluesky_queueserver/server/tests/conftest.py
@@ -71,7 +71,19 @@ def wait_for_environment_to_be_created(timeout, polling_period=0.2):
     while ttime.time() < time_start + timeout:
         ttime.sleep(polling_period)
         resp = request_to_json("get", "/status")
-        if resp["worker_environment_exists"]:
+        if resp["worker_environment_exists"] and (resp["manager_state"] == "idle"):
+            return True
+
+    return False
+
+
+def wait_for_environment_to_be_closed(timeout, polling_period=0.2):
+    """Wait for environment to be closed with timeout."""
+    time_start = ttime.time()
+    while ttime.time() < time_start + timeout:
+        ttime.sleep(polling_period)
+        resp = request_to_json("get", "/status")
+        if (not resp["worker_environment_exists"]) and (resp["manager_state"] == "idle"):
             return True
 
     return False

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -975,6 +975,9 @@ Description   Immediately start execution of the submitted item. The item may be
               almost immediately and never pushed back into the queue. If the item is a plan,
               the results of execution are added to plan history as usual. The respective history
               item could be accessed to check if the plan was executed successfully.
+
+              The API **does not start execution of the queue**. Once execution of the submitted
+              item is finished, RE Manager is switched to the IDLE state.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **item**: *dict*
                   the dictionary of plan or instruction parameters. Plans are distinguished from

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -98,6 +98,7 @@ Operations with the plan queue:
 - :ref:`method_queue_item_remove_batch`
 - :ref:`method_queue_item_move`
 - :ref:`method_queue_item_move_batch`
+- :ref:`method_queue_item_execute`
 - :ref:`method_queue_clear`
 
 Start and stop execution of the plan queue:
@@ -941,6 +942,67 @@ Returns       **success**: *boolean*
 
               **qsize**: *int* or *None*
                   the size of the queue or *None* if operation fails.
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
+============  =========================================================================================
+
+
+.. _method_queue_item_execute:
+
+**'queue_item_execute'**
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'queue_item_execute'**
+------------  -----------------------------------------------------------------------------------------
+Description   Immediately start execution of the submitted item. The item may be a plan or an
+              instruction. The request fails if item execution can not be started immediately
+              (RE Manager is not in *IDLE* state, RE Worker environment does not exist, etc.).
+              If the request succeeds, the item is executed once. The item is not added to
+              the queue if it can not be immediately started and it is not pushed back into
+              the queue in case its execution fails/stops. If the queue is in the *LOOP* mode,
+              the executed item is not added to the back of the queue after completion.
+              The API request does not alter the sequence of enqueued plans.
+
+              The API is primarily intended for implementing of interactive workflows, in which
+              users are controlling the experiment using client GUI application and user actions
+              (such as mouse click on a plot) are converted into the requests to execute plans
+              in RE Worker environment. Interactive workflows may be used for calibration of
+              the instrument, while the queue may be used to run sequences of scheduled experiments.
+
+              Internally the API request adds the submitted item to the front of the queue
+              and immediately attempts to start its execution. The item is removed from the queue
+              almost immediately and never pushed back into the queue. If the item is a plan,
+              the results of execution are added to plan history as usual. The respective history
+              item could be accessed to check if the plan was executed successfully.
+------------  -----------------------------------------------------------------------------------------
+Parameters    **item**: *dict*
+                  the dictionary of plan or instruction parameters. Plans are distinguished from
+                  instructions based the value of the required parameter 'item_type'. Currently
+                  supported item types are 'plan' and 'instruction'.
+
+              **user_group**: *str*
+                  the name of the user group (e.g. 'admin').
+
+              **user**: *str*
+                  the name of the user (e.g. 'John Doe'). The name is included in the item metadata
+                  and may be used to identify the user who added the item to the queue. It is not
+                  passed to the Run Engine or included in run metadata.
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+
+              **qsize**: *int* or *None*
+                  the number of items in the plan queue after the plan was added if
+                  the operation was successful, *None* otherwise
+
+              **item**: *dict* or *None* (optional)
+                  the inserted item. The item contains the assigned item UID. In case of error
+                  the item may be returned without modification (with assigned UID). *None* will be
+                  returned if request does not contain item parameters.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================


### PR DESCRIPTION
Implementation for the new API method: `queue_item_execute`. The method immediately starts execution of a plan or instruction. If execution of the item can not be started, the request fails. Meaningful error message is returned to the client that sent the request.

Code changes:

- Implementation of 0MQ API method `queue_item_execute`.
- Implementation of REST API method `/queue/item/execute`.
- Access to the new API method using `qserver` CLI tool (`execute plan` and `execute instruction` options).
- Unit tests for the new 0MQ and REST API and `qserver` options.
- Documentation for `queue_item_execute` 0MQ API.

The PR fully addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/167