### PR TITLE
New 0MQ API: 'execute_function'

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1489,7 +1489,7 @@ class RunEngineManager(Process):
                 msg = f"{msg_prefix}'item_type' key is not found"
             elif item_type not in supported_item_types:
                 msg = (
-                    f"{msg_prefix}unsupported 'item_type' value '{item_type}', "
+                    f"{msg_prefix}unsupported 'item_type' value: '{item_type}', "
                     f"supported item types {supported_item_types}"
                 )
         else:
@@ -1569,11 +1569,11 @@ class RunEngineManager(Process):
                 func_name = item["name"]
                 success = False
                 if ("args" in item) and not isinstance(item["args"], (list, tuple)):
-                    msg = f"Parameter 'args' is not tuple or list: {type(item['args'])}"
-                if ("kwargs" in item) and not isinstance(item["kwargs"], dict):
+                    msg = f"Parameter 'args' is not a tuple or a list: {type(item['args'])}"
+                elif ("kwargs" in item) and not isinstance(item["kwargs"], dict):
                     msg = f"Parameter 'kwargs' is not a dictionary: {type(item['kwargs'])}"
                 # Only check that file name is passed the checks based on the defined permissions
-                if not check_if_function_allowed(
+                elif not check_if_function_allowed(
                     func_name, group_name=user_group, user_group_permissions=self._user_group_permissions
                 ):
                     msg = f"Function {func_name!r} is not allowed for users from {user_group!r} group."

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1245,6 +1245,7 @@ class RunEngineManager(Process):
         worker_environment_exists = self._environment_exists
         re_state = self._worker_state_info["re_state"] if self._worker_state_info else None
         env_state = self._worker_state_info["environment_state"] if self._worker_state_info else "closed"
+        background_tasks = self._worker_state_info["background_tasks_num"] if self._worker_state_info else 0
         deferred_pause_pending = self._re_pause_pending
         run_list_uid = self._re_run_list_uid
         plan_queue_uid = self._plan_queue.plan_queue_uid
@@ -1268,6 +1269,7 @@ class RunEngineManager(Process):
             "queue_stop_pending": queue_stop_pending,
             "worker_environment_exists": worker_environment_exists,
             "worker_environment_state": env_state,  # State of the worker environment
+            "worker_background_tasks": background_tasks,  # The number of background tasks (worker health)
             "re_state": re_state,  # State of Run Engine
             "pause_pending": deferred_pause_pending,  # True/False - Cleared once pause processed
             # If Run List UID change, download the list of runs for the current plan.

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -14,6 +14,7 @@ from .profile_ops import (
     load_existing_plans_and_devices,
     validate_plan,
     load_user_group_permissions,
+    check_if_function_allowed,
 )
 from .plan_queue_ops import PlanQueueOperations
 from .output_streaming import setup_console_output_redirection
@@ -823,7 +824,7 @@ class RunEngineManager(Process):
         Success does not mean that the script is successfully loaded.
         """
         if not self._environment_exists:
-            success, err_msg, task_uid = False, "RE Worker environment is not opened", None
+            success, err_msg, task_uid = False, "RE Worker environment is not open", None
         elif not run_in_background and (self._manager_state != MState.IDLE):
             success, err_msg, task_uid = (
                 False,
@@ -848,6 +849,57 @@ class RunEngineManager(Process):
                     self._manager_state = MState.IDLE
 
         return success, err_msg, task_uid
+
+    async def _environment_function_execute(self, *, item, run_in_background):
+        """
+        Upload Python script to RE Worker environment. The script is then executed into
+        the worker namespace. The API call only inititiates the process of loading the
+        script and return success if the request is accepted and the task can be started.
+        Success does not mean that the script is successfully loaded.
+        """
+        if not self._environment_exists:
+            success, err_msg, task_uid = False, "RE Worker environment is not open", None
+        elif not run_in_background and (self._manager_state != MState.IDLE):
+            success, err_msg, task_uid = (
+                False,
+                "Failed to start the task: RE Manager must be in idle state. "
+                f"Current state: '{self._manager_state.value}'",
+                None,
+            )
+        else:
+            try:
+                if not run_in_background:
+                    self._manager_state = MState.EXECUTING_TASK
+
+                func_name = item["name"]
+                args = item.get("args", [])
+                kwargs = item.get("kwargs", {})
+                user_name = item["user"]
+                user_group = item["user_group"]
+                item_uid = item["item_uid"]
+
+                func_info = {
+                    "name": func_name,
+                    "args": args,
+                    "kwargs": kwargs,
+                    "user": user_name,
+                    "user_group": user_group,
+                    "item_uid": item_uid,
+                }
+
+                success, err_msg, item, task_uid = await self._worker_command_execute_function(
+                    func_info=func_info, run_in_background=run_in_background
+                )
+                if not run_in_background:
+                    self._running_task_uid = task_uid
+            except Exception:
+                success = False
+                raise
+            finally:
+                if not success and not run_in_background:
+                    self._manager_state = MState.IDLE
+
+        return success, err_msg, item, task_uid
 
     def _generate_lists_of_allowed_plans_and_devices(self, *, always_update_uids=False):
         """
@@ -1043,6 +1095,22 @@ class RunEngineManager(Process):
         except CommTimeoutError:
             success, err_msg, task_uid = None, "Timeout occurred", None
         return success, err_msg, task_uid
+
+    async def _worker_command_execute_function(self, *, func_info, run_in_background):
+        try:
+            response = await self._comm_to_worker.send_msg(
+                "command_execute_function",
+                params={"func_info": func_info, "run_in_background": run_in_background},
+            )
+            success = response["status"] == "accepted"
+            err_msg = response["err_msg"]
+            task_uid = response["task_uid"]
+            payload = response["payload"]
+            if success:
+                await self._task_results.add_running_task(task_uid=task_uid, payload=payload)
+        except CommTimeoutError:
+            success, err_msg, task_uid = None, "Timeout occurred", None
+        return success, err_msg, func_info, task_uid
 
     # ===============================================================================
     #         Functions that send commands/request data from Watchdog process
@@ -1384,12 +1452,12 @@ class RunEngineManager(Process):
             "plan_queue_uid": plan_queue_uid,
         }
 
