### PR TITLE
Annotation Decorator: Use Python expressions for 'default', 'min', 'max' and 'step'

### DIFF
--- a/bluesky_queueserver/manager/annotation_decorator.py
+++ b/bluesky_queueserver/manager/annotation_decorator.py
@@ -24,10 +24,10 @@ _parameter_annotation_schema = {
                     "enums": {
                         "$ref": "#/definitions/custom_types",
                     },
-                    "default": {"type": "string"},
-                    "min": {"type": "string"},
-                    "max": {"type": "string"},
-                    "step": {"type": "string"},
+                    "default": {},  # Expression of any time should be accepted
+                    "min": {"type": "number"},
+                    "max": {"type": "number"},
+                    "step": {"type": "number"},
                 },
             },
         },
@@ -89,7 +89,7 @@ def parameter_annotation_decorator(annotation):
     The decorator does not change the function and does not overwrite an existing docstring.
     The decorator does not generate function descriptions, instead the parameter dictionary
     passed to the decorator is saved as ``_custom_parameter_annotation_`` attribute of the function
-    and may be used by later for generation of plan descriptions.
+    and may be used later for generation of plan descriptions.
 
     The decorator verifies if the parameter dictionary matches JSON schema and if names of all
     the parameter names exist in the function signature. The exception is raised if there is
@@ -167,9 +167,9 @@ def parameter_annotation_decorator(annotation):
                     #   a parameter hint, but it can also be specified here. Putting
                     #   it in both places will also work.
                     "annotation": "float",
-                    "min": "0.1",  # A number must be represented as a string
-                    "max": "10.0",
-                    "step": "0.1",
+                    "min": 0.1,
+                    "max": 10.0,
+                    "step": 0.1,
                 }
 
                 "str_or_int_or_float": {

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -1501,7 +1501,7 @@ def _process_plan(plan, *, existing_devices):
         """
         Raise 'ValueError' if the string representation of the value can not be evaluated
         """
-        role_str = f"{expression_role} " if expression_role else ""
+        role_str = f" of {expression_role}" if expression_role else ""
 
         s_value = f"{value!r}"
         try:
@@ -1511,7 +1511,7 @@ def _process_plan(plan, *, existing_devices):
             #    Processing should be interrupted.
             raise ValueError(
                 f"The expression ({s_value}) can not be evaluated with 'ast.literal_eval()': "
-                f"unsupported {role_str}type."
+                f"unsupported type{role_str}."
             )
         return s_value
 

--- a/bluesky_queueserver/manager/tests/test_annotation_decorator.py
+++ b/bluesky_queueserver/manager/tests/test_annotation_decorator.py
@@ -93,7 +93,7 @@ _simple_annotation_with_default = {
         "val_arg": {
             "description": "Parameter 'val_arg'",
             "annotation": "int",
-            "default": "10",
+            "default": 10,
         },
         "val_kwarg": {
             "description": "Parameter 'val_kwarg'",
@@ -101,7 +101,7 @@ _simple_annotation_with_default = {
             "enums": {
                 "CustomEnum": ("p1", "p2", "p3"),
             },
-            "default": "'p1'",  # String value should be quoted
+            "default": "p1",  # String value should be quoted
         },
     },
 }
@@ -111,10 +111,10 @@ _simple_annotation_with_min_max_step = {
     "parameters": {
         "val_arg": {
             "description": "Parameter 'val_arg'",
-            "default": "10",
-            "min": "1",
-            "max": "100",
-            "step": "0.1",
+            "default": 10,
+            "min": 1,
+            "max": 100,
+            "step": 0.1,
         },
     },
 }
@@ -423,7 +423,7 @@ _trivial_annotation_error7 = {
             "devices": {
                 "Motor": ["abcde"],
             },
-            "default": 50,  # Must be a string ('50', not just 50)
+            "default": 50,  # Unacceptable type
         }
     },
 }
@@ -440,7 +440,7 @@ _trivial_annotation_error7 = {
      r"Additional properties are not allowed \('some_devices' was unexpected\)"),
     (_trivial_annotation_error5, jsonschema.ValidationError, "is not of type 'string'"),
     (_trivial_annotation_error6, jsonschema.ValidationError, "is not of type 'array'"),
-    (_trivial_annotation_error7, jsonschema.ValidationError, "50 is not of type 'string'"),
+    # (_trivial_annotation_error7, jsonschema.ValidationError, "50 is not of type 'string'"),
 ])
 # fmt: on
 def test_annotation_dectorator_8_fail(custom_annotation, ex_type, err_msg):

--- a/bluesky_queueserver/manager/tests/test_annotation_decorator.py
+++ b/bluesky_queueserver/manager/tests/test_annotation_decorator.py
@@ -414,21 +414,6 @@ _trivial_annotation_error6 = {
 }
 
 
