### PR TITLE
Implementation of 'script_upload' 0MQ API

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1864,6 +1864,11 @@ class RunEngineManager(Process):
 
         return {"success": success, "msg": msg}
 
+    async def _script_upload_handler(self, request):
+        logger.info("Uploading script to RE environment ...")
+        success, msg = True, ""
+        return {"success": success, "msg": msg}
+
     async def _queue_start_handler(self, request):
         """
         Start execution of the loaded queue. Additional runs can be added to the queue while
@@ -2121,6 +2126,7 @@ class RunEngineManager(Process):
             "environment_open": "_environment_open_handler",
             "environment_close": "_environment_close_handler",
             "environment_destroy": "_environment_destroy_handler",
+            "script_upload": "_script_upload_handler",
             "queue_mode_set": "_queue_mode_set_handler",
             "queue_item_add": "_queue_item_add_handler",
             "queue_item_add_batch": "_queue_item_add_batch_handler",

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -145,7 +145,7 @@ class RunEngineManager(Process):
         self._allowed_plans_uid = _generate_uid()
         self._allowed_devices_uid = _generate_uid()
 
-        self._task_results = TaskResults(retention_time=120)
+        self._task_results = None  # TaskResults(), uses threading.Lock
 
     async def _heartbeat_generator(self):
         """
@@ -2326,6 +2326,8 @@ class RunEngineManager(Process):
         self._comm_to_worker = PipeJsonRpcSendAsync(conn=self._worker_conn, name="RE Manager-Worker Comm")
         self._comm_to_watchdog.start()
         self._comm_to_worker.start()
