### PR TITLE
ENH: show helpful error message if no redis server available

### DIFF
--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -223,12 +223,15 @@ class PlanQueueOperations:
             async with self._lock:
                 try:
                     self._r_pool = await aioredis.create_redis_pool(f"redis://{self._redis_host}", encoding="utf8")
-                except OSError:
-                    logger.error(
-                        "Exception in attempting to create the redis pool, "
-                        f"is a redis server available at {self._redis_host} ?"
+                except OSError as ex:
+                    error_msg = (
+                        f"Failed to create the Redis pool: "
+                        f"Redis server may not be available at '{self._redis_host}'. "
+                        f"Exception: {ex}"
                     )
-                    raise
+                    logger.error(error_msg)
+                    raise OSError(error_msg) from ex
+
                 await self._queue_clean()
                 await self._uid_dict_initialize()
                 await self._load_plan_queue_mode()

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -221,7 +221,14 @@ class PlanQueueOperations:
         if not self._r_pool:  # Initialize only once
             self._lock = asyncio.Lock()
             async with self._lock:
-                self._r_pool = await aioredis.create_redis_pool(f"redis://{self._redis_host}", encoding="utf8")
+                try:
+                    self._r_pool = await aioredis.create_redis_pool(f"redis://{self._redis_host}", encoding="utf8")
+                except OSError:
+                    logger.error(
+                        "Exception in attempting to create the redis pool, "
+                        f"is a redis server available at {self._redis_host} ?"
+                    )
+                    raise
                 await self._queue_clean()
                 await self._uid_dict_initialize()
                 await self._load_plan_queue_mode()


### PR DESCRIPTION
Hi Dmitri, I set up the queueserver on a new machine and forgot to provide dependencies like redis so I thought this might be a small help if another person gets stuck on that, what do you think?