-_trivial_annotation_error7 = {
-    "description": "Example of annotation with varargs and varkwargs.",
-    "parameters": {
-        "existing_param": {
-            "description": "Required key is 'discription'. Schema validation should fail.",
-            "annotation": "Motor",
-            "devices": {
-                "Motor": ["abcde"],
-            },
-            "default": 50,  # Unacceptable type
-        }
-    },
-}
-
-
 # fmt: off
 @pytest.mark.parametrize("custom_annotation, ex_type, err_msg", [
     (_trivial_annotation_error1, jsonschema.ValidationError,
@@ -440,7 +425,6 @@ _trivial_annotation_error7 = {
      r"Additional properties are not allowed \('some_devices' was unexpected\)"),
     (_trivial_annotation_error5, jsonschema.ValidationError, "is not of type 'string'"),
     (_trivial_annotation_error6, jsonschema.ValidationError, "is not of type 'array'"),
-    # (_trivial_annotation_error7, jsonschema.ValidationError, "50 is not of type 'string'"),
 ])
 # fmt: on
 def test_annotation_dectorator_8_fail(custom_annotation, ex_type, err_msg):

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -845,7 +845,7 @@ def _pf1a2(val1, val2):
             Description of the parameter Value 1.
         val2 : list(str)
             Description of the parameter Value 2.
-    
+
         Returns
         -------
         v : int
@@ -1448,9 +1448,9 @@ _pf3d_processed = {
 @parameter_annotation_decorator(
     {
         "parameters": {
-            "val1": {"default": "1000"},
-            "val2": {"default": "'replacement_str'"},
-            "val3": {"default": "False"},
+            "val1": {"default": 1000},
+            "val2": {"default": "replacement_str"},
+            "val3": {"default": False},
         },
     }
 )
@@ -1492,7 +1492,7 @@ class _Pf3f_val1:
 @parameter_annotation_decorator(
     {
         "parameters": {
-            "val1": {"default": "'device_name'"},  # Replace unsupported value
+            "val1": {"default": "device_name"},  # Replace unsupported value
         },
     }
 )
@@ -1643,7 +1643,7 @@ _pf3k_processed = {
 
 @parameter_annotation_decorator(
     {
-        "parameters": {"val1": {"min": "0.1", "max": "100", "step": "0.02"}},
+        "parameters": {"val1": {"min": 0.1, "max": 100, "step": 0.02}},
     }
 )
 def _pf3l(val1):
@@ -1735,54 +1735,24 @@ def _pf4b(val1, val2: str = "some_str", val3: None = None):
 @parameter_annotation_decorator(
     {
         "parameters": {
-            "val2": {"default": "replacement_str"},  # String is not quoted
-        },
-    }
-)
-def _pf4c(val1, val2: str = "some_str", val3: typing.Any = None):
-    yield from [val1, val2, val3]
-
-
-@parameter_annotation_decorator(
-    {
-        "parameters": {
             "detector": {
                 "annotation": "Detectors1]",
                 "devices": {"Detectors1": ("d1", "d2", "d3")},
-                "default": "'d1'",
+                "default": "d1",
             },
         },
     }
 )
-def _pf4d(detector: Optional[ophyd.Device]):
+def _pf4c(detector: Optional[ophyd.Device]):
     # Expected to fail: the default value is in the decorator, but not in the header
     yield from [detector]
-
-
-@parameter_annotation_decorator({"parameters": {"val1": {"min": "a0.1"}}})
-def _pf4e1(val1):
-    yield from [val1]
-
-
-@parameter_annotation_decorator({"parameters": {"val1": {"max": "0.1a"}}})
-def _pf4e2(val1):
-    yield from [val1]
-
-
-@parameter_annotation_decorator({"parameters": {"val1": {"step": "abc"}}})
-def _pf4e3(val1):
-    yield from [val1]
 
 
 # fmt: off
 @pytest.mark.parametrize("plan_func, err_msg", [
     (_pf4a_factory(), "unsupported default value type"),
     (_pf4b, "name 'Plans1' is not defined'"),
-    (_pf4c, "Failed to decode the default value 'replacement_str'"),
-    (_pf4d, "Missing default value for the parameter 'detector' in the plan signature"),
-    (_pf4e1, "Failed to process min. value.* could not convert string to float"),
-    (_pf4e2, "Failed to process max. value.* could not convert string to float"),
-    (_pf4e3, "Failed to process step value.* could not convert string to float"),
+    (_pf4c, "Missing default value for the parameter 'detector' in the plan signature"),
 ])
 # fmt: on
 def test_process_plan_4_fail(plan_func, err_msg):
@@ -2278,9 +2248,9 @@ def _gen_environment_pp2():
     @parameter_annotation_decorator(
         {
             "parameters": {
-                "a": {"annotation": "float", "default": "0.5"},
-                "b": {"annotation": "int", "default": "5"},
-                "s": {"annotation": "int", "default": "50"},
+                "a": {"annotation": "float", "default": 0.5},
+                "b": {"annotation": "int", "default": 5},
+                "s": {"annotation": "int", "default": 50},
             }
         }
     )
@@ -2295,7 +2265,7 @@ def _gen_environment_pp2():
                     "annotation": "typing.List[Detectors]",
                     "devices": {"Detectors": ["_pp_dev1", "_pp_dev2", "_pp_dev3"]},
                     # Default list of the detectors
-                    "default": "['_pp_dev2', '_pp_dev3']",
+                    "default": ["_pp_dev2", "_pp_dev3"],
                 }
             }
         }
