### PR TITLE
CLI support for new API

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -2699,7 +2699,7 @@ class RunEngineManager(Process):
                     if dict_name in log_msg_out:
                         d = log_msg_out[dict_name]
                         for k in d.keys():
-                            d[k] = "..."
+                            d[k] = "{...}"
                 return log_msg_out
 
             #  Send reply back to client

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -2229,16 +2229,17 @@ class RunEngineManager(Process):
 
         return {"success": success, "msg": msg, "item": item, "task_uid": task_uid}
 
-    async def _task_load_result_handler(self, request):
+    async def _task_result_get_handler(self, request):
         """
-        Load result of a task executed by the worker process. The request must contain valid ``task_uid``.
-        Task UIDs are returned by the API used to start tasks. Returned parameters: ``success`` and
-        ``msg`` indicate success of the API call and error message in case of API call failure;
-        ``status`` is the status of the task (``running``, ``completed``, ``not_found``), ``result``
-        is a dictionary with information about the task. The information is be different for
-        the completed and running tasks. If ``status=='not_found'``, then is ``result`` is ``{}``.
+        Returns the information of a task executed by the worker process. The request must contain
+        valid ``task_uid``, returned by one of APIs that starts tasks. Returned
+        parameters: ``success`` and ``msg`` indicate success of the API call and error message in
+        case of API call failure; ``status`` is the status of the task (``running``, ``completed``,
+        ``not_found``), ``result`` is a dictionary with information about the task. The information
+        is be different for the completed and running tasks. If ``status=='not_found'``, then is
+        ``result`` is ``{}``.
         """
-        logger.debug("Load result of the task executed by RE worker ...")
+        logger.debug("Request for the result of the task executed by RE worker ...")
 
         task_uid = None
 
@@ -2519,7 +2520,7 @@ class RunEngineManager(Process):
             "environment_destroy": "_environment_destroy_handler",
             "script_upload": "_script_upload_handler",
             "function_execute": "_function_execute_handler",
-            "task_load_result": "_task_load_result_handler",
+            "task_result_get": "_task_result_get_handler",
             "queue_mode_set": "_queue_mode_set_handler",
             "queue_item_add": "_queue_item_add_handler",
             "queue_item_add_batch": "_queue_item_add_batch_handler",

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -128,6 +128,18 @@ qserver re runs closed     # Get the list of closed runs (subset of active runs)
 qserver history get        # Request plan history
 qserver history clear      # Clear plan history
 
+qserver function execute <function-params>             # Start execution of a function
+qserver function execute <function-params> background  # ... in the background thread
+
+Example of JSON specification of a function ("args" and "kwargs" are optional):
+    '{"name": "function_sleep", "args": [20], "kwargs": {}}'
+
+qserver script upload <path-to-file>              # Upload a script to RE Worker environment
+qserver script upload <path-to-file> background   # ... in the background
+qserver script upload <path-to-file> update-re    # ... allow 'RE' and 'db' to be updated
+
+qserver task load result <task-uid>  # Load status or result of a task with the given UID
+
 qserver manager stop           # Safely exit RE Manager application
 qserver manager stop safe on   # Safely exit RE Manager application
 qserver manager stop safe off  # Force RE Manager application to stop
@@ -827,7 +839,7 @@ def create_msg(params):
 
             run_in_background = False
             update_re = False
-            allowed_values = ("background", "update_re")
+            allowed_values = ("background", "update-re")
 
             for p in params[2:]:
                 if p not in allowed_values:
@@ -836,11 +848,11 @@ def create_msg(params):
                     )
                 if p == "background":
                     run_in_background = True
-                elif p == "update_re":
+                elif p == "update-re":
                     update_re = True
 
             method = f"{command}_{params[0]}"
-            prms = {"script": script, "run-in-background": run_in_background, "update_re": update_re}
+            prms = {"script": script, "run_in_background": run_in_background, "update_re": update_re}
 
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -481,7 +481,7 @@ def msg_function_execute(params, *, cmd_opt):
             allowed_params = ("background",)
             for p in params[2:]:
                 if p not in allowed_params:
-                    CommandParameterError(f"Unsupported combination of parameters: '{command} {params}'")
+                    raise CommandParameterError(f"Unsupported combination of parameters: '{command} {params}'")
                 if p == "background":
                     run_in_background = True
 
@@ -1045,7 +1045,6 @@ def qserver():
                 raise CommandParameterError(f"ZMQ public key is improperly formatted: {ex}")
 
         method, params, monitoring_mode = create_msg(args.command)
-
         if monitoring_mode:
             print("Running QServer monitor. Press Ctrl-C to exit ...")
 

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -138,7 +138,7 @@ qserver script upload <path-to-file>              # Upload a script to RE Worker
 qserver script upload <path-to-file> background   # ... in the background
 qserver script upload <path-to-file> update-re    # ... allow 'RE' and 'db' to be updated
 
