### PR TITLE
New 0MQ API: 'permissions_set' and 'permissions_get'

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -165,6 +165,17 @@ class RunEngineManager(Process):
         self._running_task_uid = None  # UID of currently running foreground task (if any)
         self._task_results = None  # TaskResults(), uses threading.Lock
 
+        # Indicates when to update the existing plans and devices
+        ug_permissions_reload = self._config_dict["user_group_permissions_reload"]
+        if ug_permissions_reload not in ("NEVER", "ON_REQUEST", "ON_STARTUP"):
+            logger.error(
+                "Unknown option for reloading user group permissions: '%s'. "
+                "The permissions will be reloaded on each startup of RE Manager.",
+                ug_permissions_reload,
+            )
+            ug_permissions_reload = "ON_STARTUP"
+        self._user_group_permissions_reload_option = ug_permissions_reload
+
     async def _heartbeat_generator(self):
         """
         Heartbeat generator for Watchdog (indicates that the loop is running)
@@ -551,7 +562,7 @@ class RunEngineManager(Process):
         self._existing_plans = existing_plans
         self._existing_devices = existing_devices
 
-    async def _load_existing_plans_and_devices_from_worker(self, update_user_group_permissions=False):
+    async def _load_existing_plans_and_devices_from_worker(self):
         """
         Download the updated list of existing plans and devices from the worker environment.
         User group permissions are also downloaded from the worker and could be updated if needed.
@@ -569,9 +580,6 @@ class RunEngineManager(Process):
                 existing_plans=plan_and_devices_list["existing_plans"],
                 existing_devices=plan_and_devices_list["existing_devices"],
             )
-
-            if update_user_group_permissions:
-                self._user_group_permissions = plan_and_devices_list["user_group_permissions"]
 
             try:
                 self._generate_lists_of_allowed_plans_and_devices()
@@ -942,15 +950,31 @@ class RunEngineManager(Process):
         except Exception as ex:
             logger.error("Error occurred while comparing lists of allowed devices: %s", str(ex))
 
-    def _load_permissions(self):
+    def _load_permissions_from_disk(self):
         """
         Load permissions from disk.
         """
         try:
             path_ug = self._config_dict["user_group_permissions_path"]
             self._user_group_permissions = load_user_group_permissions(path_ug)
+            # Save loaded permissions to Redis
+            self._plan_queue.user_group_permissions_save(self._user_group_permissions)
         except Exception as ex:
             logger.exception("Error occurred while loading user permissions from file '%s': %s", path_ug, str(ex))
+
+    def _load_permissions_from_redis(self):
+        """
+        Load and validate user group permissions stored in Redis. If there is no permissions data in Redis
+        or data validation fails, then attempt to load permissions from file. User group permissions are
+        left unchanged if data can not be loaded from disk.
+        """
+        try:
+            ug_permissions = self._plan_queue.user_group_permissions_retrieve()
+            validate_user_group_permissions(ug_permissions)
+            self._user_group_permissions = ug_permissions
+        except Exception as ex:
+            logger.error("Validation of user group permissions loaded from Redis failed: %s", str(ex))
+            self._load_permissions_from_disk()
 
     def _update_allowed_plans_and_devices(self, reload_plans_devices=False):
         """
@@ -1420,13 +1444,25 @@ class RunEngineManager(Process):
         """
         logger.info("Reloading lists of allowed plans and devices ...")
         try:
-            supported_param_names = ["reload_plans_devices"]
+            supported_param_names = ["reload_plans_devices", "reload_permissions"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
 
             # Do not reload the lists of existing plans and devices from disk file by default
             reload_plans_devices = request.get("reload_plans_devices", False)
+            reload_permissions = request.get("reload_permissions", True)
 
-            self._load_permissions()
+            if reload_permissions and (
+                self._user_group_permissions_reload_option not in ("ON_REQUEST", "ON_STARTUP")
+            ):
+                raise RuntimeError(
+                    "Reloading of permissions from disk is not allowed: RE Manager was started with option "
+                    f"user_group_permissions_reload={self._user_group_permissions_reload_option!r}",
+                )
+
+            if reload_permissions:
+                self._load_permissions_from_disk()
+            else:
+                self._load_permissions_from_redis()
             self._update_allowed_plans_and_devices(reload_plans_devices=reload_plans_devices)
 
             # If environment exists, then tell the worker to reload permissions. This is optional.
@@ -2655,6 +2691,19 @@ class RunEngineManager(Process):
         # Delete Redis entries (for testing and debugging)
         # self._plan_queue.delete_pool_entries()
 
+        try:
+            ug_permissions_from_redis = self._plan_queue.user_group_permissions_retrieve()
+            validate_user_group_permissions(ug_permissions_from_redis)
+        except Exception as ex:
+            logger.error("Validation of user group permissions loaded from Redis failed: %s", str(ex))
+            ug_permissions_from_redis = None
+
+        # Load user group permissions
+        if self._user_group_permissions_reload_option == "ON_STARTUP":
+            self._load_permissions_from_disk()
+        else:
+            self._load_permissions_from_redis()
+
         # Set the environment state based on whether the worker process is alive (request Watchdog)
         self._environment_exists = await self._is_worker_alive()
 
@@ -2665,7 +2714,7 @@ class RunEngineManager(Process):
             #   and a copy of user group permissions, so they could be downloaded from the worker.
             #   If the request to download plans and devices fails, then the lists of existing and allowed
             #   devices and plans and the dictionary of user group permissions are going to be empty ({}).
-            await self._load_existing_plans_and_devices_from_worker(update_user_group_permissions=True)
+            await self._load_existing_plans_and_devices_from_worker()
             try:
                 self._update_allowed_plans_and_devices(reload_plans_devices=False)
             except Exception as ex:
@@ -2716,9 +2765,6 @@ class RunEngineManager(Process):
         else:
             # Load lists of allowed plans and devices
             logger.info("Loading the lists of allowed plans and devices ...")
-            # Load user group permissions and existing plans and devices from files
-            #   if RE environment does not exist
-            self._load_permissions()
             try:
                 self._update_allowed_plans_and_devices(reload_plans_devices=True)
             except Exception as ex:

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -67,7 +67,15 @@ class RunEngineManager(Process):
     """
 
     def __init__(
-        self, *args, conn_watchdog, conn_worker, config=None, msg_queue=None, log_level=logging.DEBUG, **kwargs
+        self,
+        *args,
+        conn_watchdog,
+        conn_worker,
+        config=None,
+        msg_queue=None,
+        log_level=logging.DEBUG,
+        number_of_restarts,
+        **kwargs,
     ):
 
         if not conn_watchdog:
@@ -85,6 +93,10 @@ class RunEngineManager(Process):
 
         self._watchdog_conn = conn_watchdog
         self._worker_conn = conn_worker
+
+        # The number of time RE Manager was started (including the first attempt to start it).
+        #   Numbering starts from 1.
+        self._number_of_restarts = number_of_restarts
 
         # The following attributes hold the state of the system
         self._manager_stopping = False  # Set True to exit manager (by _manager_stop_handler)
@@ -1442,7 +1454,6 @@ class RunEngineManager(Process):
 
             if user_group_permissions != self._user_group_permissions:
                 validate_user_group_permissions(user_group_permissions)
-
                 self._user_group_permissions = user_group_permissions
                 self._update_allowed_plans_and_devices()
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -2229,7 +2229,7 @@ class RunEngineManager(Process):
 
         return {"success": success, "msg": msg, "item": item, "task_uid": task_uid}
 
-    async def _task_result_get_handler(self, request):
+    async def _task_result_handler(self, request):
         """
         Returns the information of a task executed by the worker process. The request must contain
         valid ``task_uid``, returned by one of APIs that starts tasks. Returned
@@ -2520,7 +2520,7 @@ class RunEngineManager(Process):
             "environment_destroy": "_environment_destroy_handler",
             "script_upload": "_script_upload_handler",
             "function_execute": "_function_execute_handler",
-            "task_result_get": "_task_result_get_handler",
+            "task_result": "_task_result_handler",
             "queue_mode_set": "_queue_mode_set_handler",
             "queue_item_add": "_queue_item_add_handler",
             "queue_item_add_batch": "_queue_item_add_batch_handler",

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -966,7 +966,7 @@ class RunEngineManager(Process):
         """
         Load and validate user group permissions stored in Redis. If there is no permissions data in Redis
         or data validation fails, then attempt to load permissions from file. User group permissions are
-        left unchanged if data can not be loaded from disk.
+        left unchanged if data can not be loaded from disk either.
         """
         try:
             ug_permissions = self._plan_queue.user_group_permissions_retrieve()
@@ -2691,15 +2691,8 @@ class RunEngineManager(Process):
         # Delete Redis entries (for testing and debugging)
         # self._plan_queue.delete_pool_entries()
 
-        try:
-            ug_permissions_from_redis = self._plan_queue.user_group_permissions_retrieve()
-            validate_user_group_permissions(ug_permissions_from_redis)
-        except Exception as ex:
-            logger.error("Validation of user group permissions loaded from Redis failed: %s", str(ex))
-            ug_permissions_from_redis = None
-
         # Load user group permissions
-        if self._user_group_permissions_reload_option == "ON_STARTUP":
+        if (self._user_group_permissions_reload_option == "ON_STARTUP") and (self._number_of_restarts == 1):
             self._load_permissions_from_disk()
         else:
             self._load_permissions_from_redis()

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1491,6 +1491,7 @@ class RunEngineManager(Process):
             if user_group_permissions != self._user_group_permissions:
                 validate_user_group_permissions(user_group_permissions)
                 self._user_group_permissions = user_group_permissions
+                await self._plan_queue.user_group_permissions_save(self._user_group_permissions)
                 self._update_allowed_plans_and_devices()
 
                 # If environment exists, then tell the worker to reload permissions. This is optional.
@@ -2693,8 +2694,10 @@ class RunEngineManager(Process):
 
         # Load user group permissions
         if (self._user_group_permissions_reload_option == "ON_STARTUP") and (self._number_of_restarts == 1):
+            logger.debug("Loading user permissions from disk ...")
             await self._load_permissions_from_disk()
         else:
+            logger.debug("Loading user permissions from Redis ...")
             await self._load_permissions_from_redis()
 
         # Set the environment state based on whether the worker process is alive (request Watchdog)

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2420,7 +2420,7 @@ _user_group_permission_schema = {
 }
 
 
-def validate_user_group_permissions_schema(user_group_permissions):
+def _validate_user_group_permissions_schema(user_group_permissions):
     """
     Validate user group permissions schema. Raises exception if validation fails.
 
@@ -2430,6 +2430,24 @@ def validate_user_group_permissions_schema(user_group_permissions):
         A dictionary with user group permissions.
     """
     jsonschema.validate(instance=user_group_permissions, schema=_user_group_permission_schema)
+
+
+def validate_user_group_permissions(user_group_permissions):
+    """
+    Validate the dictionary with user group permissions. Exception is raised errors are detected.
+
+    Parameters
+    ----------
+    user_group_permissions: dict
+        The dictionary with user group permissions.
+    """
+    if not isinstance(user_group_permissions, dict):
+        raise TypeError(f"User group permissions: Invalid type '{type(user_group_permissions)}', must be 'dict'")
+
+    _validate_user_group_permissions_schema(user_group_permissions)
+
+    if "root" not in user_group_permissions["user_groups"]:
+        raise KeyError("User group permissions: Missing required user group: 'root'")
 
 
 def load_user_group_permissions(path_to_file=None):
@@ -2464,7 +2482,7 @@ def load_user_group_permissions(path_to_file=None):
         with open(path_to_file, "r") as stream:
             user_group_permissions = yaml.safe_load(stream)
 
-        validate_user_group_permissions_schema(user_group_permissions)
+        validate_user_group_permissions(user_group_permissions)
 
         if "root" not in user_group_permissions["user_groups"]:
             raise Exception("Missing required user group: 'root'")

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -138,7 +138,7 @@ qserver script upload <path-to-file>              # Upload a script to RE Worker
 qserver script upload <path-to-file> background   # ... in the background
 qserver script upload <path-to-file> update-re    # ... allow 'RE' and 'db' to be updated
 
-qserver task result get <task-uid>  # Load status or result of a task with the given UID
+qserver task result <task-uid>  # Load status or result of a task with the given UID
 
 qserver manager stop           # Safely exit RE Manager application
 qserver manager stop safe on   # Safely exit RE Manager application
@@ -859,14 +859,14 @@ def create_msg(params):
 
     # ----------- task ------------
     elif command == "task":
-        if len(params) != 3:
+        if len(params) != 2:
             raise CommandParameterError(f"Request '{command}' must include at 3 parameters")
-        if (params[0] == "result") and (params[1] == "get"):
-            task_uid = str(params[2])
-            method = f"{command}_{params[0]}_{params[1]}"
+        if params[0] == "result":
+            task_uid = str(params[1])
+            method = f"{command}_{params[0]}"
             prms = {"task_uid": task_uid}
         else:
-            raise CommandParameterError(f"Request '{command} {params[0]} {params[1]}' is not supported")
+            raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
 
     # ----------- function ------------
     elif command == "function":

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -306,9 +306,9 @@ def start_manager():
         choices=["NEVER", "ON_REQUEST", "ON_STARTUP"],
         default="ON_STARTUP",
         help="Select when user group permissions are reloaded from disk. Options: 'NEVER' - "
-        "RE Manager never attempts to load permissions from disk file. If there are no permissions "
-        "saved in Redis, the permissions are loaded at the first startup of RE Manager. 'ON_REQUEST' - "
-        "permissions are loaded from disk file when requested by 'permission_reload' API call. "
+        "RE Manager never attempts to load permissions from disk file. If permissions fail to load "
+        "from Redis, they are loaded from disk at the first startup of RE Manager or on request. "
+        "'ON_REQUEST' - permissions are loaded from disk file when requested by 'permission_reload' API call. "
         "'ON_STARTUP' - permissions are loaded from disk each time RE Manager is started or when "
         "'permission_reload' API request is received "
         "(default: %(default)s)",

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -41,6 +41,9 @@ class WatchdogProcess:
         self._re_manager = None
         self._re_worker = None
 
+        # The number of restarts of the manager processes including the first start.
+        self._re_manager_n_restarts = 0
+
         # Create pipes used for connections of the modules
         self._manager_conn = None  # Worker -> Manager
         self._worker_conn = None  # Manager -> Worker
@@ -144,6 +147,7 @@ class WatchdogProcess:
     # ======================================================================
 
     def _start_re_manager(self):
+        self._re_manager_n_restarts += 1
         self._init_watchdog_state()
         self._re_manager = self._cls_run_engine_manager(
             conn_watchdog=self._manager_to_watchdog_conn,
@@ -152,6 +156,7 @@ class WatchdogProcess:
             name="RE Manager Process",
             msg_queue=self._msg_queue,
             log_level=self._log_level,
+            number_of_restarts=self._re_manager_n_restarts,
         )
         self._re_manager.start()
 

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -300,6 +300,21 @@ def start_manager():
     )
 
     parser.add_argument(
+        "--user-group-permissions-reload",
+        dest="user_group_permissions_reload",
+        type=str,
+        choices=["NEVER", "ON_REQUEST", "ON_STARTUP"],
+        default="ON_STARTUP",
+        help="Select when user group permissions are reloaded from disk. Options: 'NEVER' - "
+        "RE Manager never attempts to load permissions from disk file. If there are no permissions "
+        "saved in Redis, the permissions are loaded at the first startup of RE Manager. 'ON_REQUEST' - "
+        "permissions are loaded from disk file when requested by 'permission_reload' API call. "
+        "'ON_STARTUP' - permissions are loaded from disk each time RE Manager is started or when "
+        "'permission_reload' API request is received "
+        "(default: %(default)s)",
+    )
+
+    parser.add_argument(
         "--redis-addr",
         dest="redis_addr",
         type=str,
@@ -582,6 +597,8 @@ def start_manager():
     config_manager["user_group_permissions_path"] = user_group_pd_path
 
     config_worker["update_existing_plans_devices"] = args.update_existing_plans_devices
+
+    config_manager["user_group_permissions_reload"] = args.user_group_permissions_reload
 
     # Read private key from the environment variable, then check if the CLI parameter exists
     zmq_private_key = os.environ.get("QSERVER_ZMQ_PRIVATE_KEY", None)

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -373,9 +373,9 @@ sources:
 class ReManager:
     def __init__(self, params=None, *, stdout=sys.stdout, stderr=sys.stdout):
         self._p = None
-        self._start_manager(params, stdout=stdout, stderr=stderr)
+        self.start_manager(params, stdout=stdout, stderr=stderr)
 
-    def _start_manager(self, params=None, *, stdout, stderr):
+    def start_manager(self, params=None, *, stdout=sys.stdout, stderr=sys.stdout, cleanup=True):
         """
         Start RE manager.
 
@@ -387,6 +387,8 @@ class ReManager:
             Device to forward stdout, ``None`` - print to console
         stderr
             Device to forward stdout, ``None`` - print to console
+        cleanup: boolean
+            Perform cleanup (remove related Redis keys) before opening the manager.
 
         Returns
         -------
@@ -402,7 +404,8 @@ class ReManager:
             params.append("--verbose")
 
         if not self._p:
-            clear_redis_pool()
+            if cleanup:
+                clear_redis_pool()
 
             cmd = ["start-re-manager"]
             if params:
@@ -423,7 +426,7 @@ class ReManager:
         except subprocess.TimeoutExpired:
             return False
 
-    def stop_manager(self, timeout=10):
+    def stop_manager(self, timeout=10, cleanup=True):
         """
         Attempt to exit the subprocess that is running manager in orderly way and kill it
         after timeout.
@@ -432,6 +435,8 @@ class ReManager:
         ----------
         timeout: float
             Timeout in seconds.
+        cleanup: boolean
+            Perform cleanup (remove created Redis keys) after closing the manager.
         """
         if self._p:
             try:
@@ -481,7 +486,8 @@ class ReManager:
                 assert False, f"RE Manager failed to stop: {str(ex)}"
 
             finally:
-                clear_redis_pool()
+                if cleanup:
+                    clear_redis_pool()
                 self._p = None
 
     def kill_manager(self, timeout=10):

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -289,7 +289,7 @@ def wait_for_task_result(time, task_uid):
     while ttime.time() < time_stop:
         ttime.sleep(dt / 2)
         try:
-            resp, _ = zmq_secure_request("task_result_get", params={"task_uid": task_uid})
+            resp, _ = zmq_secure_request("task_result", params={"task_uid": task_uid})
 
             assert resp["success"] is True, f"Request for task result failed: {resp['msg']}"
             assert resp["task_uid"] == task_uid

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -311,6 +311,7 @@ def clear_redis_pool():
     async def run():
         await pq.start()
         await pq.delete_pool_entries()
+        await pq.user_group_permissions_clear()
 
     asyncio.run(run())
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -2042,3 +2042,27 @@ def test_set_processed_item_as_stopped_3(pq, loop_mode, func):
         assert "properties" not in history[0]
 
     asyncio.run(testing())
+
+
+# ==============================================================================================
+#                    Saving and retrieving user group permissions
+def test_user_group_permissions_1(pq):
+    """
+    Test for saving and retrieving and clearing user group permissions, which are backed up in Redis.
+    """
+    ug_permissions_1 = {"some_key_1": "some_value_1"}
+    ug_permissions_2 = {"some_key_2": "some_value_2"}
+
+    async def testing():
+        assert await pq.user_group_permissions_retrieve() is None
+
+        await pq.user_group_permissions_save(ug_permissions_1)
+        assert await pq.user_group_permissions_retrieve() == ug_permissions_1
+
+        await pq.user_group_permissions_save(ug_permissions_2)
+        assert await pq.user_group_permissions_retrieve() == ug_permissions_2
+
+        await pq.user_group_permissions_clear()
+        assert await pq.user_group_permissions_retrieve() is None
+
+    asyncio.run(testing())

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -16,9 +16,11 @@ def pq():
     asyncio.run(pq.start())
     # Clear any pool entries
     asyncio.run(pq.delete_pool_entries())
+    asyncio.run(pq.user_group_permissions_clear())
     yield pq
     # Don't leave any test entries in the pool
     asyncio.run(pq.delete_pool_entries())
+    asyncio.run(pq.user_group_permissions_clear())
 
 
 # fmt: off

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -2189,11 +2189,11 @@ pa2_Enum1 = enum.Enum("pa2_Enum1", {"enum1": "enum1", "enum2": "enum2"})
         {"pa2_Device1": ("dev1", "dev2", "dev3"),
          "pa2_Enum1": ("enum1", "enum2")}},
      typing.Union[typing.List[pa2_Device1], typing.List[pa2_Enum1]], True, ""),
-    # Use Tuple instead of List (different type, but the same JSON schema)
+    # Use Tuple instead of List (produces different JSON schema)
     ({"type": "typing.Union[typing.Tuple[pa2_Device1], typing.List[pa2_Enum1]]", "devices":
         {"pa2_Device1": ("dev1", "dev2", "dev3"),
          "pa2_Enum1": ("enum1", "enum2")}},
-     typing.Union[typing.List[pa2_Device1], typing.List[pa2_Enum1]], True, ""),
+     typing.Union[typing.Tuple[pa2_Device1], typing.List[pa2_Enum1]], True, ""),
     # Failing case: unknown 'custom' type in the annotation
     ({"type": "typing.Union[typing.List[unknown_type], typing.List[pa2_Enum1]]", "devices":
         {"pa2_Device1": ("dev1", "dev2", "dev3"),

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -59,7 +59,7 @@ from bluesky_queueserver.manager.profile_ops import (
     _check_ranges,
     format_text_descriptions,
     check_if_function_allowed,
-    validate_user_group_permissions_schema,
+    _validate_user_group_permissions_schema,
     prepare_function,
 )
 
@@ -2889,7 +2889,7 @@ def test_prepare_function_2(func_info, except_type, msg):
     nspace = {}
     load_script_into_existing_nspace(script=_prep_func_script_1, nspace=nspace)
 
-    validate_user_group_permissions_schema(_prep_func_permissions)
+    _validate_user_group_permissions_schema(_prep_func_permissions)
     with pytest.raises(except_type, match=msg):
         prepare_function(func_info=func_info, nspace=nspace, user_group_permissions=_prep_func_permissions)
 
@@ -4075,7 +4075,7 @@ _func_permissions_dict_7 = {
 ])
 # fmt: on
 def test_check_if_function_allowed_1(permissions_dict, func_name, group, accepted):
-    validate_user_group_permissions_schema(permissions_dict)
+    _validate_user_group_permissions_schema(permissions_dict)
     is_accepted = check_if_function_allowed(func_name, group_name=group, user_group_permissions=permissions_dict)
     assert is_accepted == accepted
 

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -1216,18 +1216,18 @@ def test_function_execute_2_fail(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "function", "execute", item, "invalid_param"]) == PARAM_ERROR
 
 
-def test_task_result_get_1(re_manager):  # noqa: F811
+def test_task_result_1(re_manager):  # noqa: F811
     """
     Tests for 'qserver task result_get'.
     """
     # The request should be successful for any 'task_uid'.
     task_uid = "01e80342-5e36-44de-bc86-9bd8d57c9885"
-    assert subprocess.call(["qserver", "task", "result", "get", task_uid]) == SUCCESS
+    assert subprocess.call(["qserver", "task", "result", task_uid]) == SUCCESS
 
     # Some cases of invalid parameters
-    assert subprocess.call(["qserver", "task", "result", "get"]) == PARAM_ERROR
-    assert subprocess.call(["qserver", "task", "result", "something"]) == PARAM_ERROR
-    assert subprocess.call(["qserver", "task", "something", "something"]) == PARAM_ERROR
+    assert subprocess.call(["qserver", "task", "result"]) == PARAM_ERROR
+    assert subprocess.call(["qserver", "task", "something"]) == PARAM_ERROR
+    assert subprocess.call(["qserver", "task", "result", task_uid, "extra_param"]) == PARAM_ERROR
 
 
 _sample_trivial_plan1 = """

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -2,6 +2,7 @@ import time as ttime
 import subprocess
 import pytest
 import os
+import yaml
 
 from bluesky_queueserver.manager.profile_ops import gen_list_of_plans_and_devices
 from bluesky_queueserver.manager.comms import generate_new_zmq_key_pair
@@ -1242,7 +1243,7 @@ def trivial_plan_for_unit_test():
 # fmt: off
 @pytest.mark.parametrize("reload_plans_devices", [True, False])
 # fmt: on
-def test_qserver_reload_permissions_1(re_manager_pc_copy, tmp_path, reload_plans_devices):  # noqa F811
+def test_qserver_permissions_reload_1(re_manager_pc_copy, tmp_path, reload_plans_devices):  # noqa F811
     """
     Tests for ``qserver permissions reload [lists]`` API.
     """
@@ -1268,6 +1269,60 @@ def test_qserver_reload_permissions_1(re_manager_pc_copy, tmp_path, reload_plans
     # Attempt to add the plan to the queue. It should be successful now.
     res_expected = SUCCESS if reload_plans_devices else REQ_FAILED
     assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == res_expected
+
+
+_permissions_dict_not_allow_count = {
+    "user_groups": {
+        "root": {"allowed_plans": [None], "allowed_devices": [None]},
+        "admin": {"allowed_plans": [None], "forbidden_plans": ["^count$"], "allowed_devices": [None]},
+    }
+}
+
+
+def test_qserver_permissions_set_get_1(re_manager, tmp_path):  # noqa F811
+    """
+    Tests for ``qserver permissions set`` and ``qserver permissions get``: basic tests.
+    """
+
+    user_group_permissions = _permissions_dict_not_allow_count
+
+    # Create yaml file with user group permissions
+    fl_path = os.path.join(tmp_path, "ugp.yaml")
+    with open(fl_path, "w") as f:
+        f.writelines(yaml.dump(user_group_permissions))
+
+    # Set user group permissions
+    assert subprocess.call(["qserver", "permissions", "set", fl_path]) == SUCCESS
+
+    # Check that permissions were really changed
+    resp1, _ = zmq_single_request("permissions_get")
+    assert resp1["success"] is True, f"resp={resp1}"
+    assert resp1["user_group_permissions"] == user_group_permissions
+
+    # Check if 'qserver permissions get' works
+    assert subprocess.call(["qserver", "permissions", "get"]) == SUCCESS
+
+
+def test_qserver_permissions_set_get_2_fail(re_manager, tmp_path):  # noqa F811
+    """
+    Tests for ``qserver permissions set`` and ``qserver permissions get``: failing cases.
+    """
+    # Create yaml file with user group permissions
+    fl_path = os.path.join(tmp_path, "ugp.yaml")
+    with open(fl_path, "w") as f:
+        f.writelines("This is not a valid permissions dictionary")  # Invalid file
+
+    # Non-existing file
+    assert subprocess.call(["qserver", "permissions", "set", os.path.join(tmp_path, "some_file")]) == PARAM_ERROR
+    # No file name
+    assert subprocess.call(["qserver", "permissions", "set"]) == PARAM_ERROR
+    # Extra parameters
+    assert subprocess.call(["qserver", "permissions", "set", fl_path, "extra_parameter"]) == PARAM_ERROR
+    # Request is correct, but the file does not contain valid dictionary
+    assert subprocess.call(["qserver", "permissions", "set", fl_path]) == REQ_FAILED
+
+    # Extra parameters
+    assert subprocess.call(["qserver", "permissions", "get", "extra_parameter"]) == PARAM_ERROR
 
 
 # fmt: off

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -61,6 +61,7 @@ _user, _user_group, _test_user_group = "Testing Script", "admin", "test_user"
 _existing_plans_and_devices_fln = "existing_plans_and_devices.yaml"
 _user_group_permissions_fln = "user_group_permissions.yaml"
 
+timeout_env_open = 10
 
 # =======================================================================================
 #                   Thread-based ZMQ API - ZMQCommSendThreads
@@ -195,7 +196,7 @@ def test_zmq_api_environment_open_close_1(re_manager):  # noqa F811
     assert resp1["success"] is True
     assert resp1["msg"] == ""
 
-    assert wait_for_condition(time=3, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     state = get_queue_state()
     assert state["re_state"] == "idle"
@@ -226,7 +227,7 @@ def test_zmq_api_environment_open_close_2(re_manager):  # noqa F811
     assert resp1b["success"] is False
     assert "in the process of creating the RE Worker environment" in resp1b["msg"]
 
-    assert wait_for_condition(time=3, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # Attempt to open the environment while it already exists
     resp2, _ = zmq_single_request("environment_open")
@@ -257,7 +258,7 @@ def test_zmq_api_environment_open_close_3(re_manager):  # noqa F811
     assert resp1["success"] is True
     assert resp1["msg"] == ""
 
-    assert wait_for_condition(time=3, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # Start a plan
     resp2, _ = zmq_single_request("queue_item_add", {"item": _plan3, "user": _user, "user_group": _user_group})
@@ -437,7 +438,7 @@ def test_zmq_api_queue_item_add_4(re_manager):  # noqa F811
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
     assert wait_for_condition(
-        time=3, condition=condition_environment_created
+        time=timeout_env_open, condition=condition_environment_created
     ), "Timeout while waiting for environment to be opened"
 
     resp2, _ = zmq_single_request("queue_start")
@@ -543,7 +544,7 @@ def test_zmq_api_queue_item_add_7(db_catalog, re_manager_cmd, meta_param, meta_s
     # Open the environment.
     resp3, _ = zmq_single_request("environment_open")
     assert resp3["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     resp4, _ = zmq_single_request("queue_start")
     assert resp4["success"] is True
@@ -663,7 +664,7 @@ def test_zmq_api_queue_item_execute_1(re_manager):  # noqa: F811
 
     resp2, _ = zmq_single_request("environment_open")
     assert resp2["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     resp2a, _ = zmq_single_request("status")
     assert resp2a["items_in_queue"] == 1
@@ -735,7 +736,7 @@ def test_zmq_api_queue_item_execute_2(re_manager):  # noqa: F811
     # The queue contains only a single instruction (stop the queue).
     resp2, _ = zmq_single_request("environment_open")
     assert resp2["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     resp2a, _ = zmq_single_request("status")
     assert resp2a["items_in_queue"] == 1
@@ -795,7 +796,7 @@ def test_zmq_api_queue_item_execute_3(re_manager):  # noqa: F811
 
     resp2, _ = zmq_single_request("environment_open")
     assert resp2["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     resp2a, _ = zmq_single_request("status")
     assert resp2a["items_in_queue"] == 0
@@ -1094,7 +1095,7 @@ def test_zmq_api_queue_item_add_batch_3(re_manager):  # noqa: F811
 
     resp2, _ = zmq_single_request("environment_open")
     assert resp2["success"] is True
-    assert wait_for_condition(time=3, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     resp3, _ = zmq_single_request("queue_start")
     assert resp3["success"] is True
@@ -1399,7 +1400,7 @@ def test_zmq_api_script_upload_1(re_manager, run_in_background):  # noqa: F811
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     status, _ = zmq_single_request("status")
     task_results_uid = status["task_results_uid"]
@@ -1547,7 +1548,7 @@ def test_zmq_api_script_upload_2(re_manager, scripts, updated_devs, updated_plan
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     status, _ = zmq_single_request("status")
     task_results_uid = status["task_results_uid"]
@@ -1641,7 +1642,7 @@ def test_zmq_api_script_upload_3(re_manager, use_bg_task):  # noqa: F811
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # Task 1
     resp2a, _ = zmq_single_request(
@@ -1702,7 +1703,7 @@ def test_zmq_api_script_upload_4(tmp_path, re_manager_cmd):  # noqa: F811
 
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # At this point the lists of allowed plans and devices are expected to be empty.
     resp2a, _ = zmq_single_request("plans_existing")
@@ -1784,7 +1785,7 @@ def test_zmq_api_script_upload_5(tmp_path, re_manager_cmd):  # noqa: F811
 
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # Upload the module that uses local imports
     script = "from mod.mod_file import *\n"
@@ -1829,7 +1830,7 @@ def test_zmq_api_script_upload_6(re_manager_cmd, update_re_param, replace_re, re
 
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # Upload script that saves instances of 'RE' and 'db' in the namespace
     resp2, _ = zmq_single_request("script_upload", params={"script": _script_save_instances_re_db})
@@ -1877,7 +1878,7 @@ def test_zmq_api_script_upload_7(re_manager):  # noqa: F811
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # Run the script in foreground
     long_script = "import time as tt\ntt.sleep(20)\n"
@@ -1905,7 +1906,7 @@ def test_zmq_api_script_upload_7(re_manager):  # noqa: F811
     # Open and close the environment to make sure everything works
     resp6a, _ = zmq_single_request("environment_open")
     assert resp6a["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     resp6b, _ = zmq_single_request("environment_close")
     assert resp6b["success"] is True, f"resp={resp6b}"
@@ -1931,7 +1932,7 @@ def test_zmq_api_script_upload_9_fail(re_manager, test_with_plan):  # noqa: F811
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     if test_with_plan:
         # Now try to run a simple plan and make sure it works
@@ -1989,7 +1990,7 @@ def test_zmq_api_function_execute_1(re_manager, run_in_background, wait_for_idle
 
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     func_item = {"name": "function_sleep", "item_type": "function"}
     if test_with_args:
@@ -2058,7 +2059,7 @@ def test_zmq_api_function_execute_2(re_manager, run_in_background, option):  # n
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     if option == "with_plan":
         resp2a, _ = zmq_single_request(
@@ -2122,7 +2123,7 @@ def test_zmq_api_function_execute_3(re_manager, start_fg_func):  # noqa: F811
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     if start_fg_func:
         fg_func_info = {"name": "function_sleep", "args": [5], "item_type": "function"}
@@ -2174,7 +2175,7 @@ def test_zmq_api_function_execute_4(re_manager):  # noqa: F811
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     resp2, _ = zmq_single_request("script_upload", params={"script": _script_func_1})
     assert resp2["success"] is True
@@ -2244,7 +2245,7 @@ def test_zmq_api_function_execute_5(
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     resp2, _ = zmq_single_request("script_upload", params={"script": script})
     assert resp2["success"] is True
@@ -2279,7 +2280,7 @@ def test_zmq_api_function_execute_6(re_manager):  # noqa: F811
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     func_info = {"name": "clear_buffer", "item_type": "function"}
 
@@ -2323,7 +2324,7 @@ def test_zmq_api_function_execute_7_fail(re_manager, option, item_type, msg):  #
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     func_info = {"name": "function_sleep", "args": [2], "item_type": item_type}
     params = {"user": _user, "user_group": _test_user_group, "run_in_background": True}
@@ -2366,7 +2367,7 @@ def test_zmq_api_function_execute_8_fail(re_manager):  # noqa: F811
     """
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # The function name is in the list of permitted functions
     non_existing_function_name = "non_existing_element"
@@ -2644,7 +2645,7 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
     resp3, _ = zmq_single_request("environment_open")
     assert resp3["success"] is True
     assert wait_for_condition(
-        time=3, condition=condition_environment_created
+        time=timeout_env_open, condition=condition_environment_created
     ), "Timeout while waiting for environment to be opened"
 
     resp4, _ = zmq_single_request("queue_start")
@@ -3103,7 +3104,7 @@ def test_zmq_api_queue_mode_set_3_loop_mode(re_manager):  # noqa: F811
 
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # Continuously test execution of the queue in both modes. The queue contains 2 plans and
     #   'stop' instruction. In the loop mode the queue stops after the instructions, but
@@ -3323,7 +3324,7 @@ def test_permissions_reload_3(re_manager_pc_copy, allow_count_plan):  # noqa: F8
 
     resp1a, _ = zmq_single_request("environment_open")
     assert resp1a["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # Add the first 'count' plan
     resp1b, _ = zmq_single_request("queue_item_add", {"item": _plan1, "user": _user, "user_group": _user_group})
@@ -3536,7 +3537,7 @@ def test_zmq_api_environment_destroy(re_manager):  # noqa: F811
 
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     status = get_queue_state()
     assert status["re_state"] == "idle"
@@ -3565,7 +3566,7 @@ def test_zmq_api_environment_destroy(re_manager):  # noqa: F811
 
     resp4, _ = zmq_single_request("environment_open")
     assert resp4["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     status = get_queue_state()
     assert status["re_state"] == "idle"
@@ -3636,7 +3637,7 @@ def test_zmq_api_re_pause_1(re_manager, pause_deferred, kill_manager, pause_befo
     # The queue contains only a single instruction (stop the queue).
     resp2, _ = zmq_single_request("environment_open")
     assert resp2["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     _check_status(1, 0, "idle", "idle", "idle", False)
 
@@ -3713,7 +3714,7 @@ def test_zmq_api_re_pause_2(re_manager, n_plans, kill_manager, pause_before_kill
     # The queue contains only a single instruction (stop the queue).
     resp2, _ = zmq_single_request("environment_open")
     assert resp2["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     _check_status(n_plans, 0, "idle", "idle", False)
 
@@ -3833,7 +3834,7 @@ def test_re_runs_1(re_manager_pc_copy, tmp_path, test_with_manager_restart):  # 
     # Open the environment
     resp3, _ = zmq_single_request("environment_open")
     assert resp3["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # Get initial value of (empty) run list to capture changes in the run list
     resp, _ = zmq_single_request("status")
@@ -3983,7 +3984,7 @@ def test_manager_kill_1(re_manager_pc_copy):  # noqa: F811
     # Open the environment
     resp1, _ = zmq_single_request("environment_open")
     assert resp1["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     # Add 'count' plan
     params2 = {"item": _plan1, "user": _user, "user_group": _user_group}
@@ -4092,7 +4093,7 @@ def test_zmq_api_queue_execution_1(re_manager):  # noqa: F811
     # The queue contains only a single instruction (stop the queue).
     resp2, _ = zmq_single_request("environment_open")
     assert resp2["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     resp2a, _ = zmq_single_request("status")
     assert resp2a["items_in_queue"] == 4
@@ -4194,7 +4195,7 @@ def test_zmq_api_queue_execution_2(re_manager):  # noqa: F811
     # The queue contains only a single instruction (stop the queue).
     resp2, _ = zmq_single_request("environment_open")
     assert resp2["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     resp2a, _ = zmq_single_request("status")
     assert resp2a["items_in_queue"] == 2
@@ -4285,7 +4286,7 @@ def test_zmq_api_queue_execution_3(monkeypatch, re_manager_cmd, test_mode):  # n
     # The queue contains only a single instruction (stop the queue).
     resp2, _ = zmq_secure_request("environment_open")
     assert resp2["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     resp2a, _ = zmq_secure_request("status")
     assert resp2a["items_in_queue"] == 2
@@ -4342,7 +4343,7 @@ def test_zmq_api_queue_execution_4(re_manager, stop_queue, pause_before_kill):  
     # The queue contains only a single instruction (stop the queue).
     resp2, _ = zmq_single_request("environment_open")
     assert resp2["success"] is True
-    assert wait_for_condition(time=10, condition=condition_environment_created)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
     _check_status(2, 0, "idle", "idle", False)
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -1438,7 +1438,7 @@ def test_zmq_api_script_upload_1(re_manager, run_in_background):  # noqa: F811
     status, _ = zmq_single_request("status")
     assert status["worker_background_tasks"] == (1 if run_in_background else 0)
 
-    resp3, _ = zmq_single_request("task_result_get", params={"task_uid": task_uid})
+    resp3, _ = zmq_single_request("task_result", params={"task_uid": task_uid})
     assert resp3["success"] is True
     assert resp3["msg"] == ""
     assert resp3["task_uid"] == task_uid
@@ -1463,7 +1463,7 @@ def test_zmq_api_script_upload_1(re_manager, run_in_background):  # noqa: F811
     assert status["items_in_history"] == 0
     assert status["worker_background_tasks"] == 0
 
-    resp4, _ = zmq_single_request("task_result_get", params={"task_uid": task_uid})
+    resp4, _ = zmq_single_request("task_result", params={"task_uid": task_uid})
     assert resp4["success"] is True
     assert resp4["msg"] == ""
     assert resp4["task_uid"] == task_uid
@@ -2025,7 +2025,7 @@ def test_zmq_api_function_execute_1(re_manager, run_in_background, wait_for_idle
         #   manager state to switch to idle. This only makes sense when function is
         #   executed on the foreground.
         assert wait_for_condition(time=10, condition=condition_manager_idle)
-        resp2, _ = zmq_single_request("task_result_get", params={"task_uid": task_uid})
+        resp2, _ = zmq_single_request("task_result", params={"task_uid": task_uid})
         assert resp2["success"] is True, pprint.pformat(resp2)
         assert resp2["result"]["success"] is True, pprint.pformat(resp2["result"])
     else:

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -3283,7 +3283,7 @@ def test_permissions_reload_2(re_manager_pc_copy, reload_permissions_from_disk):
 
     # Now create a new list of user permissions, which may allow/disallow the 'count' plan
     permissions_text = permissions_not_allow_count
-    permissions_dict = yaml.load(permissions_text)
+    permissions_dict = yaml.load(permissions_text, Loader=yaml.FullLoader)
     with open(os.path.join(pc_path, "user_group_permissions.yaml"), "w") as f:
         f.writelines(permissions_text)
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -3463,6 +3463,24 @@ def test_permissions_set_get_2(re_manager):  # noqa: F811
     assert devices_allowed_2 == devices_allowed_1
 
 
+# fmt: off
+@pytest.mark.parametrize("params, err_msg", [
+    ({"unsupported_param": 10}, "API request contains unsupported parameters: 'unsupported_param'"),
+    ({}, "Parameter 'user_group_permissions' is missing"),
+    # Following are cases of failing schema validations of permissions
+    ({"user_group_permissions": {}}, "'user_groups' is a required property"),
+    ({"user_group_permissions": {"user_groups": {}}}, "Missing required user group: 'root'"),
+])
+# fmt: on
+def test_permissions_set_get_3_fail(re_manager, params, err_msg):  # noqa: F811
+    """
+    Tests for ``permissions_set`` 0MQ API: failing cases
+    """
+    resp1, _ = zmq_single_request("permissions_set", params=params)
+    assert resp1["success"] is False, pprint.pformat(resp1)
+    assert err_msg in resp1["msg"], resp1["msg"]
+
+
 # =======================================================================================
 #                              Method `environment_destroy`
 

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -372,6 +372,9 @@ periodically requests and displays the status of Queue Server.
     qserver permissions reload       # Reload user permissions and generate lists of allowed plans and devices.
     qserver permissions reload lists # Same, but reload lists of existing plans and devices from disk.
 
+    qserver permissions set <path-to-file>  # Set user group permissions (from .yaml file)
+    qserver permissions get                 # Get current user group permissions
+
     qserver queue add plan '<plan-params>'                 # Add plan to the back of the queue
     qserver queue add instruction <instruction>            # Add instruction to the back of the queue
     qserver queue add plan front '<plan-params>'           # Add plan to the front of the queue

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -227,6 +227,15 @@ Other Configuration Parameters
                         and devices (--existing-plans-and-devices) and user group permissions
                         (--user-group-permissions) must be explicitly specified if this option
                         is used.
+      --user-group-permissions-reload {NEVER,ON_REQUEST,ON_STARTUP}
+                        Select when user group permissions are reloaded from disk. Options:
+                        'NEVER' - RE Manager never attempts to load permissions from disk
+                        file. If permissions fail to load from Redis, they are loaded from
+                        disk at the first startup of RE Manager or on request. 'ON_REQUEST' -
+                        permissions are loaded from disk file when requested by
+                        'permission_reload' API call. 'ON_STARTUP' - permissions are loaded
+                        from disk each time RE Manager is started or when 'permission_reload'
+                        API request is received (default: ON_STARTUP)
       --existing-plans-devices EXISTING_PLANS_AND_DEVICES_PATH
                         Path to file that contains the list of existing plans and devices. The
                         path may be a relative path to the profile collection directory. If

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -448,7 +448,7 @@ periodically requests and displays the status of Queue Server.
     qserver script upload <path-to-file> background   # ... in the background
     qserver script upload <path-to-file> update-re    # ... allow 'RE' and 'db' to be updated
 
-    qserver task load result <task-uid>  # Load status or result of a task with the given UID
+    qserver task result <task-uid>  # Load status or result of a task with the given UID
 
     qserver manager stop           # Safely exit RE Manager application
     qserver manager stop safe on   # Safely exit RE Manager application

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -227,15 +227,6 @@ Other Configuration Parameters
                         and devices (--existing-plans-and-devices) and user group permissions
                         (--user-group-permissions) must be explicitly specified if this option
                         is used.
-      --user-group-permissions-reload {NEVER,ON_REQUEST,ON_STARTUP}
-                        Select when user group permissions are reloaded from disk. Options:
-                        'NEVER' - RE Manager never attempts to load permissions from disk
-                        file. If permissions fail to load from Redis, they are loaded from
-                        disk at the first startup of RE Manager or on request. 'ON_REQUEST' -
-                        permissions are loaded from disk file when requested by
-                        'permission_reload' API call. 'ON_STARTUP' - permissions are loaded
-                        from disk each time RE Manager is started or when 'permission_reload'
-                        API request is received (default: ON_STARTUP)
       --existing-plans-devices EXISTING_PLANS_AND_DEVICES_PATH
                         Path to file that contains the list of existing plans and devices. The
                         path may be a relative path to the profile collection directory. If
@@ -252,6 +243,15 @@ Other Configuration Parameters
                         users. The path may be a relative path to the profile collection
                         directory. If the path is a directory, then the default file name
                         'user_group_permissions.yaml' is used.
+      --user-group-permissions-reload {NEVER,ON_REQUEST,ON_STARTUP}
+                        Select when user group permissions are reloaded from disk. Options:
+                        'NEVER' - RE Manager never attempts to load permissions from disk
+                        file. If permissions fail to load from Redis, they are loaded from
+                        disk at the first startup of RE Manager or on request. 'ON_REQUEST' -
+                        permissions are loaded from disk file when requested by
+                        'permission_reload' API call. 'ON_STARTUP' - permissions are loaded
+                        from disk each time RE Manager is started or when 'permission_reload'
+                        API request is received (default: ON_STARTUP)
       --redis-addr REDIS_ADDR
                         The address of Redis server, e.g. 'localhost', '127.0.0.1',
                         'localhost:6379' (default: localhost).

--- a/docs/source/features_and_config.rst
+++ b/docs/source/features_and_config.rst
@@ -4,6 +4,59 @@ Features and Configuration
 
 Documentation is coming soon ...
 
+Managing User Group Permissions
+-------------------------------
+
+Direct access via API calls to plans, devices and functions can be restricted by defining permissions
+for different groups of users. The permissions are represented in the form of dictionary and saved in
+a YAML file (default file name is ``user_group_permissions.yaml``) located in the same directory as
+the startup code. Alternative path to the YAML file may be specified using ``--user-group-permissions``
+parameter of ``start-re-manager``. The YAML file contains lists of conditions (based on regular expressions)
+that are applied to the names of plans and devices defined in startup scripts to generate lists of
+allowed plans and devices for each user group. Plans from the allowed list could be submitted to
+the queue using API calls such as :ref:`method_queue_item_add` and the names of allowed devices could
+be passed as plan parameters and then automatically converted to actual device objects before plans
+are executed. Additional filters could be defined for each user group that allow/forbid execution of
+functions (see :ref:`method_function_execute`).
+
+TODO: GUIDE/TUTORIAL FOR WRITING ``user_group_permissions.yaml``.
+
+Simple workflows could be implemented using static permissions defined in a YAML file and loaded
+at startup of RE Manager. If the YAML file is changed while RE Manager is running, the permissions
+may be reloaded by stopping and restarting RE Manager or sending :ref:`method_permissions_reload` API
+request. Note, that changes in permissions affect the plans that are already in the queue, i.e. some
+plans may fail to start if the respective user permissions are removed. The dictionary with current
+user group permissions can be downloaded by client applications at any time using
+:ref:`method_permissions_get` API.
+
+More complex workflows may require dynamically changing user group permissions. Dictionary with permissions
+can be uploaded by client applications using :ref:`method_permissions_set` API. (Application developers
+should be careful about exposing this API directly to facility users unless users are expected to be able
+to change permissions at will. The API is primarily intended for use by a secure server that is managing
+user data and permissions.) The way RE Manager is handling updated permissions is defined by
+``--user-group-permissions-reload`` parameter of ``start-re-manager``, which may take the following values:
+
+- ``ON_STARTUP`` (default): RE Manager is always loading permissions from disk file at startup.
+  Permissions from disk can be reloaded at any time using :ref:`method_permissions_reload`
+  API. Permissions can be uploaded by the client application using :ref:`method_permissions_set` API.
+  RE manager will use the updated permissions until the end of the session. RE Manager is using
+  the uploaded permissions until the end of the session (until the manager is stopped and started again).
+
+- ``ON_REQUEST``: RE Manager attempts to load internally stored (in Redis) permissions at startup.
+  If no permissions are found (e.g. when starting newly installed Queue Server), RE Manager loads permissions
+  from the disk file and saves the permissions internally so that they could be loaded at the next startup.
+  Permissions can be reloaded from disk at any time by :ref:`method_permissions_reload` API
+  or uploaded using :ref:`method_permissions_set` API. Each time permissions are changed, they are
+  saved internally, so that they could be loaded on the next startup.
+
+- ``NEVER``: RE manager behaves as if it was called with ``ON_REQUEST`` option except that
+  :ref:`method_permissions_reload` API can not be used to reload permissions from disk (API call fails).
+  Permissions are still loaded from disk at startup if no internally stored permissions are found.
+  This option is the most appropriate for workflows, where permissions are managed externally and
+  uploaded to RE Manager when changed. In this case the disk file may contain some default, simple
+  and very restrictive set of permissions used for initialization during the first startup of RE Manager.
+
+
 Remote Monitoring of Console Output
 -----------------------------------
 

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -122,7 +122,7 @@ Run tasks in RE Worker namespace:
 
 - :ref:`method_script_upload`
 - :ref:`method_function_execute`
-- :ref:`method_task_result_get`
+- :ref:`method_task_result`
 
 Stopping RE Manager (mostly used in testing):
 
@@ -192,7 +192,7 @@ Returns       **msg**: *str*
               **task_results_uid**: *str*
                  UID of the dictionary of task results. UID is updated each time results of a new
                  completed tasks are added to the dictionary. Check the status of the pending tasks
-                 (see *task_result_get* API) once UID is changed.
+                 (see *task_result* API) once UID is changed.
 
               **plans_allowed_uid**: *str*
                  UID for the list of allowed plans. UID is updated each time the contents of
@@ -1339,7 +1339,7 @@ Description   Upload and execute script in RE Worker namespace. The script may a
               objects defined in the namespace, including plans and devices. Dynamic modification
               of the worker namespace may be used to implement more flexible workflows. The API call
               updates the lists of existing and allowed plans and devices if necessary. Changes in
-              the lists will be indicated by changed list UIDs. Use *'task_result_get'* API to check
+              the lists will be indicated by changed list UIDs. Use *'task_result'* API to check
               if the script was loaded correctly. Note, that if the task fails, the script is
               still executed to the point where the exception is raised, changing the environment.
 ------------  -----------------------------------------------------------------------------------------
@@ -1371,10 +1371,10 @@ Returns       **success**: *boolean*
 
               **task_uid**: *str* or *None*
                   Task UID can be used to check status of the task and download results once the task
-                  is completed (see *task_result_get* API).
+                  is completed (see *task_result* API).
 ------------  -----------------------------------------------------------------------------------------
 Execution     The method initiates the operation. Monitor *task_results_uid* status field and call
-              *task_result_get* API to check for success.
+              *task_result* API to check for success.
 ============  =========================================================================================
 
 
@@ -1397,7 +1397,7 @@ Description   Start execution of a function in RE Worker namespace. The function
 
               The method allows to pass parameters (*args* and *kwargs*) to the function. Once the task
               is completed, the results of the function execution, including the return value, can be
-              loaded using *task_result_get* method. If the task fails, the return value is a string
+              loaded using *task_result* method. If the task fails, the return value is a string
               with full traceback of the raised exception. The data types of parameters and return
               values must be JSON serializable. The task fails if the return value can not be serialized.
 
@@ -1405,7 +1405,7 @@ Description   Start execution of a function in RE Worker namespace. The function
               (*success=True*), the server starts the task, which attempts to execute the function
               with given name and parameters. The function may still fail start (e.g. if the user is
               permitted to execute function with the given name, but the function is not defined
-              in the namespace). Use *'task_result_get'* method with the returned *task_uid* to
+              in the namespace). Use *'task_result'* method with the returned *task_uid* to
               check the status of the taks and load the result upon completion.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **item**: *dict*
@@ -1440,20 +1440,20 @@ Returns       **success**: *boolean*
 
               **task_uid**: *str* or *None*
                   Task UID can be used to check status of the task and download results once the task
-                  is completed (see *task_result_get* API). *None* is returned if the request fails.
+                  is completed (see *task_result* API). *None* is returned if the request fails.
 ------------  -----------------------------------------------------------------------------------------
 Execution     The method initiates the operation. Monitor *task_results_uid* status field and call
-              *task_result_get* API to check for success.
+              *task_result* API to check for success.
 ============  =========================================================================================
 
 
-.. _method_task_result_get:
+.. _method_task_result:
 
-**'task_result_get'**
-^^^^^^^^^^^^^^^^^^^^^
+**'task_result'**
+^^^^^^^^^^^^^^^^^
 
 ============  =========================================================================================
-Method        **'task_result_get'**
+Method        **'task_result'**
 ------------  -----------------------------------------------------------------------------------------
 Description   Get the status and results of task execution. The completed tasks are stored at
               the server at least for the period determined by retention time (currently 120 seconds

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -422,7 +422,7 @@ Description   Reload user group permissions from the default location or the loc
 Parameters    **reload_plans_devices**: *boolean* (optional)
                   reload the lists of existing plans and devices from disk if *True*, otherwise
                   use current lists stored in memory. Default: *False*.
-              **reload_permissions**: *boolean (optional)
+              **reload_permissions**: *boolean* (optional)
                   reload user group permissions from disk if *True*, otherwise use current permissions.
                   Default: *True*.
 ------------  -----------------------------------------------------------------------------------------

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -422,6 +422,9 @@ Description   Reload user group permissions from the default location or the loc
 Parameters    **reload_plans_devices**: *boolean* (optional)
                   reload the lists of existing plans and devices from disk if *True*, otherwise
                   use current lists stored in memory. Default: *False*.
+              **reload_permissions**: *boolean (optional)
+                  reload user group permissions from disk if *True*, otherwise use current permissions.
+                  Default: *True*.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -75,6 +75,8 @@ Existing and allowed plans and devices:
 - :ref:`method_plans_existing`
 - :ref:`method_devices_existing`
 - :ref:`method_permissions_reload`
+- :ref:`method_permissions_get`
+- :ref:`method_permissions_set`
 
 History of executed plans:
 
@@ -425,6 +427,58 @@ Parameters    **reload_plans_devices**: *boolean* (optional)
               **reload_permissions**: *boolean* (optional)
                   reload user group permissions from disk if *True*, otherwise use current permissions.
                   Default: *True*.
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
+============  =========================================================================================
+
+
+.. _method_permissions_get:
+
+**'permissions_get'**
+^^^^^^^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'permissions_get'**
+------------  -----------------------------------------------------------------------------------------
+Description   Download the dictionary of user group permissions currently used by RE Manager.
+------------  -----------------------------------------------------------------------------------------
+Parameters    ---
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+
+              **user_group_permissions**: *dict*
+                  dictionary containing user group permissions.
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
+============  =========================================================================================
+
+
+.. _method_permissions_set:
+
+**'permissions_set'**
+^^^^^^^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'permissions_set'**
+------------  -----------------------------------------------------------------------------------------
+Description   Uploads the dictionary of user group permissions. If the uploaded dictionary contains
+              a valid set of permissions different from currently used one, the new permissions
+              are set as current and the updated lists of allowed plans and devices are generated.
+              The method does nothing if the uploaded permissions are identical to currently used
+              permissions. The API request fails if the uploaded dictionary does not pass validation.
+------------  -----------------------------------------------------------------------------------------
+Parameters    **user_group_permissions**: *dict*
+                  dictionary, which contains user group permissions.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implementation for new 0MQ API: `permissions_set` (upload dictionary with user group permissions) and `permissions_get` (download dictionary with user group permissions). Additional `reload_permissions` parameter for `permissions_reload` API, which controls if permissions are to be reloaded from disk. Improved management of user group permissions: the latest version of permissions is always stored in Redis, new `--user-group-permissions-reload` parameter of `start-re-manager` controls when permissions could be reloaded (options are `NEVER`, `ON_REQUEST` and `ON_STARTUP`).

The implemented features are not expected to change the default behavior of RE Manager or break any code using 0MQ API.

## Motivation and Context
The new features are implemented as part of development of new features to support more complex workflows.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added
- New 0MQ API: `permissions_set` and `permissions_get`.
- CLI support for the new API: `qserver permissions set <fln.yaml>` and `qserver permissions get`
- New `reload_permissions` parameter of `permissions_reload` API.
- New parameter of `start-re-manager`: `--user-group-permissions-reload`. The parameter accepts values `NEVER`, `ON_REQUEST` and `ON_STARTUP`
- A section in documentation on management of user group permissions.
- `task_result_get` was renamed again to `task_result`, which seems better at this point. IN THE RELEASE NOTES JUST USE THE RIGHT API NAME.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Thorough unit tests are implemented for each new feature.

<!--
## Screenshots (if appropriate):
-->
