### PR TITLE
Fix issue with `sphinx_rtd_theme` v1.0.0

### DIFF
--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -11,5 +11,3 @@
       overflow: visible !important;
    }
 }
-
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -204,9 +204,6 @@ intersphinx_mapping = {
 
 # Fix for RTD theme issue: enables wrapping of text in table cells.
 #   see https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
-
+html_css_files = [
+    'theme_overrides.css',  # override wide tables in RTD theme
+    ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,6 @@ matplotlib
 numpydoc
 scikit-image
 sphinx
-sphinx_rtd_theme==0.5.2
+sphinx_rtd_theme
 # Extra dependencies for development
 fastapi[all]


### PR DESCRIPTION
Old method for providing a list of additional CSS files obviously does not work anymore. Fix `conf.py` file to make it compatible with `sphinx_rtd_theme` v1.0.0. Unpin `sphinx_rtd_theme`.