-qserver task load result <task-uid>  # Load status or result of a task with the given UID
+qserver task result get <task-uid>  # Load status or result of a task with the given UID
 
 qserver manager stop           # Safely exit RE Manager application
 qserver manager stop safe on   # Safely exit RE Manager application
@@ -861,7 +861,7 @@ def create_msg(params):
     elif command == "task":
         if len(params) != 3:
             raise CommandParameterError(f"Request '{command}' must include at 3 parameters")
-        if (params[0] == "load") and (params[1] == "result"):
+        if (params[0] == "result") and (params[1] == "get"):
             task_uid = str(params[2])
             method = f"{command}_{params[0]}_{params[1]}"
             prms = {"task_uid": task_uid}

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -289,7 +289,7 @@ def wait_for_task_result(time, task_uid):
     while ttime.time() < time_stop:
         ttime.sleep(dt / 2)
         try:
-            resp, _ = zmq_secure_request("task_load_result", params={"task_uid": task_uid})
+            resp, _ = zmq_secure_request("task_result_get", params={"task_uid": task_uid})
 
             assert resp["success"] is True, f"Request for task result failed: {resp['msg']}"
             assert resp["task_uid"] == task_uid

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -1216,6 +1216,20 @@ def test_function_execute_2_fail(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "function", "execute", item, "invalid_param"]) == PARAM_ERROR
 
 
+def test_task_load_result_1(re_manager):  # noqa: F811
+    """
+    Tests for 'qserver task load result'.
+    """
+    # The request should be successful for any 'task_uid'.
+    task_uid = "01e80342-5e36-44de-bc86-9bd8d57c9885"
+    assert subprocess.call(["qserver", "task", "load", "result", task_uid]) == SUCCESS
+
+    # Some cases of invalid parameters
+    assert subprocess.call(["qserver", "task", "load", "result"]) == PARAM_ERROR
+    assert subprocess.call(["qserver", "task", "load", "something"]) == PARAM_ERROR
+    assert subprocess.call(["qserver", "task", "something", "something"]) == PARAM_ERROR
+
+
 _sample_trivial_plan1 = """
 def trivial_plan_for_unit_test():
     '''

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -1216,17 +1216,17 @@ def test_function_execute_2_fail(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "function", "execute", item, "invalid_param"]) == PARAM_ERROR
 
 
-def test_task_load_result_1(re_manager):  # noqa: F811
+def test_task_result_get_1(re_manager):  # noqa: F811
     """