+
+        self._task_results = TaskResults(retention_time=120)
 
         # Start heartbeat generator
         self._heartbeat_generator_task = asyncio.ensure_future(self._heartbeat_generator(), loop=self._loop)

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -823,12 +823,13 @@ class RunEngineManager(Process):
         Success does not mean that the script is successfully loaded.
         """
         if not self._environment_exists:
-            success, err_msg = False, "RE Worker environment is not opened"
+            success, err_msg, task_uid = False, "RE Worker environment is not opened", None
         elif not run_in_background and (self._manager_state != MState.IDLE):
-            success, err_msg = (
+            success, err_msg, task_uid = (
                 False,
                 "Failed to start the task: RE Manager must be in idle state. "
                 f"Current state: '{self._manager_state.value}'",
+                None,
             )
         else:
             try:

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1234,17 +1234,17 @@ class RunEngineManager(Process):
             if user_group not in self._allowed_plans:
                 raise Exception(f"Unknown user group: '{user_group}'")
 
-            plans_allowed = self._allowed_plans[user_group]
+            plans_allowed, plans_allowed_uid = self._allowed_plans[user_group], self._allowed_plans_uid
             success, msg = True, ""
         except Exception as ex:
-            plans_allowed = {}
+            plans_allowed, plans_allowed_uid = {}, None
             success, msg = False, str(ex)
 
         return {
             "success": success,
             "msg": msg,
             "plans_allowed": plans_allowed,
-            "plans_allowed_uid": self._allowed_plans_uid,
+            "plans_allowed_uid": plans_allowed_uid,
         }
 
     async def _plans_existing_handler(self, request):
@@ -1257,17 +1257,17 @@ class RunEngineManager(Process):
             supported_param_names = []
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
 
-            plans_existing = self._existing_plans
+            plans_existing, plans_existing_uid = self._existing_plans, self._existing_plans_uid
             success, msg = True, ""
         except Exception as ex:
-            plans_existing = {}
+            plans_existing, plans_existing_uid = {}, None
             success, msg = False, str(ex)
 
         return {
             "success": success,
             "msg": msg,
             "plans_existing": plans_existing,
-            "plans_existing_uid": self._existing_plans_uid,
+            "plans_existing_uid": plans_existing_uid,
         }
 
     async def _devices_allowed_handler(self, request):
@@ -1288,17 +1288,17 @@ class RunEngineManager(Process):
             if user_group not in self._allowed_devices:
                 raise Exception(f"Unknown user group: '{user_group}'")
 
-            devices_allowed = self._allowed_devices[user_group]
+            devices_allowed, devices_allowed_uid = self._allowed_devices[user_group], self._allowed_devices_uid
             success, msg = True, ""
         except Exception as ex:
-            devices_allowed = {}
+            devices_allowed, devices_allowed_uid = {}, None
             success, msg = False, str(ex)
 
         return {
             "success": success,
             "msg": msg,
             "devices_allowed": devices_allowed,
-            "devices_allowed_uid": self._allowed_devices_uid,
+            "devices_allowed_uid": devices_allowed_uid,
         }
 
     async def _devices_existing_handler(self, request):
@@ -1312,16 +1312,17 @@ class RunEngineManager(Process):
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
 
             devices_existing = self._existing_devices
+            devices_existing_uid = self._existing_devices_uid
             success, msg = True, ""
         except Exception as ex:
-            devices_existing = {}
+            devices_existing, devices_existing_uid = {}, None
             success, msg = False, str(ex)
 
         return {
             "success": success,
             "msg": msg,
             "devices_existing": devices_existing,
-            "devices_existing_uid": self._existing_devices_uid,
+            "devices_existing_uid": devices_existing_uid,
         }
 
     async def _permissions_reload_handler(self, request):

--- a/bluesky_queueserver/manager/task_results.py
+++ b/bluesky_queueserver/manager/task_results.py
@@ -1,48 +1,118 @@
 import time as ttime
-import threading
+import asyncio
 import uuid
 
 
 class TaskResults:
+    """
+    The class that defines an object for storage and management of the results of tasks.
+
+    Parameters
+    ----------
+    retention_time: float
+        Defines minimum life time of the results of the completed tasks stored
+        by the object.
+    """
+
+    # TODO: It may be a good idea to store the results or backup of the results in Redis
+    #       so that they persist if the manager process is restarted. The class contains some
+    #       infrastructure, in particular all operations on the lists of task results are
+    #       protected by 'asyncio.Lock' and methods are made `async`.
     def __init__(self, *, retention_time=120):
         self._retention_time = retention_time
         self._running_tasks = {}
         self._completed_tasks_time = []
         self._completed_tasks_data = {}
-        self._lock = threading.Lock()
+        self._lock = asyncio.Lock()
 
         self._task_results_uid = None
         self._update_task_results_uid()
 
     def _update_task_results_uid(self):
+        """
+        Generate a new UID of the state of the object. UID should be update
+        each time the new result of a completed task is added. UID is used
+        to inform client applications that initiated execution of a task that
+        some task was completed and it is reasonable to check if the result
+        for the specific task is ready.
+        """
         self._task_results_uid = str(uuid.uuid4())
 
     @property
     def task_results_uid(self):
+        """
+        Return UID of the list of task results.
+        """
         return self._task_results_uid
 
-    def clear(self):
-        self._running_tasks.clear()
-        self._completed_tasks_time.clear()
-        self._completed_tasks_data.clear()
+    async def clear(self):
+        """
+        Clear the lists of running and completed tasks.
+        """
+        async with self._lock:
+            self._running_tasks.clear()
+            self._completed_tasks_time.clear()
+            self._completed_tasks_data.clear()
 
-    def add_running_task(self, *, task_uid, payload=None):
+    async def clear_running_tasks(self):
+        """
+        Clear the list of running tasks.
+        """
+        async with self._lock:
+            self._running_tasks.clear()
+
+    async def add_running_task(self, *, task_uid, payload=None):
+        """
+        Add a task to the list of running tasks.
+
+        Parameters
+        ----------
+        task_uid: str
+            UID of the task
+        payload: dict
+            Dictionary that contain information on the running task
+            (such as UID, start time etc.). This dictionary is passed to
+            the client application when requested.
+        """
         payload = payload or {}
-        with self._lock:
+        async with self._lock:
             self._running_tasks[task_uid] = {"time": ttime.time(), "payload": payload}
-            self._update_task_results_uid()
 
     def _remove_running_task(self, *, task_uid):
+        """
+        See docstring for ``self.remove_running_task()``.
+        """
         if task_uid in self._running_tasks:
             del self._running_tasks[task_uid]
 
-    def remove_running_task(self, *, task_uid):
-        with self._lock:
+    async def remove_running_task(self, *, task_uid):
+        """
+        Remove running task from the list of running tasks.
+
+        Parameters
+        ----------
+        task_uid: str
+            UID of the task to be removed.
+        """
+        async with self._lock:
             self._remove_running_task(task_uid=task_uid)
 
-    def add_completed_task(self, *, task_uid, payload=None):
+    async def add_completed_task(self, *, task_uid, payload=None):
+        """
+        Add task to the list of completed task (and remove it from the list of running tasks).
+        The function is updating ``task_results_uid`` to inform that there are tasks that
+        were just completed.
+
+        Parameters
+        ----------
+        task_uid: str
+            UID of the new task
+        payload: dict or None
+            Dictionary with the results of the task execution. If ``None``, the payload is set
+            to ``{}`` (empty dictionary).
+        """
         payload = payload or {}
-        with self._lock:
+        async with self._lock:
             self._clean_completed_tasks()
             self._remove_running_task(task_uid=task_uid)
             insertion_time = ttime.time()
@@ -50,8 +120,27 @@ class TaskResults:
             self._completed_tasks_time.append({"task_uid": task_uid, "time": insertion_time})
             self._update_task_results_uid()
 
-    def get_task_info(self, *, task_uid):
-        with self._lock:
+    async def get_task_info(self, *, task_uid):
+        """
+        Return information on the task with ``task_uid``. The function returns a tuple, which
+        contains task status and available information on the task or result of the task
+        execution.
+
+        Parameters
+        ----------
+        task_uid: str
+            UID of the task
+
+        Returns
+        -------
+        status: str
+            Status of the task with ``task_uid``. Status values are ``running``, ``completed``
+            and ``not_found``.
+        payload: dict
+            Dictionary with task information for a running task or task results for completed task.
+            If ``status`` is ``not_found``, then payload is ``{}`` (empty dictionary).
+        """
+        async with self._lock:
             if task_uid in self._completed_tasks_data:
                 status, payload = "completed", self._completed_tasks_data[task_uid]["payload"]
             elif task_uid in self._running_tasks:
@@ -62,9 +151,9 @@ class TaskResults:
         return status, payload
 
     def _clean_completed_tasks(self):
-
-        changed = False
-
+        """
+        See the docstring for ``self.clean_completed_tasks()``.
+        """
         time_threshold = ttime.time() - self._retention_time
         ctt = self._completed_tasks_time
         while ctt and (ctt[0]["time"] < time_threshold):
@@ -72,11 +161,11 @@ class TaskResults:
             ctt.pop(0)
             if task_uid in self._completed_tasks_info:
                 del self._completed_tasks_info[task_uid]
-                changed = True
 
-        if changed:
-            self._update_task_results_uid()
-
-    def clean_completed_tasks(self):
-        with self._lock:
+    async def clean_completed_tasks(self):
+        """
+        Remove expired tasks from the list of completed task. The ``retention_time`` parameter of
+        the class constructor is used to identify the expired tasks.
+        """
+        async with self._lock:
             self._clean_completed_tasks()

--- a/bluesky_queueserver/manager/task_results.py
+++ b/bluesky_queueserver/manager/task_results.py
@@ -63,7 +63,8 @@ class TaskResults:
 
     async def add_running_task(self, *, task_uid, payload=None):
         """