@@ -2312,7 +2282,7 @@ def _gen_environment_pp2():
                     "annotation": "Plans",
                     "plans": {"Plans": ["_pp_p1", "_pp_p2", "_pp_p3"]},
                     # Default list of plans
-                    "default": "'_pp_p2'",
+                    "default": "_pp_p2",
                 }
             }
         }
@@ -2326,7 +2296,7 @@ def _gen_environment_pp2():
                 "strings": {
                     "annotation": "typing.Union[typing.List[Selection], typing.Tuple[Selection]]",
                     "enums": {"Selection": ["one", "two", "three"]},
-                    "default": "('one', 'three')",
+                    "default": ("one", "three"),
                 }
             }
         }
@@ -3325,9 +3295,9 @@ def test_validate_plan_3(plan_func, plan, allowed_devices, success, errmsg):
 @parameter_annotation_decorator(
     {
         "parameters": {
-            "num_int": {"min": "5", "max": "15"},
-            "v_float": {"min": "19.4"},
-            "v_list": {"max": "96.54"},
+            "num_int": {"min": 5, "max": 15},
+            "v_float": {"min": 19.4},
+            "v_list": {"max": 96.54},
         },
     }
 )
@@ -3498,12 +3468,12 @@ _desc_ftd1c_html = {
             "pa": {
                 "description": "Multiline description\nof the parameter 'pa'",
                 "annotation": "str",
-                "default": "'default-value'",
+                "default": "default-value",
             },
             "pb": {
                 "description": "Single line description of the parameter 'pb'",
                 "annotation": "float",
-                "default": "50.96",
+                "default": 50.96,
             },
         },
     }
@@ -3536,10 +3506,10 @@ _desc_ftd1d_html = {
         "parameters": {
             "pa": {
                 "annotation": "int",
-                "default": "50",
-                "min": "1",
-                "max": "100.5",
-                "step": "0.001",
+                "default": 50,
+                "min": 1,
+                "max": 100.5,
+                "step": 0.001,
             },
         },
     }
@@ -3571,7 +3541,7 @@ _desc_ftd1e_html = {
                 "annotation": "typing.List[typing.Union[DeviceType1, PlanType1, PlanType2]]",
                 "devices": {"DeviceType1": ("det1", "det2", "det3")},
                 "plans": {"PlanType1": ("plan1", "plan2"), "PlanType2": ("plan3",)},
-                "default": "'det1'",
+                "default": "det1",
             },
         },
     }

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -1748,11 +1748,25 @@ def _pf4c(detector: Optional[ophyd.Device]):
     yield from [detector]
 
 
+def _pf4d_factory():
+    """Arbitrary classes are not supported"""
+
+    class SomeClass:
+        ...
+
+    @parameter_annotation_decorator({"parameters": {"val1": {"default": SomeClass()}}})
+    def f(val1):
+        yield from [val1]
+
+    return f
+
+
 # fmt: off
 @pytest.mark.parametrize("plan_func, err_msg", [
-    (_pf4a_factory(), "unsupported default value type"),
+    (_pf4a_factory(), "unsupported type of default value"),
     (_pf4b, "name 'Plans1' is not defined'"),
     (_pf4c, "Missing default value for the parameter 'detector' in the plan signature"),
+    (_pf4d_factory(), "unsupported type of default value in decorator"),
 ])
 # fmt: on
 def test_process_plan_4_fail(plan_func, err_msg):

--- a/bluesky_queueserver/profile_collection_sim/99-custom.py
+++ b/bluesky_queueserver/profile_collection_sim/99-custom.py
@@ -26,15 +26,15 @@ custom_test_flyer = ophyd.sim.MockFlyer("custom_test_flyer", ophyd.sim.det, ophy
                 "description": "Detectors to use for measurement.",
                 "annotation": "typing.List[Detectors]",
                 "devices": {"Detectors": ("det1", "det2", "det3")},
-                "default": "['det1', 'det2']",
+                "default": ["det1", "det2"],
             },
             "positions": {
                 "description": "Motor positions. The number of positions must be equal "
                 "to the number of the motors.",
                 "annotation": "typing.List[float]",
-                "min": "-10",
-                "max": "10",
-                "step": "0.01",
+                "min": -10,
+                "max": 10,
+                "step": 0.01,
             },
         },
     }


### PR DESCRIPTION
Minor improvement to `parameter_annotation_decorator`.

Use Python expressions to define values of `default`, `min`, `max` and `step`. The original decision to use string representation of values does not provide any advantages over Python expressions. The values of `min`, `max` and `step` could be of `int` and `float` type (used only for numerical values) and `default` may be of any type that could be converted to string (see https://blueskyproject.io/bluesky-queueserver/plan_annotation.html#supported-types).

Strings are still used to represent annotations in the decorator, because the expressions may contain custom enum types that do not exist in Python code.

To this point there are no known users of `parameter_annotation_decorator`, so the change is unlikely to break any code.