-    def _get_item_from_request(self, *, request=None, item=None):
+    def _get_item_from_request(self, *, request=None, item=None, supported_item_types=None):
         """
         Extract ``item`` and ``item_type`` from the request, validate the values and report errors
         """
         msg_prefix = "Incorrect request format: "
-        supported_item_types = ("plan", "instruction")
+        supported_item_types = supported_item_types or ("plan", "instruction")
 
         # The following two error reports represent serious bug, which needs to be fixed
         n_request_or_item = sum([(request is None), (item is None)])
@@ -1458,7 +1526,7 @@ class RunEngineManager(Process):
         item : dict
             original item passed to RE Manager
         item_type : str
-            item type (``plan`` or ``instruction``)
+            item type (``plan``, ``instruction`` or ``function``)
         user : str
             name of the user who submitted or modified the plan
         user_group : str
@@ -1492,6 +1560,17 @@ class RunEngineManager(Process):
                 success, msg = True, ""
             else:
                 success, msg = False, f"Unrecognized instruction: {item}"
+        elif item_type == "function":
+            if "name" not in item:
+                success, msg = False, f"Function name is not specified: {item}"
+            else:
+                func_name = item["name"]
+                # Only check that file name is passed the checks based on the defined permissions
+                if not check_if_function_allowed(
+                    func_name, group_name=user_group, user_group_permissions=self._user_group_permissions
+                ):
+                    success = False
+                    msg = f"Function {func_name!r} is not allowed for users from {user_group!r} group."
         else:
             success, msg = False, f"Invalid item: {item}"
 
@@ -2093,6 +2172,55 @@ class RunEngineManager(Process):
 
         return {"success": success, "msg": msg, "task_uid": task_uid}
 