-        Add a task to the list of running tasks.
+        Add a task to the list of running tasks. For teach task UID, the payload
+        passed as a parameter and time of insertion is saved.
 
         Parameters
         ----------
@@ -159,8 +160,8 @@ class TaskResults:
         while ctt and (ctt[0]["time"] < time_threshold):
             task_uid = ctt[0]["task_uid"]
             ctt.pop(0)
-            if task_uid in self._completed_tasks_info:
-                del self._completed_tasks_info[task_uid]
+            if task_uid in self._completed_tasks_data:
+                del self._completed_tasks_data[task_uid]
 
     async def clean_completed_tasks(self):
         """

--- a/bluesky_queueserver/manager/task_results.py
+++ b/bluesky_queueserver/manager/task_results.py
@@ -1,0 +1,82 @@
+import time as ttime
+import threading
+import uuid
+
+
+class TaskResults:
+    def __init__(self, *, retention_time=120):
+        self._retention_time = retention_time
+        self._running_tasks = {}
+        self._completed_tasks_time = []
+        self._completed_tasks_data = {}
+        self._lock = threading.Lock()
+
+        self._task_results_uid = None
+        self._update_task_results_uid()
+
+    def _update_task_results_uid(self):
+        self._task_results_uid = str(uuid.uuid4())
+
+    @property
+    def task_results_uid(self):
+        return self._task_results_uid
+
+    def clear(self):
+        self._running_tasks.clear()
+        self._completed_tasks_time.clear()
+        self._completed_tasks_data.clear()
+
+    def add_running_task(self, *, task_uid, payload=None):
+        payload = payload or {}
+        with self._lock:
+            self._running_tasks[task_uid] = {"time": ttime.time(), "payload": payload}
+            self._update_task_results_uid()
+
+    def _remove_running_task(self, *, task_uid):
+        if task_uid in self._running_tasks:
+            del self._running_tasks[task_uid]
+
+    def remove_running_task(self, *, task_uid):
+        with self._lock:
+            self._remove_running_task(task_uid=task_uid)
+
+    def add_completed_task(self, *, task_uid, payload=None):
+        payload = payload or {}
+        with self._lock:
+            self._clean_completed_tasks()
+            self._remove_running_task(task_uid=task_uid)
+            insertion_time = ttime.time()
+            self._completed_tasks_data[task_uid] = {"time": insertion_time, "payload": payload}
+            self._completed_tasks_time.append({"task_uid": task_uid, "time": insertion_time})
+            self._update_task_results_uid()
+
+    def get_task_info(self, *, task_uid):
+        with self._lock:
+            if task_uid in self._completed_tasks_data:
+                status, payload = "completed", self._completed_tasks_data[task_uid]["payload"]
+            elif task_uid in self._running_tasks:
+                status, payload = "running", self._running_tasks[task_uid]["payload"]
+            else:
+                status, payload = "not_found", {}
+
+        return status, payload
+
+    def _clean_completed_tasks(self):
+
+        changed = False
+
+        time_threshold = ttime.time() - self._retention_time
+        ctt = self._completed_tasks_time
+        while ctt and (ctt[0]["time"] < time_threshold):
+            task_uid = ctt[0]["task_uid"]
+            ctt.pop(0)
+            if task_uid in self._completed_tasks_info:
+                del self._completed_tasks_info[task_uid]
+                changed = True
+
+        if changed:
+            self._update_task_results_uid()
+
+    def clean_completed_tasks(self):
+        with self._lock:
+            self._clean_completed_tasks()

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -20,7 +20,7 @@ import logging
 logger = logging.Logger(__name__)
 
 
-def copy_default_profile_collection(tmp_path, *, copy_yaml=True):
+def copy_default_profile_collection(tmp_path, *, copy_py=True, copy_yaml=True):
     """
     Copy default profile collections (only .py files) to temporary directory.
     Returns the new temporary directory.
@@ -33,7 +33,9 @@ def copy_default_profile_collection(tmp_path, *, copy_yaml=True):
     os.makedirs(new_pc_path, exist_ok=True)
 
     # Copy simulated profile collection (only .py files)
