### PR TITLE
Allow for requesting of device configuration

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -977,6 +977,29 @@ class RunEngineManager(Process):
             "devices_allowed_uid": self._allowed_devices_uid,
         }
 
+    async def _device_configuration_handler(self, request):
+        """
+        Returns the list of allowed devices.
+        """
+        logger.info("Returning the device configuration ...")
+
+        try:
+            supported_param_names = ["device"]
+            self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            device_configuration = await self._comm_to_worker.send_msg("request_device_configuration", {"device": request["device"]})
+            success, msg = True, ""
+        except Exception as ex:
+            device_configuration = {}
+            success, msg = False, str(ex)
+
+        return {
+            "success": success,
+            "msg": msg,
+            "device_configuration": device_configuration,
+        }
+
+
     async def _permissions_reload_handler(self, request):
         """
         Reloads the list of allowed plans and devices and user group permission from the default location
@@ -1972,6 +1995,7 @@ class RunEngineManager(Process):
             "queue_get": "_queue_get_handler",
             "plans_allowed": "_plans_allowed_handler",
             "devices_allowed": "_devices_allowed_handler",
+            "device_configuration": "_device_configuration_handler",
             "permissions_reload": "_permissions_reload_handler",
             "history_get": "_history_get_handler",
             "history_clear": "_history_clear_handler",

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -49,6 +49,8 @@ qserver allowed plans          # Request the list of allowed plans
 qserver allowed devices        # Request the list of allowed devices
 qserver permissions reload     # Reload the list of allowed plans and devices and user permissions from disk
 
+qserver device configuration <device>  # request the configuration for a device, environment must be open
+
 qserver queue add plan '<plan-params>'                 # Add plan to the back of the queue
 qserver queue add instruction <instruction>            # Add instruction to the back of the queue
 qserver queue add plan front '<plan-params>'           # Add plan to the front of the queue
@@ -709,6 +711,16 @@ def create_msg(params):
         if params[0] in supported_params:
             method = f"{params[0]}_{command}"
             prms["user_group"] = default_user_group
+        else:
+            raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
+
+    # ----------- permissions ------------
+    elif command == "device":
+        if len(params) != 2:
+            raise CommandParameterError(f"Request '{command}' must include exactly two parameters")
+        if params[0] == "configuration":
+            method = f"{command}_{params[0]}"
+            prms["device"] = params[1]
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
 

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -319,6 +319,9 @@ class RunEngineWorker(Process):
         msg_out = {"run_list": self._active_run_list.get_run_list(clear_state=True)}
         return msg_out
 
+    def _request_device_configuration_handler(self, *, device):
+        return self._devices_in_nspace[device].read_configuration()
+
     def _command_close_env_handler(self):
         """
         Close RE Worker environment in orderly way.
@@ -523,6 +526,7 @@ class RunEngineWorker(Process):
         self._comm_to_manager.add_method(self._request_state_handler, "request_state")
         self._comm_to_manager.add_method(self._request_plan_report_handler, "request_plan_report")
         self._comm_to_manager.add_method(self._request_run_list_handler, "request_run_list")
+        self._comm_to_manager.add_method(self._request_device_configuration_handler, "request_device_configuration")
         self._comm_to_manager.add_method(self._command_close_env_handler, "command_close_env")
         self._comm_to_manager.add_method(self._command_confirm_exit_handler, "command_confirm_exit")
         self._comm_to_manager.add_method(self._command_run_plan_handler, "command_run_plan")


### PR DESCRIPTION
This serves as a concrete implementation of a proposal I brought up on the Nikea slack regarding allowing access to device configuration.

This serves as a _read-only_ access to configuration of devices in the worker namespace.
Such devices can provide things like units or limits which can help make UIs to interact with the queueserver with proper gaurdrails that present a streamlined user experience.
For many devices (at least from what I can tell) these units and limits are already defined.

This was a quick and dirty proof of concept implementation, happy to revise if needed.

The intent here is to allow for transfer of (potentially dynamic) information via the queueserver zmq interface without opening up the can of worms that is a general and extensible RPC layer.

Other factors to consider:
- I do no checking of whether the requesting user is _allowed_ to see the device, perhaps that is a desirable check
- Current (and as far as I can tell, any) implementation does require the worker environment to be open, as the actual `read_configuration` call happens there as that is the owner of the devices