+    async def _function_execute_handler(self, request):
+        """
+        Starts immediate execution of a function in RE Worker environment. The function must be defined
+        in startup script and exist in the worker namespace. The function may be started in the foreground
+        (default) or in the background(``run_in_background=True``). If RE Manager is busy executing
+        a plan or another foreground task, the request is rejected. The background tasks are executed
+        in separate threads, therefore thread safety must be taken into account in planning the workflow
+        that requires background tasks and in developing the background functions. The API implementation
+        does not guarantee thread safety of the code running in RE Worker namespace. It is strongly
+        recommended that the functions do not contain infinite loops or indefinite waits (always set
+        timeout). Since Python threads can not be destroyed, the function with infinite wait may require
+        closing the environment (function running in the background) or destroying environment (infinite
+        wait in forground task). Foreground tasks and plans can be started and executed when
+        background tasks are running.
+
+        The API call only inititiates the process of starting execution of the function and returns success
+        if the request is accepted. Success does not mean that the function was successfully started
+        or successfully run to completion. Use the returned ``task_uid`` to check for the status of
+        the task and load the result.
+        """
+        logger.debug("Starting execution of a function in RE Worker namespace ...")
+        try:
+            supported_param_names = ["item", "user_group", "user", "run_in_background"]
+            self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            item, item_type, _success, _msg = self._get_item_from_request(
+                request=request, supported_item_types=("function",)
+            )
+            if not _success:
+                raise Exception(_msg)
+
+            user, user_group = self._get_user_info_from_request(request=request)
+            run_in_background = request.get("run_in_background", False)
+
+            item, _ = self._prepare_item(
+                item=item, item_type=item_type, user=user, user_group=user_group, generate_new_uid=True
+            )
+
+            success, msg, item, task_uid = await self._environment_function_execute(
+                item=item, run_in_background=run_in_background
+            )
+            if not success:
+                raise RuntimeError(msg)
+
+        except Exception as ex:
+            success, msg, item, task_uid = False, f"Error: {ex}", item, None
+
+        return {"success": success, "msg": msg, "item": item, "task_uid": task_uid}
+
     async def _task_load_result_handler(self, request):
         """
         Load result of a task executed by the worker process. The request must contain valid ``task_uid``.
@@ -2382,6 +2510,7 @@ class RunEngineManager(Process):
             "environment_close": "_environment_close_handler",
             "environment_destroy": "_environment_destroy_handler",
             "script_upload": "_script_upload_handler",
+            "function_execute": "_function_execute_handler",
             "task_load_result": "_task_load_result_handler",
             "queue_mode_set": "_queue_mode_set_handler",
             "queue_item_add": "_queue_item_add_handler",

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1269,7 +1269,7 @@ class RunEngineManager(Process):
             "queue_stop_pending": queue_stop_pending,
             "worker_environment_exists": worker_environment_exists,
             "worker_environment_state": env_state,  # State of the worker environment
-            "worker_background_tasks": background_tasks,  # The number of background tasks (worker health)
+            "worker_background_tasks": background_tasks,  # The number of background tasks
             "re_state": re_state,  # State of Run Engine
             "pause_pending": deferred_pause_pending,  # True/False - Cleared once pause processed
             # If Run List UID change, download the list of runs for the current plan.

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1567,12 +1567,18 @@ class RunEngineManager(Process):
                 success, msg = False, f"Function name is not specified: {item}"
             else:
                 func_name = item["name"]
+                success = False
+                if ("args" in item) and not isinstance(item["args"], (list, tuple)):
+                    msg = f"Parameter 'args' is not tuple or list: {type(item['args'])}"
+                if ("kwargs" in item) and not isinstance(item["kwargs"], dict):
+                    msg = f"Parameter 'kwargs' is not a dictionary: {type(item['kwargs'])}"
                 # Only check that file name is passed the checks based on the defined permissions
                 if not check_if_function_allowed(
                     func_name, group_name=user_group, user_group_permissions=self._user_group_permissions
                 ):
-                    success = False
                     msg = f"Function {func_name!r} is not allowed for users from {user_group!r} group."
+                else:
+                    success, msg = True, ""
         else:
             success, msg = False, f"Invalid item: {item}"
 
@@ -2206,7 +2212,7 @@ class RunEngineManager(Process):
                 raise Exception(_msg)
 
             user, user_group = self._get_user_info_from_request(request=request)
-            run_in_background = request.get("run_in_background", False)
+            run_in_background = bool(request.get("run_in_background", False))
 
             item, _ = self._prepare_item(
                 item=item, item_type=item_type, user=user, user_group=user_group, generate_new_uid=True

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2319,7 +2319,6 @@ _user_group_permission_schema = {
             "type": "object",
             "additionalProperties": {
                 "type": "object",
-                "required": ["allowed_plans", "forbidden_plans", "allowed_devices", "forbidden_devices"],
                 "additionalProperties": False,
                 "properties": {
                     "allowed_plans": {
@@ -2338,6 +2337,14 @@ _user_group_permission_schema = {
                         "type": "array",
                         "items": {"type": ["string", "null"]},
                     },
+                    "allowed_functions": {
+                        "type": "array",
+                        "items": {"type": ["string", "null"]},
+                    },
+                    "forbidden_functions": {
+                        "type": "array",
+                        "items": {"type": ["string", "null"]},
+                    },
                 },
             },
         },
@@ -2347,7 +2354,8 @@ _user_group_permission_schema = {
 
 def load_user_group_permissions(path_to_file=None):
     """