-    patterns = ["*.py", "*.ipy"]
+    patterns = []
+    if copy_py:
+        patterns.extend(["*.py", "*.ipy"])
     if copy_yaml:
         patterns.append("*.yaml")
     for pattern in patterns:

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -282,7 +282,7 @@ def wait_for_task_result(time, task_uid):
     timeout ``time`` is exceeded while waiting for the task result. Returns the task result
     of the task only if it was completed.
     """
-    dt = 0.5  # Period for checking if the task is available
+    dt = 0.2  # Period for checking if the task is available
     time_stop = ttime.time() + time
     while ttime.time() < time_stop:
         ttime.sleep(dt / 2)

--- a/bluesky_queueserver/manager/tests/test_task_results.py
+++ b/bluesky_queueserver/manager/tests/test_task_results.py
@@ -8,11 +8,16 @@ def test_TaskResults_update_uid():
     """
     TaskResults: Test that task result UID is updated.
     """
-    tr = TaskResults()
-    uid = tr.task_results_uid
-    assert isinstance(uid, str)
-    tr._update_task_results_uid()
-    assert tr.task_results_uid != tr
+
+    async def testing():
+        tr = TaskResults()
+
+        uid = tr.task_results_uid
+        assert isinstance(uid, str)
+        tr._update_task_results_uid()
+        assert tr.task_results_uid != uid
+
+    asyncio.run(testing())
 
 
 def test_TaskResults_add_running_task():

--- a/bluesky_queueserver/manager/tests/test_task_results.py
+++ b/bluesky_queueserver/manager/tests/test_task_results.py
@@ -1,0 +1,241 @@
+import asyncio
+import time as ttime
+
+from bluesky_queueserver.manager.task_results import TaskResults
+
+
+def test_TaskResults_update_uid():
+    """
+    TaskResults: Test that task result UID is updated.
+    """
+    tr = TaskResults()
+    uid = tr.task_results_uid
+    assert isinstance(uid, str)
+    tr._update_task_results_uid()
+    assert tr.task_results_uid != tr
+
+
+def test_TaskResults_add_running_task():
+    """
+    TaskResults: tests for ``add_running_task``, ``clear_running_task``
+    """
+
+    async def testing():
+        tr = TaskResults()
+
+        assert tr._running_tasks == {}
+        uid = tr.task_results_uid
+
+        await tr.add_running_task(task_uid="abc")
+        await tr.add_running_task(task_uid="def", payload={"some_value": 10})
+        assert len(tr._running_tasks) == 2
+
+        assert tr._running_tasks["abc"]["payload"] == {}
+        assert isinstance(tr._running_tasks["abc"]["time"], float)
+        assert tr._running_tasks["def"]["payload"] == {"some_value": 10}
+        assert isinstance(tr._running_tasks["def"]["time"], float)
+
+        await tr.clear_running_tasks()
+        assert tr._running_tasks == {}
+
+        # UID is not expected to change
+        assert tr.task_results_uid == uid
+
+    asyncio.run(testing())
+
+
+def test_TaskResults_remove_running_task():
+    """
+    TaskResults: tests for ``remove_running_task``
+    """
+
+    async def testing():
+        tr = TaskResults()
+
+        assert tr._running_tasks == {}
+        uid = tr.task_results_uid
+
+        await tr.add_running_task(task_uid="abc")
+        await tr.add_running_task(task_uid="def", payload={"some_value": 10})
+        assert len(tr._running_tasks) == 2
+
+        await tr.remove_running_task(task_uid="abc")
+
+        assert len(tr._running_tasks) == 1
+        assert tr._running_tasks["def"]["payload"] == {"some_value": 10}
+        assert isinstance(tr._running_tasks["def"]["time"], float)
+
+        # UID is not expected to change
+        assert tr.task_results_uid == uid
+
+    asyncio.run(testing())
+
+
+def test_TaskResults_add_completed_task():
+    """
+    TaskResults: tests for ``add_running_task``, ``clear_running_task``
+    """
+
+    async def testing():
+        tr = TaskResults()
+
+        uid1 = tr.task_results_uid
+
+        # Add running tasks. The running tasks should be removed as completed tasks
+        #   with the same UID are added.
+        await tr.add_running_task(task_uid="abc", payload={"some_value": "arbitrary_payload"})
+        await tr.add_running_task(task_uid="def", payload={"some_value": "arbitrary_payload"})
+
+        assert tr.task_results_uid == uid1
+
+        assert tr._completed_tasks_time == []
+        assert tr._completed_tasks_data == {}
+        assert len(tr._running_tasks) == 2
+
+        await tr.add_completed_task(task_uid="abc")
+        uid2 = tr.task_results_uid
+        await tr.add_completed_task(task_uid="def", payload={"some_value": 10})
+        uid3 = tr.task_results_uid
+
+        assert len(tr._completed_tasks_time) == 2
+        assert len(tr._completed_tasks_data) == 2
+        assert len(tr._running_tasks) == 0
+
+        assert uid1 != uid2
+        assert uid2 != uid3
+
+        assert tr._completed_tasks_data["abc"]["payload"] == {}
+        assert isinstance(tr._completed_tasks_data["abc"]["time"], float)
+        assert tr._completed_tasks_time[0]["task_uid"] == "abc"
+        assert tr._completed_tasks_time[0]["time"] == tr._completed_tasks_data["abc"]["time"]
+        assert tr._completed_tasks_data["def"]["payload"] == {"some_value": 10}
+        assert isinstance(tr._completed_tasks_data["def"]["time"], float)
+        assert tr._completed_tasks_time[1]["task_uid"] == "def"
+        assert tr._completed_tasks_time[1]["time"] == tr._completed_tasks_data["def"]["time"]
+
+        await tr.clear()
+        assert tr._completed_tasks_time == []
+        assert tr._completed_tasks_data == {}
+
+        # UID is not expected to change
+        assert tr.task_results_uid == uid3
+
+    asyncio.run(testing())
+
+
+def test_TaskResults_clear():
+    """
+    TaskResults: tests for ``clear``
+    """
+
+    async def testing():
+        tr = TaskResults()
+
+        await tr.add_running_task(task_uid="abc", payload={"some_value": "arbitrary_payload"})
+        await tr.add_running_task(task_uid="def", payload={"some_value": "arbitrary_payload"})
+        await tr.add_completed_task(task_uid="abc")
+
+        assert len(tr._completed_tasks_time) == 1
+        assert len(tr._completed_tasks_data) == 1
+        assert len(tr._running_tasks) == 1
+
+        uid = tr.task_results_uid
+        await tr.clear()
+
+        assert tr._running_tasks == {}
+        assert tr._completed_tasks_time == []
+        assert tr._completed_tasks_data == {}
+
+        # UID is not expected to change
+        assert tr.task_results_uid == uid
+
+    asyncio.run(testing())
+
+
+def test_TaskResults_clean_completed_tasks_1():
+    """
+    TaskResults: tests for ``clean_completed_tasks``
+    """
+
+    async def testing():
+        tr = TaskResults(retention_time=1)  # Intentionally set short retention time
+
+        await tr.add_completed_task(task_uid="abc")
+        assert len(tr._completed_tasks_data) == 1
+        assert len(tr._completed_tasks_time) == 1
+
+        await tr.clean_completed_tasks()  # No effect
+        assert len(tr._completed_tasks_data) == 1
+        assert len(tr._completed_tasks_time) == 1
+
+        ttime.sleep(0.8)
+
+        # 'add_completed_task' is expected to 'clean' tha task list, but there are no expired tasks yet.
+        await tr.add_completed_task(task_uid="def", payload={"some_value": 10})
+        assert len(tr._completed_tasks_data) == 2
+        assert len(tr._completed_tasks_time) == 2
+
+        ttime.sleep(0.5)
+
+        await tr.clean_completed_tasks()  # Should remove the 1st task
+        assert len(tr._completed_tasks_data) == 1
+        assert len(tr._completed_tasks_time) == 1
+
+        ttime.sleep(0.8)
+        await tr.clean_completed_tasks()  # Should remove the 2nd task
+        assert len(tr._completed_tasks_data) == 0
+        assert len(tr._completed_tasks_time) == 0
+
+    asyncio.run(testing())
+
+
+def test_TaskResults_clean_completed_tasks_2():
+    """
+    TaskResults: tests that ``clean_completed_tasks`` is implicitely called when completed task is added.
+    """
+
+    async def testing():
+        tr = TaskResults(retention_time=1)  # Intentionally set short retention time
+
+        await tr.add_completed_task(task_uid="abc")
+        assert len(tr._completed_tasks_data) == 1
+        assert len(tr._completed_tasks_time) == 1
+
+        ttime.sleep(1.5)
+
+        # Adds the 2nd task, but removes the 1st (because it is expired)
+        await tr.add_completed_task(task_uid="def", payload={"some_value": 10})
+        assert len(tr._completed_tasks_data) == 1
+        assert len(tr._completed_tasks_time) == 1
+
+        assert tr._completed_tasks_time[0]["task_uid"] == "def"
+        assert list(tr._completed_tasks_data.keys())[0] == "def"
+
+    asyncio.run(testing())
+
+
+def test_TaskResults_get_task_info():
+    """
+    TaskResults: ``get_task_info``.
+    """
+
+    async def testing():
+        tr = TaskResults(retention_time=1)  # Intentionally set short retention time
+
+        await tr.add_running_task(task_uid="abc", payload={"some_value": 5})
+        await tr.add_running_task(task_uid="def", payload={"some_value": 10})
+        await tr.add_completed_task(task_uid="def", payload={"some_value": 20})
+
+        status, payload = await tr.get_task_info(task_uid="abc")
+        assert status == "running"
+        assert payload == {"some_value": 5}
+
+        status, payload = await tr.get_task_info(task_uid="def")
+        assert status == "completed"
+        assert payload == {"some_value": 20}
+
+        status, payload = await tr.get_task_info(task_uid="gih")
+        assert status == "not_found"
+        assert payload == {}
+
+    asyncio.run(testing())

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1381,14 +1381,29 @@ def test_zmq_api_script_upload_1(re_manager):  # noqa: F811
     assert resp2["success"] is True
     assert wait_for_condition(time=10, condition=condition_environment_created)
 
+    status, _ = zmq_single_request("status")
+    task_results_uid = status["task_results_uid"]
+    assert isinstance(task_results_uid, str)
+
     script = "a = 10\nb=20\n"
 
     resp3, _ = zmq_single_request("script_upload", params={"script": script})
-    assert resp3["success"] is True
+    assert resp3["success"] is True, pprint.pformat(resp3)
     assert resp3["msg"] == ""
     assert resp3["task_uid"]
-    assert isinstance(resp3["task_uid"], str)
+    task_uid = resp3["task_uid"]
+    assert isinstance(task_uid, str)
     ttime.sleep(1)
+
+    resp4, _ = zmq_single_request("task_load_result", params={"task_uid": task_uid})
+    assert resp4["success"] is True
+    assert resp4["msg"] == ""
+    assert resp4["task_uid"] == task_uid
+    assert resp4["status"] == "completed"
+    assert isinstance(resp4["result"], dict)
+
+    status, _ = zmq_single_request("status")
+    assert status["task_results_uid"] != task_results_uid
 
     # resp2a, _ = zmq_single_request("status")
     # assert resp2a["items_in_queue"] == 1

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1514,11 +1514,13 @@ def test_zmq_api_plans_allowed_and_devices_allowed_1(re_manager):  # noqa F811
     assert resp1["msg"] == ""
     assert isinstance(resp1["plans_allowed"], dict)
     assert len(resp1["plans_allowed"]) > 0
+    assert isinstance(resp1["plans_allowed_uid"], str)
     resp2, _ = zmq_single_request("devices_allowed", params)
     assert resp2["success"] is True
     assert resp2["msg"] == ""
     assert isinstance(resp2["devices_allowed"], dict)
     assert len(resp2["devices_allowed"]) > 0
+    assert isinstance(resp2["devices_allowed_uid"], str)
 
 
 def test_zmq_api_plans_allowed_and_devices_allowed_2(re_manager):  # noqa F811
@@ -1569,11 +1571,54 @@ def test_zmq_api_plans_allowed_and_devices_allowed_3_fail(re_manager, params, me
     assert message in resp1["msg"]
     assert isinstance(resp1["plans_allowed"], dict)
     assert len(resp1["plans_allowed"]) == 0
+    assert resp1["plans_allowed_uid"] is None
     resp2, _ = zmq_single_request("devices_allowed", params)
     assert resp1["success"] is False
     assert message in resp1["msg"]
     assert isinstance(resp2["devices_allowed"], dict)
     assert len(resp2["devices_allowed"]) == 0
+    assert resp2["devices_allowed_uid"] is None
+
+
+# =======================================================================================
+#                      Method 'plans_existing', 'devices_existing'
+
+
+def test_zmq_api_plans_existing_and_devices_existing_1(re_manager):  # noqa F811
+    """
+    Basic calls to 'plans_existing', 'devices_existing' methods.
+    """
+    resp1, _ = zmq_single_request("plans_existing")
+    assert resp1["success"] is True
+    assert resp1["msg"] == ""
+    assert isinstance(resp1["plans_existing"], dict)
+    assert len(resp1["plans_existing"]) > 0
+    assert isinstance(resp1["plans_existing_uid"], str)
+    resp2, _ = zmq_single_request("devices_existing")
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+    assert isinstance(resp2["devices_existing"], dict)
+    assert len(resp2["devices_existing"]) > 0
+    assert isinstance(resp2["devices_existing_uid"], str)
+
+
+def test_zmq_api_plans_existing_and_devices_existing_2_fail(re_manager):  # noqa F811
+    """
+    Test that 'plans_existing', 'devices_existing' methods fail if extra parameters are passed.
+    """
+    params = {"user_group": _user_group}  # 'user_group' is not supported by the methods
+
+    resp1, _ = zmq_single_request("plans_existing", params=params)
+    assert resp1["success"] is False
+    assert "API request contains unsupported parameters: 'user_group'." in resp1["msg"]
+    assert resp1["plans_existing"] == {}
+    assert resp1["plans_existing_uid"] is None
+
+    resp2, _ = zmq_single_request("devices_existing", params=params)
+    assert resp2["success"] is False
+    assert "API request contains unsupported parameters: 'user_group'." in resp2["msg"]
+    assert resp2["devices_existing"] == {}
+    assert resp2["devices_existing_uid"] is None
 
 
 # =======================================================================================

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1871,7 +1871,7 @@ def test_zmq_api_script_upload_7(re_manager):  # noqa: F811
     # Run the script in foreground
     long_script = "import time as tt\ntt.sleep(20)\n"
     resp2, _ = zmq_single_request("script_upload", params={"script": long_script})
-    assert resp2["success"] == True
+    assert resp2["success"] is True
 
     # Attempt to close the environment
     resp3, _ = zmq_single_request("environment_close")
@@ -1903,7 +1903,7 @@ def test_zmq_api_script_upload_8_fail(re_manager):  # noqa: F811
     'script_upload' API: Check if call fails if the environment is not open.
     """
     resp2, _ = zmq_single_request("script_upload", params={"script": _script_to_upload_1})
