### PR TITLE
Return 'worker_environment_state' as one of RE status parameters

### DIFF
--- a/bluesky_queueserver/manager/logging_setup.py
+++ b/bluesky_queueserver/manager/logging_setup.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 
-def setup_loggers(*, name, log_level):
+def setup_loggers(*, log_level, name="bluesky_queueserver"):
     """
     Configure loggers used by Bluesky Queue Server.
 

--- a/bluesky_queueserver/manager/logging_setup.py
+++ b/bluesky_queueserver/manager/logging_setup.py
@@ -1,0 +1,31 @@
+import logging
+import sys
+
+
+def setup_loggers(*, name, log_level):
+    """
+    Configure loggers used by Bluesky Queue Server.
+
+    Parameters
+    ----------
+    name: str
+        Module name (typically ``__name__``)
+    log_level
+        Logging level (e.g. ``logging.INFO``, ``"INFO"`` or ``20``)
+    """
+    log_stream_handler = logging.StreamHandler(sys.stdout)
+    log_stream_handler.setLevel(log_level)
+    if (
+        (log_level == logging.DEBUG)
+        or (log_level == "DEBUG")
+        or (isinstance(log_level, int) and (log_level <= 10))
+    ):
+        log_stream_format = "[%(levelname)1.1s %(asctime)s.%(msecs)03d %(name)s %(module)s:%(lineno)d] %(message)s"
+    else:
+        log_stream_format = "[%(levelname)1.1s %(asctime)s %(name)s] %(message)s"
+
+    log_stream_handler.setFormatter(logging.Formatter(fmt=log_stream_format))
+    logging.getLogger(name).handlers.clear()
+    logging.getLogger(name).addHandler(log_stream_handler)
+    logging.getLogger(name).setLevel(log_level)
+    logging.getLogger(name).propagate = False

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1034,6 +1034,7 @@ class RunEngineManager(Process):
         queue_stop_pending = self._queue_stop_pending
         worker_environment_exists = self._environment_exists
         re_state = self._worker_state_info["re_state"] if self._worker_state_info else None
+        env_state = self._worker_state_info["environment_state"] if self._worker_state_info else "closed"
         deferred_pause_pending = self._re_pause_pending
         run_list_uid = self._re_run_list_uid
         plan_queue_uid = self._plan_queue.plan_queue_uid
@@ -1053,6 +1054,7 @@ class RunEngineManager(Process):
             "manager_state": manager_state,
             "queue_stop_pending": queue_stop_pending,
             "worker_environment_exists": worker_environment_exists,
+            "worker_environment_state": env_state,  # State of the worker environment
             "re_state": re_state,  # State of Run Engine
             "pause_pending": deferred_pause_pending,  # True/False - Cleared once pause processed
             # If Run List UID change, download the list of runs for the current plan.

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -403,7 +403,7 @@ class RunEngineManager(Process):
                     elif self._manager_state == MState.CREATING_ENVIRONMENT:
                         # If RE Worker environment fails to open, then it switches to 'closing' state.
                         #   Closing must be confirmed by Manager before it is closed.
-                        if ws["environment_state"] in "ready":
+                        if ws["environment_state"] in ("idle", "executing_plan", "executing_task"):
                             self._fut_manager_task_completed.set_result(True)
                         if ws["environment_state"] == "closing":
                             self._fut_manager_task_completed.set_result(False)

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -231,8 +231,10 @@ class RunEngineManager(Process):
                 asyncio.ensure_future(self._execute_background_task(self._start_re_worker_task()))
 
         except Exception as ex:
-            self._lock_env_ops_release()
             accepted, msg = False, str(ex)
+
+        finally:
+            self._lock_env_ops_release()
 
         return accepted, msg
 
@@ -278,7 +280,7 @@ class RunEngineManager(Process):
             self._manager_state = MState.IDLE
 
         finally:
-            self._lock_env_ops_release()
+            pass
 
         return success, err_msg
 
@@ -304,8 +306,10 @@ class RunEngineManager(Process):
                 asyncio.ensure_future(self._execute_background_task(self._stop_re_worker_task()))
 
         except Exception as ex:
-            self._lock_env_ops_release()
             accepted, err_msg = False, str(ex)
+
+        finally:
+            self._lock_env_ops_release()
 
         return accepted, err_msg
 
@@ -339,7 +343,7 @@ class RunEngineManager(Process):
             self._manager_state = MState.IDLE
 
         finally:
-            self._lock_env_ops_release()
+            pass
 
         return success, err_msg
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1718,11 +1718,11 @@ class RunEngineManager(Process):
         Immediately start execution of the submitted item. The item may be a plan or an
         instruction. The request fails if item execution can not be started immediately
         (RE Manager is not in IDLE state, RE Worker environment does not exist, etc.).
-        If the request succeeds, the item is executed once. The item is not added to
-        the queue if it can not be immediately started and it is not pushed back into
-        the queue in case its execution fails/stops. If the queue is in the *LOOP* mode,
-        the executed item is not added to the back of the queue after completion.
-        The API request does not alter the sequence of enqueued plans.
+        If the request succeeds, the item is executed once. The item is never added to
+        the queue and it is not pushed back into the queue in case its execution fails/stops.
+        If the queue is in the *LOOP* mode, the executed item is not added to the back of
+        the queue after completion. The API request does not alter the sequence of enqueued plans
+        or change plan queue UID.
 
         The API is primarily intended for implementing of interactive workflows, in which
         users are controlling the experiment using client GUI application and user actions
@@ -1730,11 +1730,9 @@ class RunEngineManager(Process):
         in RE Worker environment. Interactive workflows may be used for calibration of
         the instrument, while the queue may be used to run sequences of scheduled experiments.
 
-        Internally the API request adds the submitted item to the front of the queue
-        and immediately attempts to start its execution. The item is removed from the queue
-        almost immediately and never pushed back into the queue. If the item is a plan,
-        the results of execution are added to plan history as usual. The respective history
-        item could be accessed to check if the plan was executed successfully.
+        If the item is a plan, the results of execution are added to plan history as usual.
+        The respective history item could be accessed to check if the plan was executed
+        successfully.
 
         The API DOES NOT START EXECUTION OF THE QUEUE. Once execution of the submitted
         item is finished, RE Manager is switched to the IDLE state.

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -16,6 +16,7 @@ from .profile_ops import (
 )
 from .plan_queue_ops import PlanQueueOperations
 from .output_streaming import setup_console_output_redirection
+from .logging_setup import setup_loggers
 
 
 import logging
@@ -2286,7 +2287,8 @@ class RunEngineManager(Process):
         setup_console_output_redirection(msg_queue=self._msg_queue)
 
         logging.basicConfig(level=max(logging.WARNING, self._log_level))
-        logging.getLogger(__name__).setLevel(self._log_level)
+        setup_loggers(name=__name__, log_level=self._log_level)
+        # logging.getLogger(__name__).setLevel(self._log_level)
 
         logger.info("Starting RE Manager process")
         try:

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -43,6 +43,7 @@ class MState(enum.Enum):
     IDLE = "idle"
     PAUSED = "paused"  # Paused plan
     CREATING_ENVIRONMENT = "creating_environment"
+    STARTING_QUEUE = "starting_queue"  # Starting the first plan of the queue
     EXECUTING_QUEUE = "executing_queue"
     CLOSING_ENVIRONMENT = "closing_environment"
     DESTROYING_ENVIRONMENT = "destroying_environment"
@@ -556,19 +557,65 @@ class RunEngineManager(Process):
 
             if not self._environment_exists:
                 raise RuntimeError("RE Worker environment does not exist.")
-            elif not self._manager_state == MState.IDLE:
+            elif self._manager_state != MState.IDLE:
                 raise RuntimeError("RE Manager is busy.")
             else:
                 self._queue_stop_deactivate()  # Just in case
-
+                self._manager_state = MState.STARTING_QUEUE
                 asyncio.ensure_future(self._execute_background_task(self._start_plan_task(starting_queue=True)))
                 success, err_msg = True, ""
 
         except Exception as ex:
-            self._lock_env_ops_release()
             success, err_msg = False, str(ex)
+        finally:
+            self._lock_env_ops_release()
 
         return success, err_msg
+
+    async def _start_single_plan(self, *, item):
+        """
+        Initiate upload of next plan to the worker process for execution.
+        """
+        qsize, item_uid = None, None
+
+        try:
+            await self._lock_env_ops_acquire()
+
+            if not self._environment_exists:
+                raise RuntimeError("RE Worker environment does not exist.")
+            elif self._manager_state != MState.IDLE:
+                raise RuntimeError("RE Manager is busy.")
+            else:
+                self._queue_stop_deactivate()  # Just in case
+                self._manager_state = MState.STARTING_QUEUE
+
+                item = copy.deepcopy(item)
+
+                # Adding plan to queue may raise an exception
+                item["properties"] = {"immediate_execution": True}
+                item, qsize_with_new_item = await self._plan_queue.add_item_to_queue(item, pos="front")
+                item_uid = item.get("item_uid", None)  # The item WAS added to the queue
+                qsize = max(qsize_with_new_item - 1, 0)
+
+                asyncio.ensure_future(self._execute_background_task(self._start_plan_task(starting_queue=True)))
+
+                success, err_msg = True, ""
+
+        except Exception as ex:
+            # If execution of the plan fails to start, the plan remains in the queue and needs to be deleted.
+            #   We use UID to delete the plan. It guarantees that only recently added plan is deleted.
+            #   Exception may be raised if the plan is not in the queue and must be properly handled.
+            if item_uid is not None:
+                try:
+                    await self._plan_queue.pop_item_from_queue(uid=item_uid)
+                except Exception as ex2:
+                    logger.exception("Failed to delete plan with UID '%s' from queue: %s", item_uid, str(ex2))
+            success, err_msg = False, str(ex)
+
+        finally:
+            self._lock_env_ops_release()
+
+        return success, err_msg, item, qsize
 
     async def _start_plan_task(self, stop_queue=False, starting_queue=False):
         """