-    Load the data on allowed plans and devices for user groups.
+    Load the data on allowed plans and devices for user groups. User group 'root'
+    is required. Exception is raised in user group 'root' is missing.
 
     Parameters
     ----------
@@ -2357,7 +2365,7 @@ def load_user_group_permissions(path_to_file=None):
     Returns
     -------
     dict
-        Data structure with user permissions. Returns ``{}`` if path is empty string
+        Data structure with user permissions. Returns ``{}`` if path is an empty string
         or None.
 
     Raises
@@ -2370,7 +2378,6 @@ def load_user_group_permissions(path_to_file=None):
         return {}
 
     try:
-
         if not os.path.isfile(path_to_file):
             raise IOError(f"File '{path_to_file}' does not exist.")
 
@@ -2383,8 +2390,6 @@ def load_user_group_permissions(path_to_file=None):
 
         if "root" not in user_group_permissions["user_groups"]:
             raise Exception("Missing required user group: 'root'")
-        if "admin" not in user_group_permissions["user_groups"]:
-            raise Exception("Missing required user group: 'admin'")
 
     except Exception as ex:
         msg = f"Error while loading user group permissions from file '{path_to_file}': {str(ex)}"
@@ -2409,8 +2414,9 @@ def _select_allowed_items(item_dict, allow_patterns, disallow_patterns):
         Selected item should match at least one of the re patterns. If the value is ``[None]``
         then all items are selected. If ``[]``, then no items are selected.
     disallow_patterns: list(str)
-        Selected item should not match any of the re patterns. If the value is ``[None]``
-        or ``[]`` then no items are deselected.
+        Items are deselected based on re patterns in the list: if an item matches at least one
+        of the patterns, it is deselected. If the value is ``[None]`` or ``[]`` then no items
+        are deselected.
 
     Returns
     -------

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -796,15 +796,18 @@ def prepare_function(*, func_info, nspace, user_group_permissions=None):
     func_name = func_info["name"]
     user_group = func_info["user_group"]
     if user_group_permissions is not None:
-        check_if_function_allowed(func_name, group_name=user_group, user_group_permissions=user_group_permissions)
+        if not check_if_function_allowed(
+            func_name, group_name=user_group, user_group_permissions=user_group_permissions
+        ):
+            raise RuntimeError(f"Function {func_name!r} is not allowed for users from {user_group!r} user group")
 
-    func_args = func_info.get("args", [])
-    func_kwargs = func_info.get("kwargs", {})
+    func_args = list(func_info.get("args", []))
+    func_kwargs = dict(func_info.get("kwargs", {}))
 
     if func_name not in nspace:
         raise RuntimeError(f"Function {func_name!r} is not found in the worker namespace")
 
-    func_callable = nspace["func_name"]
+    func_callable = nspace[func_name]
 
     # Following are basic checks to avoid most common errors. The list of check can be expanded.
     if not callable(func_callable):

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2352,6 +2352,18 @@ _user_group_permission_schema = {
 }
 
 