-    assert resp2["success"] == False
+    assert resp2["success"] is False
     assert "RE Worker environment is not opened" in resp2["msg"]
 
 
@@ -1921,30 +1921,32 @@ def test_zmq_api_script_upload_9_fail(re_manager, test_with_plan):  # noqa: F811
 
     if test_with_plan:
         # Now try to run a simple plan and make sure it works
-        resp2a, _ = zmq_single_request("queue_item_add", {"item": _plan3, "user": _user, "user_group": _user_group})
+        resp2a, _ = zmq_single_request(
+            "queue_item_add", {"item": _plan3, "user": _user, "user_group": _user_group}
+        )
         assert resp2a["success"] is True
         resp2b, _ = zmq_single_request("queue_start")
         assert resp2b["success"] is True
     else:
         script = "import time as tt\ntt.sleep(3)\n"
         resp3, _ = zmq_single_request("script_upload", params={"script": script})
-        assert resp3["success"] == True
+        assert resp3["success"] is True
 
     resp4a, _ = zmq_single_request("script_upload", params={"script": _script_to_upload_1})
-    assert resp4a["success"] == False
+    assert resp4a["success"] is False
     assert "RE Manager must be in idle state" in resp4a["msg"], resp4a["msg"]
 
     ttime.sleep(1)
 
     resp4b, _ = zmq_single_request("script_upload", params={"script": _script_to_upload_1})