@@ -577,107 +624,102 @@ class RunEngineManager(Process):
         "args" (list of args), "kwargs" (list of kwargs). Only the plan name is mandatory.
         Names of plans and devices are strings.
         """
-        try:
-            n_pending_plans = await self._plan_queue.get_queue_size()
-            if n_pending_plans:
-                logger.info("Processing the next queue item: %d plans are left in the queue.", n_pending_plans)
-            else:
-                logger.info("No items are left in the queue.")
+        n_pending_plans = await self._plan_queue.get_queue_size()
+        if n_pending_plans:
+            logger.info("Processing the next queue item: %d plans are left in the queue.", n_pending_plans)
+        else:
+            logger.info("No items are left in the queue.")
 
-            if not n_pending_plans:
-                self._manager_state = MState.IDLE
-                self._re_pause_pending = False
-                success, err_msg = False, "Queue is empty."
-                logger.info(err_msg)
+        if not n_pending_plans:
+            self._manager_state = MState.IDLE
+            self._re_pause_pending = False
+            success, err_msg = False, "Queue is empty."
+            logger.info(err_msg)
 
-            elif self._queue_stop_pending or stop_queue:
-                self._manager_state = MState.IDLE
-                self._re_pause_pending = False
-                success, err_msg = False, "Queue is stopped."
-                logger.info(err_msg)
+        elif self._queue_stop_pending or stop_queue:
+            self._manager_state = MState.IDLE
+            self._re_pause_pending = False
+            success, err_msg = False, "Queue is stopped."
+            logger.info(err_msg)
 
-            elif self._re_pause_pending:
-                self._manager_state = MState.IDLE
-                self._re_pause_pending = False
-                success, err_msg = False, "Queue is stopped due to unresolved outstanding RE pause request."
-                logger.info(err_msg)
+        elif self._re_pause_pending:
+            self._manager_state = MState.IDLE
+            self._re_pause_pending = False
+            success, err_msg = False, "Queue is stopped due to unresolved outstanding RE pause request."
+            logger.info(err_msg)
 
-            else:
-                next_item = await self._plan_queue.get_item(pos="front")
+        else:
+            next_item = await self._plan_queue.get_item(pos="front")
 
-                self._re_pause_pending = False
+            self._re_pause_pending = False
 
-                # The next items is PLAN
-                if next_item["item_type"] == "plan":
+            # The next items is PLAN
+            if next_item["item_type"] == "plan":
 
-                    # Reset RE environment (worker)
-                    success, err_msg = await self._worker_command_reset_worker()
-                    if not success:
-                        self._manager_state = MState.IDLE
-                        err_msg = f"Failed to reset RE Worker: {err_msg}"
-                        logger.error(err_msg)
-                        return success, err_msg
+                # Reset RE environment (worker)
+                success, err_msg = await self._worker_command_reset_worker()
+                if not success:
+                    self._manager_state = MState.IDLE
+                    err_msg = f"Failed to reset RE Worker: {err_msg}"
+                    logger.error(err_msg)
+                    return success, err_msg
 
+                self._manager_state = MState.EXECUTING_QUEUE
+
+                new_plan = await self._plan_queue.process_next_item()
+
+                plan_name = new_plan["name"]
+                args = new_plan["args"] if "args" in new_plan else []
+                kwargs = new_plan["kwargs"] if "kwargs" in new_plan else {}
+                user_name = new_plan["user"]
+                user_group = new_plan["user_group"]
+                meta = new_plan["meta"] if "meta" in new_plan else {}
+                item_uid = new_plan["item_uid"]
+
+                plan_info = {
+                    "name": plan_name,
+                    "args": args,
+                    "kwargs": kwargs,
+                    "user": user_name,
+                    "user_group": user_group,
+                    "meta": meta,
+                    "item_uid": item_uid,
+                }
+
+                # TODO: Decide if we really want to have metadata in the log
+                logger.info("Starting the plan:\n%s.", pprint.pformat(plan_info))
+
+                success, err_msg = await self._worker_command_run_plan(plan_info)
+                if not success:
+                    await self._plan_queue.set_processed_item_as_stopped(exit_status="error", run_uids=[])
+                    self._manager_state = MState.IDLE
+                    logger.error(
+                        "Failed to start the plan %s.\nError: %s",
+                        pprint.pformat(plan_info),
+                        err_msg,
+                    )
+                    err_msg = f"Failed to start the plan: {err_msg}"
+
+            # The next items is INSTRUCTION
+            elif next_item["item_type"] == "instruction":
+                logger.info("Executing instruction:\n%s.", pprint.pformat(next_item))
+
+                if next_item["name"] == "queue_stop":
+                    await self._plan_queue.process_next_item()
                     self._manager_state = MState.EXECUTING_QUEUE
-
-                    new_plan = await self._plan_queue.process_next_item()
-
-                    plan_name = new_plan["name"]
-                    args = new_plan["args"] if "args" in new_plan else []
-                    kwargs = new_plan["kwargs"] if "kwargs" in new_plan else {}
-                    user_name = new_plan["user"]
-                    user_group = new_plan["user_group"]
-                    meta = new_plan["meta"] if "meta" in new_plan else {}
-                    item_uid = new_plan["item_uid"]
-
-                    plan_info = {
-                        "name": plan_name,
-                        "args": args,
-                        "kwargs": kwargs,
-                        "user": user_name,
-                        "user_group": user_group,
-                        "meta": meta,
-                        "item_uid": item_uid,
-                    }
-
-                    # TODO: Decide if we really want to have metadata in the log
-                    logger.info("Starting the plan:\n%s.", pprint.pformat(plan_info))
-
-                    success, err_msg = await self._worker_command_run_plan(plan_info)
-                    if not success:
-                        await self._plan_queue.set_processed_item_as_stopped(exit_status="error", run_uids=[])
-                        self._manager_state = MState.IDLE
-                        logger.error(
-                            "Failed to start the plan %s.\nError: %s",
-                            pprint.pformat(plan_info),
-                            err_msg,
-                        )
-                        err_msg = f"Failed to start the plan: {err_msg}"
-
-                # The next items is INSTRUCTION
-                elif next_item["item_type"] == "instruction":
-                    logger.info("Executing instruction:\n%s.", pprint.pformat(next_item))
-
-                    if next_item["name"] == "queue_stop":
-                        await self._plan_queue.process_next_item()
-                        self._manager_state = MState.EXECUTING_QUEUE
-                        asyncio.ensure_future(self._start_plan_task(stop_queue=True))
-                        success, err_msg = True, ""
-                    else:
-                        success = False
-                        err_msg = f"Unsupported action: '{next_item['name']}' (item {next_item})"
-
+                    asyncio.ensure_future(self._start_plan_task(stop_queue=True))
+                    success, err_msg = True, ""
                 else:
                     success = False
-                    err_msg = f"Unrecognized item type: '{next_item['item_type']}' (item {next_item})"
+                    err_msg = f"Unsupported action: '{next_item['name']}' (item {next_item})"
 
-            if self._manager_state == MState.IDLE:
-                # No plans are running: deactivate the stop sequence.
-                self._queue_stop_deactivate()
+            else:
+                success = False
+                err_msg = f"Unrecognized item type: '{next_item['item_type']}' (item {next_item})"
 
-        finally:
-            if starting_queue:
-                self._lock_env_ops_release()
+        if self._manager_state == MState.IDLE:
+            # No plans are running: deactivate the stop sequence.
+            self._queue_stop_deactivate()
 
         return success, err_msg
 
@@ -1735,7 +1777,6 @@ class RunEngineManager(Process):
         logger.debug("Request: %s", pprint.pformat(request))
 
         item_type, item, qsize, msg = None, None, None, ""
-        item_uid = None
 
         try:
             supported_param_names = ["item", "user_group", "user"]
@@ -1752,35 +1793,12 @@ class RunEngineManager(Process):
                 item=item, item_type=item_type, user=user, user_group=user_group, generate_new_uid=True
             )
 
-            # Execution of an item can not be immediately started if RE Manager is not idle
-            if self._manager_state != MState.IDLE:
-                raise RuntimeError(f"RE Manager is not idle. RE Manager state is '{self._manager_state.value}'")
-
-            # Adding plan to queue may raise an exception
-            item["properties"] = {"immediate_execution": True}
-            item, qsize_with_new_item = await self._plan_queue.add_item_to_queue(item, pos="front")
-            item_uid = item.get("item_uid", None)  # The item WAS added to the queue
-
-            # Start the queue
-            start_success, start_msg = await self._start_plan()
-            if not start_success:
-                raise RuntimeError(start_msg)
-
-            # The returned queue size is not supposed to include the plan that was started.
-            qsize = max(qsize_with_new_item - 1, 0)
-            success = True
+            success, msg, item, qsize = await self._start_single_plan(item=item)
+            if not success:
+                raise RuntimeError(msg)
 
         except Exception as ex:
-            # If execution of the plan fails to start, the plan remains in the queue and needs to be deleted.
-            #   We use UID to delete the plan. It guarantees that only recently added plan is deleted.
-            #   Exception may be raised if the plan is not in the queue and must be properly handled.
-            if item_uid is not None:
-                try:
-                    await self._plan_queue.pop_item_from_queue(uid=item_uid)
-                except Exception as ex2:
-                    logger.exception("Failed to delete plan with UID '%s' from queue: %s", item_uid, str(ex2))
-            success = False
-            msg = f"Failed to start execution of the item: {str(ex)}"
+            success, msg = False, f"Failed to start execution of the item: {str(ex)}"
 
         logger.info(self._generate_item_log_msg("Item execution started", success, item_type, item, qsize))
 

--- a/bluesky_queueserver/manager/output_streaming.py
+++ b/bluesky_queueserver/manager/output_streaming.py
@@ -496,6 +496,7 @@ def qserver_console_monitor_cli():
     CLI tool for remote monitoring of console output from RE Manager. The function is also
     expected to be used as an example of using  ``ReceiveConsoleOutput`` class.
     """
