### PR TITLE
PKG: fix inclusion of `profile_collection_sim` into sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,7 +11,7 @@ recursive-include docs *.rst conf.py Makefile make.bat
 
 include versioneer.py
 include bluesky_queueserver/_version.py
-recursive-include bluesky_queueserver/profile_collection_sim/*
+recursive-include bluesky_queueserver/profile_collection_sim *
 
 # If including data files in the package, add them like:
 # include path/to/data_file


### PR DESCRIPTION
Fixed the syntax of `recursive-include` per https://packaging.python.org/guides/using-manifest-in/#manifest-in-commands. With this update, the needed files are included, see the log:
```bash
...
copying bluesky_queueserver/profile_collection_sim/00-ophyd.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/profile_collection_sim
copying bluesky_queueserver/profile_collection_sim/15-plans.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/profile_collection_sim
copying bluesky_queueserver/profile_collection_sim/99-custom.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/profile_collection_sim
copying bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/profile_collection_sim
copying bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/profile_collection_sim
...
```

Full log:
<details>

```bash
$ python setup.py sdist
running sdist
running egg_info
creating bluesky_queueserver.egg-info
writing bluesky_queueserver.egg-info/PKG-INFO
writing dependency_links to bluesky_queueserver.egg-info/dependency_links.txt
writing entry points to bluesky_queueserver.egg-info/entry_points.txt
writing requirements to bluesky_queueserver.egg-info/requires.txt
writing top-level names to bluesky_queueserver.egg-info/top_level.txt
writing manifest file 'bluesky_queueserver.egg-info/SOURCES.txt'
reading manifest file 'bluesky_queueserver.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '__pycache__' found under directory '*'
warning: no previously-included files matching '*.py[co]' found under directory '*'
adding license file 'LICENSE'
adding license file 'AUTHORS.rst'
writing manifest file 'bluesky_queueserver.egg-info/SOURCES.txt'
running check
warning: check: missing meta-data: if 'author' supplied, 'author_email' should be supplied too

creating bluesky-queueserver-0.0.7.post0.dev0+gb4a6243
creating bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver
creating bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver.egg-info
creating bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
creating bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
creating bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/profile_collection_sim
creating bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/tests
creating bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs
creating bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying files to bluesky-queueserver-0.0.7.post0.dev0+gb4a6243...
copying AUTHORS.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243
copying CONTRIBUTING.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243
copying LICENSE -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243
copying MANIFEST.in -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243
copying README.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243
copying pyproject.toml -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243
copying requirements.txt -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243
copying setup.cfg -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243
copying setup.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243
copying versioneer.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243
copying bluesky_queueserver/__init__.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver
copying bluesky_queueserver/_version.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver
copying bluesky_queueserver.egg-info/PKG-INFO -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver.egg-info
copying bluesky_queueserver.egg-info/SOURCES.txt -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver.egg-info
copying bluesky_queueserver.egg-info/dependency_links.txt -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver.egg-info
copying bluesky_queueserver.egg-info/entry_points.txt -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver.egg-info
copying bluesky_queueserver.egg-info/requires.txt -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver.egg-info
copying bluesky_queueserver.egg-info/top_level.txt -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver.egg-info
copying bluesky_queueserver/manager/__init__.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/_protocols.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/annotation_decorator.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/comms.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/conversions.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/manager.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/output_streaming.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/plan_monitoring.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/plan_queue_ops.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/profile_ops.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/profile_tools.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/qserver_cli.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/start_manager.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/worker.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager
copying bluesky_queueserver/manager/tests/__init__.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/common.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/plan_lists.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/spreadsheet_custom_functions.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_annotation_decorator.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_comms.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_conversions.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_fixtures.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_manager.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_manager_options.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_output_streaming.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_plan_monitoring.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_plan_queue_ops.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_profile_ops.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_profile_tools.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_qserver_cli.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_start_manager.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_start_re_manager_cli.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/manager/tests/test_zmq_api.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/manager/tests
copying bluesky_queueserver/profile_collection_sim/00-ophyd.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/profile_collection_sim
copying bluesky_queueserver/profile_collection_sim/15-plans.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/profile_collection_sim
copying bluesky_queueserver/profile_collection_sim/99-custom.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/profile_collection_sim
copying bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/profile_collection_sim
copying bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/profile_collection_sim
copying bluesky_queueserver/tests/__init__.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/tests
copying bluesky_queueserver/tests/common.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/tests
copying bluesky_queueserver/tests/conftest.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/tests
copying docs/Makefile -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs
copying docs/make.bat -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs
copying docs/source/cli_tools.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/conf.py -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/features_and_config.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/index.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/installation.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/interacting_with_qs.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/introduction_for_users.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/ipython.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/item_validation.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/plan_annotation.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/re_manager_api.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/release_history.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/startup_code.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/tutorial.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
copying docs/source/workflow.rst -> bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/docs/source
Writing bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/setup.cfg
UPDATING bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/_version.py
set bluesky-queueserver-0.0.7.post0.dev0+gb4a6243/bluesky_queueserver/_version.py to '0.0.7.post0.dev0+gb4a6243'
creating dist
Creating tar archive
removing 'bluesky-queueserver-0.0.7.post0.dev0+gb4a6243' (and everything under it)
```

</details>