+def validate_user_group_permissions_schema(user_group_permissions):
+    """
+    Validate user group permissions schema. Raises exception if validation fails.
+
+    Parameters
+    ----------
+    user_group_permissions: dict
+        A dictionary with user group permissions.
+    """
+    jsonschema.validate(instance=user_group_permissions, schema=_user_group_permission_schema)
+
+
 def load_user_group_permissions(path_to_file=None):
     """
     Load the data on allowed plans and devices for user groups. User group 'root'
@@ -2384,9 +2396,7 @@ def load_user_group_permissions(path_to_file=None):
         with open(path_to_file, "r") as stream:
             user_group_permissions = yaml.safe_load(stream)
 
-        # if "user_groups" not in user_group_permissions:
-        #    raise IOError(f"Incorrect format of user group permissions: key 'user_groups' is missing.")
-        jsonschema.validate(instance=user_group_permissions, schema=_user_group_permission_schema)
+        validate_user_group_permissions_schema(user_group_permissions)
 
         if "root" not in user_group_permissions["user_groups"]:
             raise Exception("Missing required user group: 'root'")
@@ -2396,6 +2406,104 @@ def load_user_group_permissions(path_to_file=None):
         raise IOError(msg)
 
     return user_group_permissions
+
+
+def _check_if_item_allowed(item_name, allow_patterns, disallow_patterns):
+    """
+    Check if an item with ``item_name`` is allowed based on ``allow_patterns``
+    and ``disallow_patterns``.
+
+    Parameters
+    ----------
+    item_name: str
+        Name of the item.
+    allow_patterns: list(str)
+        Selected item should match at least one of the re patterns. If the value is ``[None]``
+        then all items are selected. If ``[]``, then no items are selected.
+    disallow_patterns: list(str)
+        Items are deselected based on re patterns in the list: if an item matches at least one
+        of the patterns, it is deselected. If the value is ``[None]`` or ``[]`` then no items
+        are deselected.
+
+    Returns
+    -------
+    boolean
+        Indicates if the item is permitted based on ``allow_patterns`` and ``disallow_patterns``.
+    """
+    item_is_allowed = False
+
+    if allow_patterns:
+        if allow_patterns[0] is None:
+            item_is_allowed = True
+        else:
+            for pattern in allow_patterns:
+                if re.search(pattern, item_name):
+                    item_is_allowed = True
+                    break
+
+    if item_is_allowed:
+        if disallow_patterns and (disallow_patterns[0] is not None):
+            for pattern in disallow_patterns:
+                if re.search(pattern, item_name):
+                    item_is_allowed = False
+                    break
+
+    return item_is_allowed
+
+
+def check_if_function_allowed(function_name, *, group_name, user_group_permissions=None):
+    """
+    Check if the function with name ``function_name`` is allowed for users of ``group_name`` group.
+    The function first checks if the functio name passes root permissions and then permissions
+    for the specific group.
+
+    Parameters
+    ----------
+    function_name: str
+        Function name to check
+    group_name: str
+        User group name. Permissions must be defined for this group.
+    user_group_permissions: dict or None
+        Reference to a dictionary, which contains the defined user group permissions.
+
+    Returns
+    -------
+    boolean
+        Indicates if the user that belong to ``user_group`` are allowed to run the function.
+
+    Raises
+    ------
+    KeyError
+        ``user_group_permissions`` do not contain ``user_groups`` key or permissions for
+        ``group_name`` group are not defined.
+    """
+    if not user_group_permissions:
+        return False
+
+    if "user_groups" not in user_group_permissions:
+        raise KeyError("User group permissions dictionary does not contain 'user_groups' key")
+
+    user_groups = user_group_permissions["user_groups"]
+
+    if "root" not in user_groups:
+        raise KeyError("No permissions are defined for user group 'root'")
+    if group_name not in user_groups:
+        raise KeyError(f"No permissions are defined for user group {group_name!r}")
+
+    root_allow_patterns = user_groups["root"].get("allowed_functions", [])
+    root_disallow_patterns = user_groups["root"].get("forbidden_functions", [])
+    group_allow_patterns = user_groups[group_name].get("allowed_functions", [])
+    group_disallow_patterns = user_groups[group_name].get("forbidden_functions", [])
+
+    return _check_if_item_allowed(
+        function_name,
+        root_allow_patterns,
+        root_disallow_patterns,
+    ) and _check_if_item_allowed(
+        function_name,
+        group_allow_patterns,
+        group_disallow_patterns,
+    )
 
 
 def _select_allowed_items(item_dict, allow_patterns, disallow_patterns):
@@ -2424,24 +2532,9 @@ def _select_allowed_items(item_dict, allow_patterns, disallow_patterns):
         Dictionary of the selected items.
     """
     items_selected = {}
-    for item in item_dict:
-        select_item = False
-        if allow_patterns:
-            if allow_patterns[0] is None:
-                select_item = True
-            else:
-                for pattern in allow_patterns:
-                    if re.search(pattern, item):
-                        select_item = True
-                        break
-        if select_item:
-            if disallow_patterns and (disallow_patterns[0] is not None):
-                for pattern in disallow_patterns:
-                    if re.search(pattern, item):
-                        select_item = False
-                        break
-        if select_item:
-            items_selected[item] = copy.deepcopy(item_dict[item])
+    for item_name in item_dict:
+        if _check_if_item_allowed(item_name, allow_patterns, disallow_patterns):
+            items_selected[item_name] = copy.deepcopy(item_dict[item_name])
 
     return items_selected
 