+
     logging.basicConfig(level=logging.WARNING)
     logging.getLogger("bluesky_queueserver").setLevel("INFO")
 

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -1475,7 +1475,11 @@ class PlanQueueOperations:
         # Read the item from the front of the queue
 
         immediate_execution = bool(item)
-        item = item or await self._get_item(pos="front")
+        if immediate_execution:
+            # Generate UID if it does not exist or creates a deep copy
+            item = copy.deepcopy(item) if "item_uid" in item else self.set_new_item_uuid(item)
+        else:
+            item = await self._get_item(pos="front")
 
         item_to_return = item
         if item:
@@ -1503,6 +1507,9 @@ class PlanQueueOperations:
         If ``item`` is a plan, then the plan is set for immediate execution. If ``item`` is
         an instruction, then the function does nothing.
 
+        If an item submitted for 'immediate' execution has no UID, a new UID is created.
+        The returned plan is in the exact form, which is set for execution.
+
         For more details on processing of queue plans, see the description for
         ``self.set_next_item_as_running`` method.
         """
@@ -1515,7 +1522,8 @@ class PlanQueueOperations:
         """
         immediate_execution = bool(item)
         if immediate_execution:
-            item = self.set_new_item_uuid(item)  # Creates deep copy
+            # Generate UID if it does not exist or creates a deep copy
+            item = copy.deepcopy(item) if "item_uid" in item else self.set_new_item_uuid(item)
             item.setdefault("properties", {})["immediate_execution"] = True
 
         # UID remains in the `self._uid_dict` after this operation.