-    assert resp4b["success"] == False
+    assert resp4b["success"] is False
     assert "RE Manager must be in idle state" in resp4b["msg"], resp4b["msg"]
 
     assert wait_for_condition(time=10, condition=condition_manager_idle)
 
     # Now try again, it should work
     resp5, _ = zmq_single_request("script_upload", params={"script": _script_to_upload_1})
-    assert resp5["success"] == True
+    assert resp5["success"] is True
     wait_for_task_result(time=10, task_uid=resp5["task_uid"])
 
     resp6, _ = zmq_single_request("environment_close")

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1395,6 +1395,8 @@ def test_zmq_api_script_upload_1(re_manager, run_in_background):  # noqa: F811
     task_results_uid = status["task_results_uid"]
     plans_allowed_uid = status["plans_allowed_uid"]
     devices_allowed_uid = status["devices_allowed_uid"]
+    plans_existing_uid = status["plans_existing_uid"]
+    devices_existing_uid = status["devices_existing_uid"]
     assert isinstance(task_results_uid, str)
 
     # Make the plan sleep for 1 second (emulates a script that takes 1s to load)
@@ -1418,6 +1420,8 @@ def test_zmq_api_script_upload_1(re_manager, run_in_background):  # noqa: F811
     assert status["task_results_uid"] == task_results_uid
     assert status["plans_allowed_uid"] == plans_allowed_uid
     assert status["devices_allowed_uid"] == devices_allowed_uid