-    Tests for 'qserver task load result'.
+    Tests for 'qserver task result_get'.
     """
     # The request should be successful for any 'task_uid'.
     task_uid = "01e80342-5e36-44de-bc86-9bd8d57c9885"
-    assert subprocess.call(["qserver", "task", "load", "result", task_uid]) == SUCCESS
+    assert subprocess.call(["qserver", "task", "result", "get", task_uid]) == SUCCESS
 
     # Some cases of invalid parameters
-    assert subprocess.call(["qserver", "task", "load", "result"]) == PARAM_ERROR
-    assert subprocess.call(["qserver", "task", "load", "something"]) == PARAM_ERROR
+    assert subprocess.call(["qserver", "task", "result", "get"]) == PARAM_ERROR
+    assert subprocess.call(["qserver", "task", "result", "something"]) == PARAM_ERROR
     assert subprocess.call(["qserver", "task", "something", "something"]) == PARAM_ERROR
 
 

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -50,6 +50,10 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "allowed", "plans"], stdout=subprocess.DEVNULL) == SUCCESS
     assert subprocess.call(["qserver", "allowed", "devices"], stdout=subprocess.DEVNULL) == SUCCESS
 
+    # Request the list of existing plans and devices (we don't check what is returned)
+    assert subprocess.call(["qserver", "existing", "plans"], stdout=subprocess.DEVNULL) == SUCCESS
+    assert subprocess.call(["qserver", "existing", "devices"], stdout=subprocess.DEVNULL) == SUCCESS
+
     # Add a number of plans
     plan_1 = "{'name':'count', 'args':[['det1', 'det2']]}"
     plan_2 = "{'name':'scan', 'args':[['det1', 'det2'], 'motor', -1, 1, 10]}"
@@ -1168,6 +1172,10 @@ def test_qserver_secure_1(monkeypatch, re_manager_cmd, test_mode):  # noqa: F811
     # Request the list of allowed plans and devices (we don't check what is returned)
     assert subprocess.call(["qserver", "allowed", "plans"], stdout=subprocess.DEVNULL) == SUCCESS
     assert subprocess.call(["qserver", "allowed", "devices"], stdout=subprocess.DEVNULL) == SUCCESS
+
+    # Request the list of existing plans and devices (we don't check what is returned)
+    assert subprocess.call(["qserver", "existing", "plans"], stdout=subprocess.DEVNULL) == SUCCESS
+    assert subprocess.call(["qserver", "existing", "devices"], stdout=subprocess.DEVNULL) == SUCCESS
 
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
     assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)

--- a/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -189,7 +189,7 @@ def test_cli_update_existing_plans_devices_01(
     assert resp2["success"] is True
     assert resp2["msg"] == ""
 
-    assert wait_for_condition(time=3, condition=condition_environment_created)
+    assert wait_for_condition(time=10, condition=condition_environment_created)
 
     resp3, _ = zmq_single_request("environment_close")
     assert resp3["success"] is True

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1438,7 +1438,7 @@ def test_zmq_api_script_upload_1(re_manager, run_in_background):  # noqa: F811
     status, _ = zmq_single_request("status")
     assert status["worker_background_tasks"] == (1 if run_in_background else 0)
 
-    resp3, _ = zmq_single_request("task_load_result", params={"task_uid": task_uid})
+    resp3, _ = zmq_single_request("task_result_get", params={"task_uid": task_uid})
     assert resp3["success"] is True
     assert resp3["msg"] == ""
     assert resp3["task_uid"] == task_uid
@@ -1463,7 +1463,7 @@ def test_zmq_api_script_upload_1(re_manager, run_in_background):  # noqa: F811
     assert status["items_in_history"] == 0
     assert status["worker_background_tasks"] == 0
 
-    resp4, _ = zmq_single_request("task_load_result", params={"task_uid": task_uid})
+    resp4, _ = zmq_single_request("task_result_get", params={"task_uid": task_uid})
     assert resp4["success"] is True
     assert resp4["msg"] == ""
     assert resp4["task_uid"] == task_uid
@@ -2025,7 +2025,7 @@ def test_zmq_api_function_execute_1(re_manager, run_in_background, wait_for_idle
         #   manager state to switch to idle. This only makes sense when function is
         #   executed on the foreground.
         assert wait_for_condition(time=10, condition=condition_manager_idle)
-        resp2, _ = zmq_single_request("task_load_result", params={"task_uid": task_uid})
+        resp2, _ = zmq_single_request("task_result_get", params={"task_uid": task_uid})
         assert resp2["success"] is True, pprint.pformat(resp2)
         assert resp2["result"]["success"] is True, pprint.pformat(resp2["result"])
     else:

--- a/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -21,6 +21,8 @@ user_groups:
       - ".*"  # A different way to allow all
     forbidden_devices:
       - null  # Nothing is forbidden
+    allowed_functions:
+      - "^function_sleep$"
   test_user:  # Users with limited access capabilities
     allowed_plans:
       - "^count$"  # Use regular expression patterns

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -356,6 +356,8 @@ periodically requests and displays the status of Queue Server.
     qserver environment close        # Close RE environment
     qserver environment destroy      # Destroy RE environment (kill RE worker process)
 
+    qserver existing plans           # Request the list of existing plans
+    qserver existing devices         # Request the list of existing devices
     qserver allowed plans            # Request the list of allowed plans
     qserver allowed devices          # Request the list of allowed devices
     qserver permissions reload       # Reload user permissions and generate lists of allowed plans and devices.
@@ -435,6 +437,18 @@ periodically requests and displays the status of Queue Server.
 
     qserver history get        # Request plan history
     qserver history clear      # Clear plan history
+
+    qserver function execute <function-params>             # Start execution of a function
+    qserver function execute <function-params> background  # ... in the background thread
+
+    Example of JSON specification of a function ("args" and "kwargs" are optional):
+        '{"name": "function_sleep", "args": [20], "kwargs": {}}'
+
+    qserver script upload <path-to-file>              # Upload a script to RE Worker environment
+    qserver script upload <path-to-file> background   # ... in the background
+    qserver script upload <path-to-file> update-re    # ... allow 'RE' and 'db' to be updated
+
+    qserver task load result <task-uid>  # Load status or result of a task with the given UID
 
     qserver manager stop           # Safely exit RE Manager application
     qserver manager stop safe on   # Safely exit RE Manager application

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -122,7 +122,7 @@ Run tasks in RE Worker namespace:
 
 - :ref:`method_script_upload`
 - :ref:`method_function_execute`
-- :ref:`method_task_load_result`
+- :ref:`method_task_result_get`
 
 Stopping RE Manager (mostly used in testing):
 
@@ -192,7 +192,7 @@ Returns       **msg**: *str*
               **task_results_uid**: *str*
                  UID of the dictionary of task results. UID is updated each time results of a new
                  completed tasks are added to the dictionary. Check the status of the pending tasks
-                 (see *task_load_result* API) once UID is changed.
+                 (see *task_result_get* API) once UID is changed.
 
               **plans_allowed_uid**: *str*
                  UID for the list of allowed plans. UID is updated each time the contents of
@@ -1339,7 +1339,7 @@ Description   Upload and execute script in RE Worker namespace. The script may a
               objects defined in the namespace, including plans and devices. Dynamic modification
               of the worker namespace may be used to implement more flexible workflows. The API call
               updates the lists of existing and allowed plans and devices if necessary. Changes in
-              the lists will be indicated by changed list UIDs. Use *'task_load_result'* API to check
+              the lists will be indicated by changed list UIDs. Use *'task_result_get'* API to check
               if the script was loaded correctly. Note, that if the task fails, the script is
               still executed to the point where the exception is raised, changing the environment.
 ------------  -----------------------------------------------------------------------------------------
@@ -1371,10 +1371,10 @@ Returns       **success**: *boolean*
 
               **task_uid**: *str* or *None*
                   Task UID can be used to check status of the task and download results once the task
-                  is completed (see *task_load_result* API).
+                  is completed (see *task_result_get* API).
 ------------  -----------------------------------------------------------------------------------------
 Execution     The method initiates the operation. Monitor *task_results_uid* status field and call
-              *task_load_results* API to check for success.
+              *task_result_get* API to check for success.
 ============  =========================================================================================
 
 
@@ -1397,7 +1397,7 @@ Description   Start execution of a function in RE Worker namespace. The function
 
               The method allows to pass parameters (*args* and *kwargs*) to the function. Once the task
               is completed, the results of the function execution, including the return value, can be
-              loaded using *task_load_result* method. If the task fails, the return value is a string
+              loaded using *task_result_get* method. If the task fails, the return value is a string
               with full traceback of the raised exception. The data types of parameters and return
               values must be JSON serializable. The task fails if the return value can not be serialized.
 
@@ -1405,7 +1405,7 @@ Description   Start execution of a function in RE Worker namespace. The function
               (*success=True*), the server starts the task, which attempts to execute the function
               with given name and parameters. The function may still fail start (e.g. if the user is
               permitted to execute function with the given name, but the function is not defined
-              in the namespace). Use *'task_load_result'* method with the returned *task_uid* to
+              in the namespace). Use *'task_result_get'* method with the returned *task_uid* to
               check the status of the taks and load the result upon completion.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **item**: *dict*
@@ -1440,22 +1440,22 @@ Returns       **success**: *boolean*
 
               **task_uid**: *str* or *None*
                   Task UID can be used to check status of the task and download results once the task
-                  is completed (see *task_load_result* API). *None* is returned if the request fails.
+                  is completed (see *task_result_get* API). *None* is returned if the request fails.
 ------------  -----------------------------------------------------------------------------------------
 Execution     The method initiates the operation. Monitor *task_results_uid* status field and call
-              *task_load_results* API to check for success.
+              *task_result_get* API to check for success.
 ============  =========================================================================================
 
 
-.. _method_task_load_result:
+.. _method_task_result_get:
 
-**'task_load_result'**
-^^^^^^^^^^^^^^^^^^^^^^
+**'task_result_get'**
+^^^^^^^^^^^^^^^^^^^^^
 
 ============  =========================================================================================
-Method        **'task_load_result'**
+Method        **'task_result_get'**
 ------------  -----------------------------------------------------------------------------------------
-Description   Load the status and results of task execution. The completed tasks are stored at
+Description   Get the status and results of task execution. The completed tasks are stored at
               the server at least for the period determined by retention time (currently 120 seconds
               after completion of the task). The expired results could be automatically deleted
               at any time and the method will return the task status as *'not_found'*.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implemented CLI support for new 0MQ API:
- `qserver script upload` (`script_upload` API);
- `qserver function execute` (`function_execute` API);
- `qserver task result get` (`task_result_get` API);
- `qserver existing devices` (`devices_existing` API);
- `qserver existing plans` (`plans_existing` API).

Renamed `task_load_result` API to `task_result_get`. The latter name is more consistent with other API names (the respective name for REST API is going to be `/task/result/get`. The API was implemented very recently, so no user code using this API is expected to exist.

## Motivation and Context
Several previous PRs introduced new 0MQ API, but contained no CLI implementation. 

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added
- CLI implementation for the new 0MQ API:  `qserver script upload` (`script_upload` API), `qserver function execute` (`function_execute` API), `qserver task result get` (`task_result_get` API), `qserver existing devices` (`devices_existing` API), `qserver existing plans` (`plans_existing` API).
- !!!! CHANGED THE NAME FOR `task_load_result` TO `task_result_get`. THIS IS THE NEW API, SO USE THE NEW NAME IN RELEASE NOTES

### Changed

### Removed

## How Has This Been Tested?
Unit tests are implemented

<!--
## Screenshots (if appropriate):
-->