@@ -1564,8 +1572,8 @@ class PlanQueueOperations:
         This function can only be applied to the plans. Use ``process_next_item`` that
         works correctly for any item (it calls this function if an item is a plan).
 
-        All plans submitted for 'immediate' execution are assigned new item UIDs to avoid
-        duplicate history entries if copies of plans from the queue are submitted.
+        If a plan submitted for 'immediate' execution has no UID, a new UID is created.
+        The returned plan is in the exact form, which is set for execution.
 
         Parameters
         ----------

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -1556,7 +1556,7 @@ class PlanQueueOperations:
 
         except RuntimeError:
             raise
-        except Exception as ex:
+        except Exception:
             plan = {}
 
         return plan

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -654,8 +654,8 @@ class PlanQueueOperations:
 
         Parameters
         ----------
-        plan: dict
-            Dictionary of plan parameters. Must be identical to the plan that is
+        item: dict
+            Dictionary of item parameters. Must be identical to the item that is
             expected to be deleted.
         single: boolean
             True - RuntimeError exception is raised if no or more than one matching
@@ -1466,77 +1466,128 @@ class PlanQueueOperations:
                 del item["properties"]
         return item
 
-    async def _process_next_item(self):
+    async def _process_next_item(self, *, item=None):
         """
         See ``self.process_next_item()`` method.
         """
         loop_mode = self._plan_queue_mode["loop"]
 
         # Read the item from the front of the queue
-        item = await self._get_item(pos="front")
+
+        immediate_execution = bool(item)
+        item = item or await self._get_item(pos="front")
+
         item_to_return = item
         if item:
             item_type = item["item_type"]
             if item_type == "plan":
-                item_to_return = await self._set_next_item_as_running()
-            else:
+                kwargs = {"item": item} if immediate_execution else {}
+                item_to_return = await self._set_next_item_as_running(**kwargs)
+
+            elif not immediate_execution:
                 # Items other than plans should be pushed to the back of the queue.
                 await self._pop_item_from_queue(pos="front")
                 if loop_mode:
                     item_to_add = self.set_new_item_uuid(item)
                     await self._add_item_to_queue(item_to_add)
+
         return item_to_return
 
-    async def process_next_item(self):
+    async def process_next_item(self, *, item=None):
         """
         Process the next item in the queue. If the item is a plan, it is set as currently
         running (``self.set_next_item_as_running``), otherwise it is popped from the queue.
         If the queue is LOOP mode, then it the item other than plan is pushed to the back
         of the queue. (Plans are pushed to the back of the queue upon successful completion.)
+
+        If ``item`` is a plan, then the plan is set for immediate execution. If ``item`` is
+        an instruction, then the function does nothing.
+
+        For more details on processing of queue plans, see the description for
+        ``self.set_next_item_as_running`` method.
         """
         async with self._lock:
-            return await self._process_next_item()
+            return await self._process_next_item(item=item)
 
-    async def _set_next_item_as_running(self):
+    async def _set_next_item_as_running(self, *, item=None):
         """
         See ``self.set_next_item_as_running()`` method.
         """
+        immediate_execution = bool(item)
+        if immediate_execution:
+            item = self.set_new_item_uuid(item)  # Creates deep copy
+            item.setdefault("properties", {})["immediate_execution"] = True
+
         # UID remains in the `self._uid_dict` after this operation.
-        if not await self._is_item_running():
-            plan_json = await self._r_pool.lpop(self._name_plan_queue)
-            if plan_json:
-                plan = json.loads(plan_json)
-                if plan["item_type"] != "plan":
-                    raise RuntimeError(
-                        "Function 'PlanQueueOperations.set_next_item_as_running' was called for "
-                        f"an item other than plan: {plan}"
-                    )
-                self._plan_queue_uid = self.new_item_uid()
-                await self._set_running_item_info(plan)
+        try:
+            if await self._is_item_running():
+                raise Exception()
+
+            if immediate_execution:
+                plan = item
             else:
-                plan = {}
-        else:
+                plan = await self._get_item(pos="front")
+                if not plan:
+                    raise Exception()
+
+            if "item_type" not in plan:
+                raise Exception()
+
+            if plan["item_type"] != "plan":
+                raise RuntimeError(
+                    "Function 'PlanQueueOperations.set_next_item_as_running' was called for "
+                    f"an item other than plan: {plan}"
+                )
+
+            if not immediate_execution:
+                # Pop plan from the front of the queue (it is the same plan as currently loaded)
+                await self._r_pool.lpop(self._name_plan_queue)
+                self._plan_queue_uid = self.new_item_uid()
+
+            await self._set_running_item_info(plan)
+
+        except RuntimeError:
+            raise
+        except Exception as ex:
             plan = {}
+
         return plan
 
-    async def set_next_item_as_running(self):
+    async def set_next_item_as_running(self, *, item=None):
         """
         Sets the next item from the queue as 'running'. The item MUST be a plan
         (e.g. not an instruction), otherwise an exception will be raised. The item is removed
         from the queue. UID remains in ``self._uid_dict``, i.e. item with the same UID
-        may not be added to the queue while it is being executed.
+        may not be added to the queue while it is being executed. If ``item`` parameter
+        represents a plan, then the plan is set for immediate execution.
 
         This function can only be applied to the plans. Use ``process_next_item`` that
         works correctly for any item (it calls this function if an item is a plan).
+
+        All plans submitted for 'immediate' execution are assigned new item UIDs to avoid
+        duplicate history entries if copies of plans from the queue are submitted.
+
+        Parameters
+        ----------
+        item: dict or None
+            The dictionary that represents a plan submitted for immediate execution.
+            If ``item`` is a plan, then the queue remains intact and the plan is
+            set for immediate execution. If ``item=None``, then the top queue item
+            is removed from the queue and set for execution.
 
         Returns
         -------
         dict
             The item that was set as currently running. If another item is currently
             set as 'running' or the queue is empty, then ``{}`` is returned.
+
+        Raises
+        ------
+        RuntimeError
+            The function is called for an item other than plan.
         """
         async with self._lock:
-            return await self._set_next_item_as_running()
+            return await self._set_next_item_as_running(item=item)
 
     async def _set_processed_item_as_completed(self, exit_status, run_uids):
         """
@@ -1560,7 +1611,7 @@ class PlanQueueOperations:
             item_cleaned["result"]["exit_status"] = exit_status
             item_cleaned["result"]["run_uids"] = run_uids
             await self._clear_running_item_info()
-            if not loop_mode:
+            if not loop_mode and not immediate_execution:
                 self._uid_dict_remove(item["item_uid"])
             await self._add_to_history(item_cleaned)
         else:

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -910,6 +910,7 @@ def qserver():
 
 
 def qserver_zmq_keys():
+
     logging.basicConfig(level=logging.WARNING)
     logging.getLogger("bluesky_queueserver").setLevel("INFO")
 

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -10,6 +10,7 @@ from .manager import RunEngineManager
 from .comms import PipeJsonRpcReceive, validate_zmq_key
 from .profile_ops import get_default_startup_dir
 from .output_streaming import PublishConsoleOutput, setup_console_output_redirection
+from .logging_setup import setup_loggers
 
 from .. import __version__
 
@@ -157,7 +158,8 @@ class WatchdogProcess:
     def run(self):
 
         logging.basicConfig(level=max(logging.WARNING, self._log_level))
-        logging.getLogger(__name__).setLevel(self._log_level)
+        setup_loggers(name=__name__, log_level=self._log_level)
+        # logging.getLogger(__name__).setLevel(self._log_level)
 
         # Requests
         self._comm_to_manager.add_method(self._start_re_worker_handler, "start_re_worker")
@@ -428,7 +430,8 @@ def start_manager():
     setup_console_output_redirection(msg_queue)
 
     logging.basicConfig(level=max(logging.WARNING, log_level))
-    logging.getLogger("bluesky_queueserver").setLevel(log_level)
+    setup_loggers(name=__name__, log_level=log_level)
+    # logging.getLogger("bluesky_queueserver").setLevel(log_level)
 
     stream_publisher = PublishConsoleOutput(
         msg_queue=msg_queue,

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -158,8 +158,7 @@ class WatchdogProcess:
     def run(self):
 
         logging.basicConfig(level=max(logging.WARNING, self._log_level))
-        setup_loggers(name=__name__, log_level=self._log_level)
-        # logging.getLogger(__name__).setLevel(self._log_level)
+        setup_loggers(log_level=self._log_level)
 
         # Requests
         self._comm_to_manager.add_method(self._start_re_worker_handler, "start_re_worker")
@@ -430,8 +429,7 @@ def start_manager():
     setup_console_output_redirection(msg_queue)
 
     logging.basicConfig(level=max(logging.WARNING, log_level))
-    setup_loggers(name=__name__, log_level=log_level)
-    # logging.getLogger("bluesky_queueserver").setLevel(log_level)
+    setup_loggers(log_level=log_level)
 
     stream_publisher = PublishConsoleOutput(
         msg_queue=msg_queue,

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -343,7 +343,7 @@ sources:
 
 class ReManager:
     def __init__(self, params=None, *, stdout=sys.__stdout__, stderr=sys.__stdout__):
-    # def __init__(self, params=None, *, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
+        # def __init__(self, params=None, *, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
         self._p = None
         self._start_manager(params, stdout=stdout, stderr=stderr)
 

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -342,7 +342,8 @@ sources:
 
 
 class ReManager:
-    def __init__(self, params=None, *, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
+    def __init__(self, params=None, *, stdout=sys.__stdout__, stderr=sys.__stdout__):
+    # def __init__(self, params=None, *, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
         self._p = None
         self._start_manager(params, stdout=stdout, stderr=stderr)
 

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -368,9 +368,10 @@ class ReManager:
         params = params or []
 
         # Set logging level for RE Manager unless it is already set in parameters
-        logging_levels = ("--verbose", "--quiet", "--silent")
-        if not any([_ in params for _ in logging_levels]):
-            params.append("--verbose")
+        #   Leads to excessive output and some tests may fail at tearup. Enable only when needed.
+        # logging_levels = ("--verbose", "--quiet", "--silent")
+        # if not any([_ in params for _ in logging_levels]):
+        #     params.append("--verbose")
 
         if not self._p:
             clear_redis_pool()

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -365,6 +365,13 @@ class ReManager:
         subprocess.Popen
             Subprocess in which the manager is running. It needs to be stopped at certain point.
         """
+        params = params or []
+
+        # Set logging level for RE Manager unless it is already set in parameters
+        logging_levels = ("--verbose", "--quiet", "--silent")
+        if not any([_ in params for _ in logging_levels]):
+            params.append("--verbose")
+
         if not self._p:
             clear_redis_pool()
 

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -342,12 +342,11 @@ sources:
 
 
 class ReManager:
-    def __init__(self, params=None, *, stdout=sys.__stdout__, stderr=sys.__stdout__):
-        # def __init__(self, params=None, *, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
+    def __init__(self, params=None, *, stdout=sys.stdout, stderr=sys.stdout):
         self._p = None
         self._start_manager(params, stdout=stdout, stderr=stderr)
 