+    assert status["plans_existing_uid"] == plans_existing_uid
+    assert status["devices_existing_uid"] == devices_existing_uid
     assert status["manager_state"] == "idle" if run_in_background else "executing_task"
 
     resp3, _ = zmq_single_request("task_load_result", params={"task_uid": task_uid})
@@ -1437,6 +1441,8 @@ def test_zmq_api_script_upload_1(re_manager, run_in_background):  # noqa: F811
     assert status["task_results_uid"] != task_results_uid
     assert status["plans_allowed_uid"] != plans_allowed_uid
     assert status["devices_allowed_uid"] != devices_allowed_uid
+    assert status["plans_existing_uid"] != plans_existing_uid
+    assert status["devices_existing_uid"] != devices_existing_uid
     assert status["manager_state"] == "idle"
     assert status["worker_environment_state"] == "idle"
     assert status["items_in_queue"] == 0
@@ -1464,6 +1470,14 @@ def test_zmq_api_script_upload_1(re_manager, run_in_background):  # noqa: F811
     resp5b, _ = zmq_single_request("devices_allowed", params={"user_group": _user_group})
     assert resp5b["success"] is True, resp5b
     assert "dev_test" in resp5b["devices_allowed"]
+
+    resp5c, _ = zmq_single_request("plans_existing")
+    assert resp5c["success"] is True, resp5c
+    assert "sleep_for_a_few_sec" in resp5c["plans_existing"]
+
+    resp5d, _ = zmq_single_request("devices_existing")
+    assert resp5d["success"] is True, resp5d
+    assert "dev_test" in resp5d["devices_existing"]
 
     # Add plan to queue
     _p6 = {"name": "sleep_for_a_few_sec", "kwargs": {"tt": 1.5}, "item_type": "plan"}

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1385,7 +1385,7 @@ def sleep_for_a_few_sec(tt=1):
 # fmt: on
 def test_zmq_api_script_upload_1(re_manager, run_in_background):  # noqa: F811
     """
-    Basic test for ``script_upload`` API.
+    Basic test for ``script_upload`` API: detailed checks of all flag at each transition.
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1365,6 +1365,91 @@ def test_zmq_api_queue_item_update_4_fail(re_manager):  # noqa F811
 
 
 # =======================================================================================
+#                              Method 'script_upload'
+
+
+def test_zmq_api_script_upload_1(re_manager):  # noqa: F811
+    """
+    Basic test for ``script_upload`` API.
+    """
+    # Add plan to queue
+    # params1a = {"item": _plan1, "user": _user, "user_group": _user_group}
+    # resp1a, _ = zmq_single_request("queue_item_add", params1a)
+    # assert resp1a["success"] is True, f"resp={resp1a}"
+
+    resp2, _ = zmq_single_request("environment_open")
+    assert resp2["success"] is True
+    assert wait_for_condition(time=10, condition=condition_environment_created)
+
+    script = "a = 10\nb=20\n"
+
+    resp3, _ = zmq_single_request("script_upload", params={"script": script})
+    assert resp3["success"] is True
+    assert resp3["msg"] == ""
+    assert resp3["task_uid"]
+    assert isinstance(resp3["task_uid"], str)
+    ttime.sleep(1)
+
+    # resp2a, _ = zmq_single_request("status")
+    # assert resp2a["items_in_queue"] == 1
+    # assert resp2a["items_in_history"] == 0
+    # assert resp2a["worker_environment_state"] == "idle"
+
+    # # Execute a plan
+    # params3 = {"item": _plan3, "user": _user, "user_group": _user_group}
+    # resp3, _ = zmq_single_request("queue_item_execute", params3)
+    # assert resp3["success"] is True, f"resp={resp3}"
+    # assert resp3["msg"] == ""
+    # assert resp3["qsize"] == 1
+    # assert resp3["item"]["name"] == _plan3["name"]
+
+    # ttime.sleep(1)
+    # status, _ = zmq_single_request("status")
+    # assert status["items_in_queue"] == 1
+    # assert status["items_in_history"] == 0
+    # assert status["worker_environment_state"] == "executing_plan"
+
+    # assert wait_for_condition(time=30, condition=condition_manager_idle)
+
+    # # Execute an instruction (STOP instruction - nothing will be done)
+    # params3a = {"item": _instruction_stop, "user": _user, "user_group": _user_group}
+    # resp3a, _ = zmq_single_request("queue_item_execute", params3a)
+    # assert resp3a["success"] is True, f"resp={resp3a}"
+    # assert resp3a["msg"] == ""
+    # assert resp3a["qsize"] == 1
+    # assert resp3a["item"]["name"] == _instruction_stop["name"]
+
+    # assert wait_for_condition(time=5, condition=condition_manager_idle)
+
+    # resp3b, _ = zmq_single_request("status")
+    # assert resp3b["items_in_queue"] == 1
+    # assert resp3b["items_in_history"] == 1
+    # assert resp3b["worker_environment_state"] == "idle"
+
+    # resp4, _ = zmq_single_request("queue_start")
+    # assert resp4["success"] is True
+
+    # assert wait_for_condition(time=5, condition=condition_manager_idle)
+
+    # resp4a, _ = zmq_single_request("status")
+    # assert resp4a["items_in_queue"] == 0
+    # assert resp4a["items_in_history"] == 2
+
+    # history, _ = zmq_single_request("history_get")
+    # h_items = history["items"]
+    # assert len(h_items) == 2, pprint.pformat(h_items)
+    # assert h_items[0]["name"] == _plan3["name"]
+    # assert h_items[1]["name"] == _plan1["name"]
+
+    # Close the environment
+    resp6, _ = zmq_single_request("environment_close")
+    assert resp6["success"] is True, f"resp={resp6}"
+    assert wait_for_condition(time=5, condition=condition_environment_closed)
+
+    # assert False
+
+
+# =======================================================================================
 #                      Method 'plans_allowed', 'devices_allowed'
 
 

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -394,8 +394,19 @@ class RunEngineWorker(Process):
         )
 
         if update_re:
-            self._RE = self._re_namespace.get("RE", self._RE)
-            self._db = self._re_namespace.get("db", self._db)
+            if ("RE" in self._re_namespace) and (self._RE != self._re_namespace["RE"]):
+                self._RE = self._re_namespace["RE"]
+
+                from .plan_monitoring import CallbackRegisterRun
+
+                run_reg_cb = CallbackRegisterRun(run_list=self._active_run_list)
+                self._RE.subscribe(run_reg_cb)
+
+                logger.info("Run Engine instance ('RE') was replaced while executing the uploaded script.")
+
+            if ("db" in self._re_namespace) and (self._db != self._re_namespace["db"]):
+                self._db = self._re_namespace["db"]
+                logger.info("Data Broker instance ('db') was replaced while executing the uploaded script.")
 
         epd = existing_plans_and_devices_from_nspace(nspace=self._re_namespace)
         existing_plans, existing_devices, plans_in_nspace, devices_in_nspace = epd

--- a/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
+++ b/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
@@ -1283,7 +1283,7 @@ existing_plans:
         value: 1
       name: detectors
     - description: "For one dimension, ``motor, start, stop``.\nIn general:\n\n..\
-        \ code-block:: python\n\n    motor1, start1, stop1,\n    motor2, start2, start2,\n\
+        \ code-block:: python\n\n    motor1, start1, stop1,\n    motor2, start2, stop2,\n\
         \    ...,\n    motorN, startN, stopN\n\nMotors can be any 'settable' object\
         \ (motor, temp controller, etc.)"
       kind:

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -1362,7 +1362,7 @@ Returns       **success**: *boolean*
 
               **task_uid**: *str* or *None*
                   Task UID can be used to check status of the task and download results once the task
-                  is completed (see *task_load_results* API).
+                  is completed (see *task_load_result* API).
 ------------  -----------------------------------------------------------------------------------------
 Execution     The method initiates the operation. Monitor *task_results_uid* status field and call
               *task_load_results* API to check for success.
@@ -1371,13 +1371,16 @@ Execution     The method initiates the operation. Monitor *task_results_uid* sta
 
 .. _method_task_load_result:
 
-**'task_load_results'**
-^^^^^^^^^^^^^^^^^^^^^^^
+**'task_load_result'**
+^^^^^^^^^^^^^^^^^^^^^^
 
 ============  =========================================================================================
-Method        **'task_load_results'**
+Method        **'task_load_result'**
 ------------  -----------------------------------------------------------------------------------------
-Description   Load the status and results of task execution.
+Description   Load the status and results of task execution. The completed tasks are stored at
+              the server at least for the period determined by retention time (currently 120 seconds
+              after completion of the task). The expired results could be automatically deleted
+              at any time and the method will return the task status as *'not_found'*.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **task_uid**: *str*
                   Task UID.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implementation of `script_upload` 0MQ API, which uploads and executes a script in RE Worker namespace. The API can be used to dynamically add plans to the namespace. The new plans appear in the list of allowed plans for all user groups with appropriate permissions. The PR also includes implementation for related simple API: `task_load_result` loads information on the running task or the result of a completed  task (scripts are executed as tasks in separate threads), `plans_existing` `devices_existing` load the lists of existing plans and devices (work similarly to `plans_allowed` and `devices_allowed` API, useful for testing).

The PR include documentation on the new API and status fields. CLI access to the new API will be implemented in one of the following PRs.

## Motivation and Context
The API is required to implement workflows with dynamically created or changed plans. It can also be useful for remote development and testing of plans.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added
- New 0MQ API: `script_upload`, `task_load_result`, `plans_existing`, `devices_existing`.
- New status fields returned by `status` 0MQ API: `task_results_uid`, `plans_existing_uid`, `devices_existing_uid`.

### Changed

### Removed

## How Has This Been Tested?
PR include detailed unit tests for all implemented API and features.
 