@@ -2484,7 +2577,7 @@ def load_allowed_plans_and_devices(
         List (dict) of the existing devices. If ``None``, then the list is loaded from
         the file ``path_existing_plans_and_devices``.
     user_group_permissions: str or None
-        Dictionary with user group permissions. If ``None``, then permissionas are loaded
+        Dictionary with user group permissions. If ``None``, then permissions are loaded
         from the file ``path_user_group_permissions``. If ``{}``, then dictionaries of allowed
         plans and devices will contain one group 'root' with all existing devices and plans
         set as allowed.
@@ -2535,14 +2628,14 @@ def load_allowed_plans_and_devices(
             if existing_devices:
                 devices_root = _select_allowed_items(
                     existing_devices,
-                    group_permissions_root["allowed_devices"],
-                    group_permissions_root["forbidden_devices"],
+                    group_permissions_root.get("allowed_devices", []),
+                    group_permissions_root.get("forbidden_devices", []),
                 )
             if existing_plans:
                 plans_root = _select_allowed_items(
                     existing_plans,
-                    group_permissions_root["allowed_plans"],
-                    group_permissions_root["forbidden_plans"],
+                    group_permissions_root.get("allowed_plans", []),
+                    group_permissions_root.get("forbidden_plans", []),
                 )
 
         # Now create lists of allowed devices and plans based on the lists for the 'root' user group
@@ -2556,12 +2649,16 @@ def load_allowed_plans_and_devices(
 
                 if existing_devices:
                     selected_devices = _select_allowed_items(
-                        devices_root, group_permissions["allowed_devices"], group_permissions["forbidden_devices"]
+                        devices_root,
+                        group_permissions.get("allowed_devices", []),
+                        group_permissions.get("forbidden_devices", []),
                     )
 
                 if existing_plans:
                     selected_plans = _select_allowed_items(
-                        plans_root, group_permissions["allowed_plans"], group_permissions["forbidden_plans"]
+                        plans_root,
+                        group_permissions.get("allowed_plans", []),
+                        group_permissions.get("forbidden_plans", []),
                     )
 
             selected_plans = _filter_allowed_plans(allowed_plans=selected_plans, allowed_devices=selected_devices)

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -3199,6 +3199,10 @@ _user_groups_text = r"""user_groups:
       - null  # Allow all
     forbidden_devices:
       - null  # Nothing is forbidden
+    allowed_functions:
+      - null  # Allow all
+    forbidden_functions:
+      - null  # Nothing is forbidden
   admin:  # The group includes beamline staff, includes all or most of the plans and devices
     allowed_plans:
       - ".*"  # A different way to allow all
@@ -3207,6 +3211,10 @@ _user_groups_text = r"""user_groups:
     allowed_devices:
       - ".*"  # A different way to allow all
     forbidden_devices:
+      - null  # Nothing is forbidden
+    allowed_functions:
+      - ".*"  # A different way to allow all
+    forbidden_functions:
       - null  # Nothing is forbidden
   test_user:  # Users with limited access capabilities
     allowed_plans:
@@ -3221,6 +3229,15 @@ _user_groups_text = r"""user_groups:
     forbidden_devices:
       - "^det[3-5]$" # Use regular expression patterns
       - "^motor\\d+$"
+  test_user_1:
+    allowed_plans:
+      - "^count$"  # Use regular expression patterns
+      - "scan$"
+    allowed_devices:
+      - "^det"  # Use regular expression patterns
+      - "^motor"
+    allowed_functions:
+      - ".*"  # A different way to allow all
 """
 
 _user_groups_dict = {
@@ -3230,18 +3247,27 @@ _user_groups_dict = {
             "forbidden_plans": [None],
             "allowed_devices": [None],
             "forbidden_devices": [None],
+            "allowed_functions": [None],
+            "forbidden_functions": [None],
         },
         "admin": {
             "allowed_plans": [".*"],
             "forbidden_plans": [None],
             "allowed_devices": [".*"],
             "forbidden_devices": [None],
+            "allowed_functions": [".*"],
+            "forbidden_functions": [None],
         },
         "test_user": {
             "allowed_plans": ["^count$", "scan$"],
             "forbidden_plans": ["^adaptive_scan$", "^inner_product"],
             "allowed_devices": ["^det", "^motor"],
             "forbidden_devices": ["^det[3-5]$", r"^motor\d+$"],
+        },
+        "test_user_1": {
+            "allowed_plans": ["^count$", "scan$"],
+            "allowed_devices": ["^det", "^motor"],
+            "allowed_functions": [".*"],
         },
     }
 }
@@ -3309,7 +3335,7 @@ def test_load_user_group_permissions_4_fail(tmp_path):
         load_user_group_permissions(path_to_file)
 
 
-@pytest.mark.parametrize("group_to_delete", ["root", "admin"])
+@pytest.mark.parametrize("group_to_delete", ["root"])
 def test_load_user_group_permissions_5_fail(tmp_path, group_to_delete):
     """
     Function ``load_user_group_permissions``. Failed schema validation.

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -2883,7 +2883,9 @@ def test_prepare_function_1(func_info, result):
 ])
 # fmt: on
 def test_prepare_function_2(func_info, except_type, msg):
-
+    """
+    Tests for 'prepare_function': failing cases
+    """
     nspace = {}
     load_script_into_existing_nspace(script=_prep_func_script_1, nspace=nspace)
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -626,7 +626,7 @@ def test_zmq_api_queue_item_add_8_fail(re_manager):  # noqa F811
     resp7, _ = zmq_single_request("queue_item_add", params7)
     assert resp7["success"] is False
     assert resp7["item"] == plan7
-    assert "Incorrect request format: unsupported 'item_type' value 'unsupported'" in resp7["msg"]
+    assert "Incorrect request format: unsupported 'item_type' value: 'unsupported'" in resp7["msg"]
 
     # Valid plan
     plan8 = {"name": "count", "args": [["det1", "det2"]], "item_type": "plan"}
@@ -833,7 +833,7 @@ def test_zmq_api_queue_item_execute_4_fail(re_manager):  # noqa: F811
     params1a = {"item": plan, "user": _user, "user_group": _user_group}
     resp1a, _ = zmq_single_request("queue_item_execute", params1a)
     assert resp1a["success"] is False, f"resp={resp1a}"
-    assert "unsupported 'item_type' value 'unknown'" in resp1a["msg"]
+    assert "unsupported 'item_type' value: 'unknown'" in resp1a["msg"]
     assert resp1a["qsize"] is None
     assert resp1a["item"]["name"] == plan["name"]
 
@@ -1350,7 +1350,7 @@ def test_zmq_api_queue_item_update_4_fail(re_manager):  # noqa F811
     resp9, _ = zmq_single_request("queue_item_update", params9)
     assert resp9["success"] is False
     assert resp9["item"] == plan9
-    assert "Incorrect request format: unsupported 'item_type' value 'unsupported'" in resp9["msg"]
+    assert "Incorrect request format: unsupported 'item_type' value: 'unsupported'" in resp9["msg"]
 
     # Valid plan
     plan10 = plan_to_update.copy()

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1904,7 +1904,7 @@ def test_zmq_api_script_upload_8_fail(re_manager):  # noqa: F811
     """
     resp2, _ = zmq_single_request("script_upload", params={"script": _script_to_upload_1})
     assert resp2["success"] is False
-    assert "RE Worker environment is not opened" in resp2["msg"]
+    assert "RE Worker environment is not open" in resp2["msg"]
 
 
 # fmt: off

--- a/bluesky_queueserver/profile_collection_sim/99-custom.py
+++ b/bluesky_queueserver/profile_collection_sim/99-custom.py
@@ -102,9 +102,13 @@ def sim_multirun_plan_nested(npts: int, delay: float = 1.0):
         yield from bps.sleep(delay)
 
 
+# =====================================================================================
+#                Functions for testing 'function_execute' API.
+
+
 def function_sleep(time):
     """
-    The function used for testing of 'function_execute' API.
+    Sleep for a given number of seconds.
     """
     print("******** Starting execution of the function 'function_sleep' **************")
     print(f"*******************   Waiting for {time} seconds **************************")
@@ -114,9 +118,29 @@ def function_sleep(time):
     return {"success": True, "time": time}
 
 
-def function_test():
+_fifo_buffer = []
+
+
+def push_buffer_element(element):
+    """
+    Push an element to a FIFO buffer.
+    """
+    print("******** Executing the function 'push_buffer_element' **************")
+    _fifo_buffer.append(element)
+
+
+def pop_buffer_element():
+    """
+    Pop an element from FIFO buffer. Raises exception if the buffer is empty
+    (function call fails, traceback should be returned).
+    """
+    print("******** Executing the function 'pop_buffer_element' **************")
+    return _fifo_buffer.pop(0)
+
+
+def clear_buffer():
     """
     The function used for testing of 'function_execute' API.
     """
-    print("******** Executing the function 'function_test' **************")
-    return "Function 'function_test' is completed"
+    print("******** Executing the function 'clear_buffer' **************")
+    return _fifo_buffer.clear()

--- a/bluesky_queueserver/profile_collection_sim/99-custom.py
+++ b/bluesky_queueserver/profile_collection_sim/99-custom.py
@@ -104,6 +104,9 @@ def sim_multirun_plan_nested(npts: int, delay: float = 1.0):
 
 # =====================================================================================
 #                Functions for testing 'function_execute' API.
+#
+#        NOTE: those functions are used in unit tests. Changing the functions
+#                     may cause those tests to fail.
 
 
 def function_sleep(time):
@@ -144,3 +147,6 @@ def clear_buffer():
     """
     print("******** Executing the function 'clear_buffer' **************")
     return _fifo_buffer.clear()
+
+
+# ===========================================================================================

--- a/bluesky_queueserver/profile_collection_sim/99-custom.py
+++ b/bluesky_queueserver/profile_collection_sim/99-custom.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+import time as ttime
 import typing
 import ophyd
 import bluesky
@@ -99,3 +100,23 @@ def sim_multirun_plan_nested(npts: int, delay: float = 1.0):
         yield from bps.mov(motor, j * 0.2)
         yield from bps.trigger_and_read([motor, det])
         yield from bps.sleep(delay)
+
+
+def function_sleep(time):
+    """
+    The function used for testing of 'function_execute' API.
+    """
+    print("******** Starting execution of the function 'function_sleep' **************")
+    print(f"*******************   Waiting for {time} seconds **************************")
+    ttime.sleep(time)
+    print("******** Finished execution of the function 'function_sleep' **************")
+
+    return {"success": True, "time": time}
+
+
+def function_test():
+    """
+    The function used for testing of 'function_execute' API.
+    """
+    print("******** Executing the function 'function_test' **************")
+    return "Function 'function_test' is completed"

--- a/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -36,6 +36,7 @@ user_groups:
       - "^motor\\d+$"
     allowed_functions:
       - "element$"
+      - "elements$"
       - "^function_sleep$"
       - "^clear_buffer$"
     forbidden_functions:

--- a/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -8,6 +8,10 @@ user_groups:
       - null  # Allow all
     forbidden_devices:
       - "^_"  # All devices with names starting with '_'
+    allowed_functions:
+      - null  # Allow all
+    forbidden_functions:
+      - "^_"  # All devices with names starting with '_'
   admin:  # The group includes beamline staff, includes all or most of the plans and devices
     allowed_plans:
       - ".*"  # A different way to allow all
@@ -30,4 +34,9 @@ user_groups:
     forbidden_devices:
       - "^det[3-5]$" # Use regular expression patterns
       - "^motor\\d+$"
-
+    allowed_functions:
+      - "element$"
+      - "^function_sleep$"
+      - "^clear_buffer$"
+    forbidden_functions:
+      - "^_"  # All devices with names starting with '_'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ sphinx
 # These are dependencies of various sphinx extensions for documentation.
 ipython
 matplotlib
+numpy
 numpydoc
 scikit-image
 sphinx


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implementation of a 0MQ API that starts execution of a user-defined function in RE Worker namespace. The function must be defined in RE Worker namespace, e.g. in startup script. The function can be executed in foreground or background. Support for new options for user group permissions (``allowed_functions`` and ``forbidden_functions``) are implemented to filter the names of the functions allowed for users from different group. Handling of user permissions is updated to make all entries of `user_group_permissions.yaml` optional. Changes to user group permissions handling are not expected to change existing behavior. A new field (`worker_background_tasks`) which indicates the number of background tasks running in RE Worker environment is added to status information returned by RE Manager

The new API is currently not supported by CLI tool. CLI support will be added in future PRs.

## Motivation and Context
Ability to execute functions in RE Worker environment add flexibility that could be useful for some workflows.  

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New 0MQ API: `function_execute`.
- New RE Manager status field: `worker_background_tasks`. The field indicates the number of background tasks running in RE Worker environment.
- New options for user group permissions: `allowed_functions` and `forbidden_functions`. The options define filters for names of the functions accessible using `function_execute` API for different user groups.

### Changed
- All options for user group permissions are now optional. Options `forbidden_plans`, `forbidden_devices` and `forbidden_functions` could be skipped if there are no forbidden items. Skipping `allowed_...` option disables all items (plans, devices or functions) for the group, e.g. a group for which `allowed_plans` is not defined will not be able to run any plans. Skipping `allowed_plans` for `root` disables all plans for all groups. Logic is similar for devices and functions.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Detailed unit tests are implemented to keep track of new functionality.

<!--
## Screenshots (if appropriate):
-->