-    def _start_manager(self, params=None, *, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
+    def _start_manager(self, params=None, *, stdout, stderr):
         """
         Start RE manager.
 
@@ -369,9 +368,9 @@ class ReManager:
 
         # Set logging level for RE Manager unless it is already set in parameters
         #   Leads to excessive output and some tests may fail at tearup. Enable only when needed.
-        # logging_levels = ("--verbose", "--quiet", "--silent")
-        # if not any([_ in params for _ in logging_levels]):
-        #     params.append("--verbose")
+        logging_levels = ("--verbose", "--quiet", "--silent")
+        if not any([_ in params for _ in logging_levels]):
+            params.append("--verbose")
 
         if not self._p:
             clear_redis_pool()
@@ -436,7 +435,7 @@ class ReManager:
 
                     # If only the first request failed, then there is a chance that the manager stops
                     try:
-                        self._p.wait(timeout)
+                        self._p.communicate(timeout=timeout)
                         self._p = None
                     except subprocess.TimeoutExpired:
                         raise RuntimeError(f"Timeout occured while waiting for the manager to stop: {msg}")
@@ -492,7 +491,7 @@ def re_manager_cmd():
     re = {"re": None}
     failed_to_start = False
 
-    def _create(params, *, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
+    def _create(params, *, stdout, stderr):
         """
         Create RE Manager. ``start-re-manager`` is called with command line parameters from
           the list ``params``.
@@ -518,7 +517,7 @@ def re_manager_cmd():
             else:
                 re["re"].kill_manager()
 
-    def create_re_manager(params=None, *, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
+    def create_re_manager(params=None, *, stdout=sys.stdout, stderr=sys.stdout):
         params = params or []
         _close()
         _create(params, stdout=stdout, stderr=stderr)

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -1653,16 +1653,10 @@ def test_process_next_item_3(pq, item_type, has_uid):
         running_item = await pq.process_next_item(item=item4)
 
         if has_uid:
-            if item_type == "plan":
-                assert running_item["item_uid"] != item4["item_uid"]
-            else:
-                assert running_item["item_uid"] == item4["item_uid"]
+            assert running_item["item_uid"] == item4["item_uid"]
         else:
-            if item_type == "plan":
-                assert "item_uid" in running_item
-                assert isinstance(running_item["item_uid"], str)
-            else:
-                assert "item_uid" not in running_item
+            assert "item_uid" in running_item
+            assert isinstance(running_item["item_uid"], str)
 
     asyncio.run(testing())
 

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -32,6 +32,8 @@ REQ_FAILED = QServerExitCodes.REQUEST_FAILED.value
 COM_ERROR = QServerExitCodes.COMMUNICATION_ERROR.value
 EXCEPTION_OCCURRED = QServerExitCodes.EXCEPTION_OCCURRED.value
 
+timeout_env_open = 10
+
 
 def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     """
@@ -67,15 +69,11 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     assert n_plans == 2, "Incorrect number of plans in the queue"
 
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
-    assert wait_for_condition(
-        time=3, condition=condition_environment_created
-    ), "Timeout while waiting for environment to be created"
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
 
-    assert wait_for_condition(
-        time=60, condition=condition_queue_processing_finished
-    ), "Timeout while waiting for process to finish"
+    assert wait_for_condition(time=60, condition=condition_queue_processing_finished)
 
     # Smoke test for 'history_get' and 'history_clear'
     assert subprocess.call(["qserver", "history", "get"]) == SUCCESS
@@ -161,9 +159,7 @@ def test_qserver_environment_close(re_manager):  # noqa: F811
     assert is_plan_running is False
 
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
-    assert wait_for_condition(
-        time=3, condition=condition_environment_created
-    ), "Timeout while waiting for environment to be opened"
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
     ttime.sleep(2)
@@ -209,9 +205,7 @@ def test_qserver_environment_destroy(re_manager):  # noqa: F811
     assert is_plan_running is False
 
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
-    assert wait_for_condition(
-        time=3, condition=condition_environment_created
-    ), "Timeout while waiting for environment to be opened"
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
     ttime.sleep(2)
@@ -229,9 +223,7 @@ def test_qserver_environment_destroy(re_manager):  # noqa: F811
     assert is_plan_running is False
 
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
-    assert wait_for_condition(
-        time=3, condition=condition_environment_created
-    ), "Timeout while waiting for environment to be opened"
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
     ttime.sleep(2)
@@ -286,10 +278,8 @@ def test_qserver_re_pause_continue(re_manager, option_pause, option_continue):  
     assert n_plans == 2, "Incorrect number of plans in the queue"
     assert is_plan_running is False
 
-    assert subprocess.call(["qserver", "environment", "open"]) == 0
-    assert wait_for_condition(
-        time=3, condition=condition_environment_created
-    ), "Timeout while waiting for environment to be opened"
+    assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
     ttime.sleep(2)
@@ -382,9 +372,7 @@ def test_qserver_manager_kill(re_manager, time_kill):  # noqa: F811
     assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == SUCCESS
 
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
-    assert wait_for_condition(
-        time=3, condition=condition_environment_created
-    ), "Timeout while waiting for environment to be opened"
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     if time_kill == "before":
         # The command that kills manager always times out
@@ -465,7 +453,7 @@ def test_qserver_env_open_various_cases(re_manager_pc_copy, additional_code, suc
     # Wait until RE Manager is started
     assert wait_for_condition(time=10, condition=condition_manager_idle)
 
-    # Attempt to create the environment
+    # Attempt to create the environment. Long timeout.
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
     assert wait_for_condition(time=30, condition=condition_manager_idle)
 
@@ -476,7 +464,7 @@ def test_qserver_env_open_various_cases(re_manager_pc_copy, additional_code, suc
         # Remove the offending patch and try to start the environment again. It should work
         patch_first_startup_file_undo(pc_path)
         assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
-        assert wait_for_condition(time=3, condition=condition_environment_created)
+        assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # Run a plan to make sure RE Manager is functional after the startup.
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num': 10, 'delay': 1}}"
@@ -510,7 +498,7 @@ def test_qserver_manager_stop_1(re_manager, option):  # noqa: F811
 
     # Attempt to create the environment
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
-    assert wait_for_condition(time=30, condition=condition_manager_idle)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_manager_idle)
 
     cmd = ["qserver", "manager", "stop"]
     if option:
@@ -534,7 +522,7 @@ def test_qserver_manager_stop_2(re_manager, option):  # noqa: F811
 
     # Attempt to create the environment
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
-    assert wait_for_condition(time=30, condition=condition_manager_idle)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_manager_idle)
 
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num': 10, 'delay': 1}}"
     assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == SUCCESS
@@ -867,9 +855,7 @@ def test_qserver_item_execute_1(re_manager, item_type, env_exists):  # noqa: F81
 
     if env_exists:
         assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
-        assert wait_for_condition(
-            time=3, condition=condition_environment_created
-        ), "Timeout while waiting for environment to be created"
+        assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     expected_result = SUCCESS if env_exists else REQ_FAILED
     expected_n_history = 1 if env_exists and (item_type == "plan") else 0
@@ -1040,7 +1026,7 @@ def test_qserver_queue_stop(re_manager, deactivate):  # noqa: F811
 
     # Attempt to create the environment
     assert subprocess.call(["qserver", "environment", "open"]) == 0
-    assert wait_for_condition(time=10, condition=condition_manager_idle)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_manager_idle)
 
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num': 10, 'delay': 1}}"
     assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == 0
@@ -1184,9 +1170,7 @@ def test_qserver_secure_1(monkeypatch, re_manager_cmd, test_mode):  # noqa: F811
     assert subprocess.call(["qserver", "allowed", "devices"], stdout=subprocess.DEVNULL) == SUCCESS
 
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
-    assert wait_for_condition(
-        time=3, condition=condition_environment_created
-    ), "Timeout while waiting for environment to be created"
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     state = get_queue_state()
     assert state["items_in_queue"] == 2

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -1207,4 +1207,5 @@ def test_qserver_zmq_keys():
 
     # Generated public key based on private key - success
     _, private_key = generate_new_zmq_key_pair()
+    print(f"Private key used for the test: '{private_key}'")
     assert subprocess.call(["qserver-zmq-keys", "--zmq-private-key", private_key]) == SUCCESS

--- a/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -91,7 +91,7 @@ def test_start_re_manager_console_output_1(re_manager_cmd, console_print, consol
         ["qserver-console-monitor"], universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
-    re_manager = re_manager_cmd(params)
+    re_manager = re_manager_cmd(params, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
@@ -124,16 +124,17 @@ def test_start_re_manager_console_output_1(re_manager_cmd, console_print, consol
         assert collected_stdout != ""
         # Verify that output from all sources is present in the output
         # Logging from manager
-        assert "INFO:bluesky_queueserver.manager.manager:" in collected_stdout
-        assert "INFO:bluesky_queueserver.manager.profile_ops:" in collected_stdout
+        assert "bluesky_queueserver.manager.manager manager:" in collected_stdout
+        assert "bluesky_queueserver.manager.profile_ops profile_ops:" in collected_stdout
         # Logging from Worker
-        assert "INFO:bluesky_queueserver.manager.worker:RE Environment is ready" in collected_stdout
+        assert "bluesky_queueserver.manager.worker worker:" in collected_stdout
+        assert "RE Environment is ready" in collected_stdout
         # Printing from live table
         assert "generator count" in collected_stdout
         assert "Run was closed:" in collected_stdout
 
     assert re_manager_stderr == ""
-    assert "INFO:bluesky_queueserver.manager.output_streaming:" in streamed_stderr
+    assert "bluesky_queueserver.manager.output_streaming" in streamed_stderr
 
     if console_print:
         check_output_contents(re_manager_stdout)

--- a/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -91,7 +91,7 @@ def test_start_re_manager_console_output_1(re_manager_cmd, console_print, consol
         ["qserver-console-monitor"], universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
-    re_manager = re_manager_cmd(params, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    re_manager = re_manager_cmd(params)
 
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
@@ -171,7 +171,7 @@ def test_cli_update_existing_plans_devices_01(
 
     # Start the manager
     params = ["--startup-dir", pc_path, "--update-existing-plans-devices", update_existing_plans_devices]
-    re_manager_cmd(params, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    re_manager_cmd(params)
 
     resp1, _ = zmq_single_request("status")
     devices_allowed_uid1 = resp1["devices_allowed_uid"]

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -725,9 +725,7 @@ def test_zmq_api_queue_item_execute_2(re_manager):  # noqa: F811
     params3a = {"item": _plan1, "user": _user, "user_group": _user_group}
     resp3a, _ = zmq_single_request("queue_item_execute", params3a)
     assert resp3a["success"] is False, f"resp={resp3a}"
-    expected_error_msg = (
-        "Failed to start execution of the item: RE Manager is not idle. RE Manager state is 'executing_queue'"
-    )
+    expected_error_msg = "Failed to start execution of the item: RE Manager is busy."
     assert resp3a["msg"] == expected_error_msg
     assert resp3a["qsize"] is None
     assert resp3a["item"]["name"] == _plan1["name"]

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -2390,12 +2390,15 @@ def test_zmq_api_re_pause_1(re_manager, pause_deferred, kill_manager, pause_befo
     resp3, _ = zmq_single_request("queue_start")
     assert resp3["success"] is True
 
-    ttime.sleep(1)  # ~50% of the first measurement in the plan
+    ttime.sleep(0.9)  # ~50% of the first measurement in the plan
+    _check_status(0, 0, "executing_queue", "running", False)
 
     resp3, _ = zmq_single_request("re_pause", params={"option": ("deferred" if pause_deferred else "immediate")})
     assert resp3["success"] is True, f"resp={resp3}"
 
-    _check_status(0, 0, "executing_queue", "running", True)
+    if pause_deferred:
+        # In case of immediate pause, the state will depend on how fast the request is processed
+        _check_status(0, 0, "executing_queue", "running", True)
 
     if kill_manager:
         if pause_before_kill:

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -162,6 +162,9 @@ def test_zmq_api_ping_status(re_manager, api_name):  # noqa F811
     assert resp["re_state"] is None
     assert resp["pause_pending"] is False
 
+    # Worker environment is initially 'closed'
+    assert resp["worker_environment_state"] == "closed"
+
     assert isinstance(resp["plan_queue_mode"], dict)
     assert resp["plan_queue_mode"]["loop"] is False
 
@@ -176,6 +179,7 @@ def test_zmq_api_environment_open_close_1(re_manager):  # noqa F811
     """
     state = get_queue_state()
     assert state["re_state"] is None
+    assert state["worker_environment_state"] == "closed"
 
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
@@ -185,6 +189,7 @@ def test_zmq_api_environment_open_close_1(re_manager):  # noqa F811
 
     state = get_queue_state()
     assert state["re_state"] == "idle"
+    assert state["worker_environment_state"] == "idle"
 
     resp2, _ = zmq_single_request("environment_close")
     assert resp2["success"] is True
@@ -194,6 +199,7 @@ def test_zmq_api_environment_open_close_1(re_manager):  # noqa F811
 
     state = get_queue_state()
     assert state["re_state"] is None
+    assert state["worker_environment_state"] == "closed"
 
 
 def test_zmq_api_environment_open_close_2(re_manager):  # noqa F811
@@ -652,6 +658,7 @@ def test_zmq_api_queue_item_execute_1(re_manager):  # noqa: F811
     resp2a, _ = zmq_single_request("status")
     assert resp2a["items_in_queue"] == 1
     assert resp2a["items_in_history"] == 0
+    assert resp2a["worker_environment_state"] == "idle"
 
     # Execute a plan
     params3 = {"item": _plan3, "user": _user, "user_group": _user_group}
@@ -660,6 +667,12 @@ def test_zmq_api_queue_item_execute_1(re_manager):  # noqa: F811
     assert resp3["msg"] == ""
     assert resp3["qsize"] == 1
     assert resp3["item"]["name"] == _plan3["name"]
+
+    ttime.sleep(1)
+    status, _ = zmq_single_request("status")
+    assert status["items_in_queue"] == 1
+    assert status["items_in_history"] == 0
+    assert status["worker_environment_state"] == "executing_plan"
 
     assert wait_for_condition(time=30, condition=condition_manager_idle)
 
@@ -676,6 +689,7 @@ def test_zmq_api_queue_item_execute_1(re_manager):  # noqa: F811
     resp3b, _ = zmq_single_request("status")
     assert resp3b["items_in_queue"] == 1
     assert resp3b["items_in_history"] == 1
+    assert resp3b["worker_environment_state"] == "idle"
 
     resp4, _ = zmq_single_request("queue_start")
     assert resp4["success"] is True
@@ -2343,7 +2357,7 @@ def test_zmq_api_environment_destroy(re_manager):  # noqa: F811
 #                           Method 're_pause'
 
 
-_plan_2steps = {"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 2, "delay": 2}, "item_type": "plan"}
+_plan_3steps = {"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 3, "delay": 2}, "item_type": "plan"}
 
 
 # fmt: off
@@ -2363,7 +2377,7 @@ def test_zmq_api_re_pause_1(re_manager, pause_deferred, kill_manager, pause_befo
     ``pause_pending`` flag is correctly set.
     """
 
-    def _check_status(n_queue, n_hist, m_state, re_state, pause_pend):
+    def _check_status(n_queue, n_hist, m_state, re_state, env_state, pause_pend):
         resp, _ = zmq_single_request("status")
         assert resp["items_in_queue"] == n_queue
         assert resp["items_in_history"] == n_hist
@@ -2372,9 +2386,10 @@ def test_zmq_api_re_pause_1(re_manager, pause_deferred, kill_manager, pause_befo
             assert resp["re_state"] in re_state, str(resp["re_state"])
         else:
             assert resp["re_state"] == re_state
+        assert resp["worker_environment_state"] == env_state
         assert resp["pause_pending"] == pause_pend
 
-    params1a = {"item": _plan_2steps, "user": _user, "user_group": _user_group}
+    params1a = {"item": _plan_3steps, "user": _user, "user_group": _user_group}
     resp1a, _ = zmq_single_request("queue_item_add", params1a)
     assert resp1a["success"] is True, f"resp={resp1a}"
 
@@ -2383,20 +2398,20 @@ def test_zmq_api_re_pause_1(re_manager, pause_deferred, kill_manager, pause_befo
     assert resp2["success"] is True
     assert wait_for_condition(time=10, condition=condition_environment_created)
 
-    _check_status(1, 0, "idle", "idle", False)
+    _check_status(1, 0, "idle", "idle", "idle", False)
 
     resp3, _ = zmq_single_request("queue_start")
     assert resp3["success"] is True
 
     ttime.sleep(0.9)  # ~50% of the first measurement in the plan
-    _check_status(0, 0, "executing_queue", "running", False)
+    _check_status(0, 0, "executing_queue", "running", "executing_plan", False)
 
     resp3, _ = zmq_single_request("re_pause", params={"option": ("deferred" if pause_deferred else "immediate")})
     assert resp3["success"] is True, f"resp={resp3}"
 
     if pause_deferred:
         # In case of immediate pause, the state will depend on how fast the request is processed
-        _check_status(0, 0, "executing_queue", "running", True)
+        _check_status(0, 0, "executing_queue", "running", "executing_plan", True)
 
     if kill_manager:
         if pause_before_kill:
@@ -2406,15 +2421,18 @@ def test_zmq_api_re_pause_1(re_manager, pause_deferred, kill_manager, pause_befo
 
     assert wait_for_condition(time=20, condition=condition_manager_paused)
 
-    _check_status(0, 0, "paused", "paused", False)
+    _check_status(0, 0, "paused", "paused", "idle", False)
 
     # Execute the remaining plans (if any plans left)
     resp4, _ = zmq_single_request("re_resume")
     assert resp4["success"] is True
 
+    ttime.sleep(1)
+    _check_status(0, 0, "executing_queue", "running", "executing_plan", False)
+
     assert wait_for_condition(time=20, condition=condition_manager_idle)
 
-    _check_status(0, 1, "idle", "idle", False)
+    _check_status(0, 1, "idle", "idle", "idle", False)
 
     # Close the environment
     resp6, _ = zmq_single_request("environment_close")
@@ -2448,7 +2466,7 @@ def test_zmq_api_re_pause_2(re_manager, n_plans, kill_manager, pause_before_kill
         assert resp["pause_pending"] == pause_pend
 
     for _ in range(n_plans):
-        params1a = {"item": _plan_2steps, "user": _user, "user_group": _user_group}
+        params1a = {"item": _plan_3steps, "user": _user, "user_group": _user_group}
         resp1a, _ = zmq_single_request("queue_item_add", params1a)
         assert resp1a["success"] is True, f"resp={resp1a}"
 
@@ -2462,7 +2480,7 @@ def test_zmq_api_re_pause_2(re_manager, n_plans, kill_manager, pause_before_kill
     resp3, _ = zmq_single_request("queue_start")
     assert resp3["success"] is True
 
-    ttime.sleep(3)  # ~50% of the second (last) measurement of the 1st plan
+    ttime.sleep(5)  # ~50% of the third (last) measurement of the 1st plan
 
     resp3, _ = zmq_single_request("re_pause", params={"option": "deferred"})
     assert resp3["success"] is True

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -10,6 +10,7 @@ import uuid
 
 from .comms import PipeJsonRpcReceive
 from .output_streaming import setup_console_output_redirection
+from .logging_setup import setup_loggers
 
 from event_model import RunRouter
 
@@ -189,7 +190,7 @@ class RunEngineWorker(Process):
                 self._re_report["re_state"] = str(self._RE._state)
 
         self._state["environment_state"] = "idle"
-        logger.debug("Finished execution of the plan")
+        logger.debug("Plan execution is completed or interrupted")
 
     def _load_new_plan(self, plan_info):
         """
@@ -673,7 +674,8 @@ class RunEngineWorker(Process):
         setup_console_output_redirection(msg_queue=self._msg_queue)
 
         logging.basicConfig(level=max(logging.WARNING, self._log_level))
-        logging.getLogger(__name__).setLevel(self._log_level)
+        setup_loggers(name=__name__, log_level=self._log_level)
+        # logging.getLogger(__name__).setLevel(self._log_level)
 
         success = True
 

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -674,8 +674,7 @@ class RunEngineWorker(Process):
         setup_console_output_redirection(msg_queue=self._msg_queue)
 
         logging.basicConfig(level=max(logging.WARNING, self._log_level))
-        setup_loggers(name=__name__, log_level=self._log_level)
-        # logging.getLogger(__name__).setLevel(self._log_level)
+        setup_loggers(name="bluesky_queueserver", log_level=self._log_level)
 
         success = True
 

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -290,6 +290,8 @@ class RunEngineWorker(Process):
                 f"Accepted state: '{EState.IDLE.value}'"
             )
 
+        self._env_state = EState.EXECUTING_PLAN
+
         logger.info("Continue plan execution with the option '%s'", option)
 
         available_options = ("resume", "abort", "stop", "halt")

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -223,8 +223,8 @@ Returns       **msg**: *str*
               **worker_environment_state**: *str*
                   current state of the worker environment. Supported states: *'initializing'*,
                   *'idle'*, *'executing_plan'*, *'executing_task'*, *'closing'* and *'closed'*.
-                  The *'executing_task'* state is not used to indicate that background tasks are
-                  executed.
+                  Running background tasks does not influence the state (*'executing_task'* is
+                  not set).
 
               **plan_queue_mode**: *dict*
                   the dictionary of parameters that determine queue execution mode. The key/value pairs

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -220,6 +220,12 @@ Returns       **msg**: *str*
                   current state of Bluesky Run Engine (see Blue Sky documentation) or *None* if
                   RE Worker environment does not exist (or closed).
 
+              **worker_environment_state**: *str*
+                  current state of the worker environment. Supported states: *'initializing'*,
+                  *'idle'*, *'executing_plan'*, *'executing_task'*, *'closing'* and *'closed'*.
+                  The *'executing_task'* state is not used to indicate that background tasks are
+                  executed.
+
               **plan_queue_mode**: *dict*
                   the dictionary of parameters that determine queue execution mode. The key/value pairs
                   in the dictionary represent parameter names and values. Supported parameters:

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -224,7 +224,8 @@ Returns       **msg**: *str*
                   current state of the worker environment. Supported states: *'initializing'*,
                   *'idle'*, *'executing_plan'*, *'executing_task'*, *'closing'* and *'closed'*.
                   Running background tasks does not influence the state (*'executing_task'* is
-                  not set).
+                  not set). The environment state is different from Run Engine state (*re_state*),
+                  e.g. the environment is considered *idle* when the current plan is paused.
 
               **plan_queue_mode**: *dict*
                   the dictionary of parameters that determine queue execution mode. The key/value pairs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes that extend functionality of the queue server:
- Extend the set of states of worker environment. Currently used states include `initializing`, `idle`, `executing_plan`, `executing_task`, `closing`, `closed`.
- Return the state of worker environment as a `worker_environment_state` status parameter of RE Manager

Maintenance (most of the PR):
- Modified code that is used to start and stop the manager during unit tests. The manager is now started in `--verbose` mode, `stdout` and `stderr` are captured and displayed for failing tests (useful for finding issues). The code for stopping the manager is now more robust and successfully stops the manager in most failing cases (the test is still registered as failed, but it is much less likely that consecutive tests using RE Manager will fail as well).
- Used detailed logging to find issues with that were making unit tests increasingly unreliable (especially on CI). The detected issues were minor and would manifest only in specific circumstances. For example, calling `queue_item_execute` followed by any queue operation that would affect the first item in the queue (e.g. using `add_item` to add a plan to the front of the queue) in rapid succession (within a few ms) could make Queue Server fail with significant probability. The necessary changes to the code were implemented to fix those issues. The changes are not expected to affect functionality of the Queue Server.

## Motivation and Context
The state of worker environment will be used extensively in implementation of new features of the Queue Server. It may also be useful to monitor the state of the worker to diagnose issues with the environment (especially in testing). 

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed
- Numerous fixes related to reliability of Queue Server operation.

### Added
- Extended the number of states of worker environment. Currently used states include `initializing`, `idle`, `executing_plan`, `executing_task`, `closing`, `closed`. 
- The state of the worker environment is returned as an RE Manager status parameter (`status` 0MQ API). The parameter name is `worker_environment_state`.

### Changed

### Removed

## How Has This Been Tested?
Unit tests were extended to check if the state is updated correctly after opening the environment, executing plan queue, executing individual plans, pausing the plan.
