### PR TITLE
CI: pinned 'sphinx_rtd_theme==0.5.2'

### DIFF
--- a/docs/source/release_history.rst
+++ b/docs/source/release_history.rst
@@ -14,9 +14,8 @@ Added
 Changed
 -------
 
-* Renamed parameters of `start-re-manager`:
-  - ``--zmq-publish`` is renamed to ``--zmq-publish-console``
-  - ``--zmq-publish-addr`` is renamed to ``--zmq-publish-console-addr``
+* Renamed parameters of `start-re-manager`: ``--zmq-publish`` is renamed to ``--zmq-publish-console``,
+  ``--zmq-publish-addr`` is renamed to ``--zmq-publish-console-addr``.
 * Parameters ``default``, ``min``, ``max`` and ``step`` of ``parameter_annotation_decorator`` now must be
   python expressions of supported types (``default``) or `int` or `float` numbers (``min``, ``max``
   and ``step``). In previous versions the parameter values had to be converted to strings in user code.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,6 @@ matplotlib
 numpydoc
 scikit-image
 sphinx
-sphinx_rtd_theme
+sphinx_rtd_theme==0.5.2
 # Extra dependencies for development
 fastapi[all]


### PR DESCRIPTION
Update to `sphinx_rtd_theme==1.0.0` resulted in corrupt documents, so it had to be pinned to previous stable version 0.5.2.