### PR TITLE
Suport for subdevice names in `user_group_permissions.yaml`

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -1226,11 +1226,6 @@ def _build_device_name_list(*, components, uses_re, device_type, existing_device
     condition = _get_device_type_condition(device_type)
 
     if uses_re:
-        # Always Set 'include_devices = True' for the last component
-        components = copy.copy(components)
-        _ = components[-1]
-        components[-1] = (_[0], True, _[2], _[3])
-
         max_depth, device_list = len(components), []
 
         def process_devices_full_name(devices, base_name, name_suffix, pattern, depth, depth_stop):
@@ -1359,13 +1354,7 @@ def _filter_device_tree(item_dict, allow_patterns, disallow_patterns):
         components, uses_re, device_type = _split_name_pattern(pattern)
 
         if uses_re:
-            # Always Set 'include_devices = True' for the last component
-            components = copy.copy(components)
-            _ = components[-1]
-            components[-1] = (_[0], True, _[2], _[3])
-
             condition = _get_device_type_condition(device_type)
-
             max_depth = len(components)
 
             def apply_filter_full_name(devices, name_suffix, pattern, depth, depth_stop, *, exclude):
@@ -1514,17 +1503,12 @@ def _build_plan_name_list(*, components, uses_re, device_type, existing_plans):
     pattern, include_devices, is_full_re, remaining_depth = components[0]
 
     if remaining_depth is not None:
-        raise ValueError(f"Depth specification can not be part of the element describing a plan: {pattern!r}")
+        raise ValueError(f"Depth specification can not be part of the name pattern for a plan: {pattern!r}")
 
     if device_type:
-        raise ValueError(f"Device type can not be included in the plan description: {(device_type + ':')!r}")
-
-    # '?' and '+' should not be used in plan descriptions, since they have no meaning
-    #   and would contaminate the code
-    if include_devices:
-        raise ValueError(f"Plus sign (+) can not be used in a pattern for a plan name: {('+'+pattern)!r}")
-    if is_full_re:
-        raise ValueError(f"Question mark (?) can not be used in a pattern for a plan name: {('?'+pattern)!r}")
+        raise ValueError(
+            f"Device type can not be included in the name pattern for a plan: {(device_type + ':')!r}"
+        )
 
     plan_list = []
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -607,7 +607,6 @@ def _get_nspace_object(object_name, *, objects_in_nspace):
 
     if object_found:
         for c in components[1:]:
-            print(f"c={c} {hasattr(device, 'component_names')}")
             if hasattr(device, "component_names") and (c in device.component_names):
                 # The defice MUST have the attribute 'c', but still process the case when
                 #   there is a bug and the device doesn't have the attribute

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -1048,16 +1048,16 @@ def _split_list_element_definition(element_def):
         components = list(zip(components, components_include, components_full_re, components_depth))
 
     else:
+        if not re.search(r"^[_a-zA-Z][_a-zA-Z0-9\.]*[_a-zA-Z0-9]$", element_def):
+            raise ValueError(
+                f"Element name pattern {element_def!r} contains invalid characters. "
+                "The pattern could be a valid regular expression, but it is not labeled with ':' (e.g. ':^det$')"
+            )
         components = element_def.split(".")
         for c in components:
             if not c:
                 raise ValueError(
                     f"Plan, device or subdevice name in the description {element_def!r} is an empty string"
-                )
-            if not re.search("^[_a-zA-Z][_a-zA-Z0-9]*$", c):
-                raise ValueError(
-                    f"Plan, device or subdevice name {c!r} in the description "
-                    f"{element_def!r} contains invalid characters"
                 )
         components_include = [False] * len(components)
         components_full_re = [False] * len(components)
@@ -1118,6 +1118,52 @@ def _is_object_name_in_list(object_name, *, allowed_objects):
     return object_in_list
 
 
+def _get_device_type_condition(device_type):
+    """
+    Generator function that returns reference to a function that verifies if device
+    satisfy condition for the selecte device type.
+
+    Parameters
+    ----------
+    device_type: str
+        Deivce type
+
+    Returns
+    -------
+    callable
+    """
+    # The condition is applied to the device to decide if it is included in the list
+    if device_type == "":
+
+        def condition(_btype):
+            return True
+
+    elif device_type == "__READABLE__":
+
+        def condition(_btype):
+            return bool(_btype["is_readable"])
+
+    elif device_type == "__DETECTOR__":
+
+        def condition(_btype):
+            return _btype["is_readable"] and not _btype["is_movable"]
+
+    elif device_type == "__MOTOR__":
+
+        def condition(_btype):
+            return _btype["is_readable"] and _btype["is_movable"]
+
+    elif device_type == "__FLYABLE__":
+
+        def condition(_btype):
+            return bool(_btype["is_flyable"])
+
+    else:
+        raise ValueError(f"Unsupported device type: {device_type!r}. Supported types: {_supported_device_types}")
+
+    return condition
+
+
 def _build_device_name_list(*, components, uses_re, device_type, existing_devices):
     """
     Generate list of device names (including subdevices) based on one element of a device
@@ -1165,34 +1211,8 @@ def _build_device_name_list(*, components, uses_re, device_type, existing_device
     list(str)
         List of device names.
     """
-    # The condition is applied to the device to decide if it is included in the list
-    if device_type == "":
 
-        def condition(_btype):
-            return True
-
-    elif device_type == "__READABLE__":
-
-        def condition(_btype):
-            return bool(_btype["is_readable"])
-
-    elif device_type == "__DETECTOR__":
-
-        def condition(_btype):
-            return _btype["is_readable"] and not _btype["is_movable"]
-
-    elif device_type == "__MOTOR__":
-
-        def condition(_btype):
-            return _btype["is_readable"] and _btype["is_movable"]
-
-    elif device_type == "__FLYABLE__":
-
-        def condition(_btype):
-            return bool(_btype["is_flyable"])
-
-    else:
-        raise ValueError(f"Unsupported device type: {device_type!r}. Supported types: {_supported_device_types}")
+    condition = _get_device_type_condition(device_type)
 
     if uses_re:
         # Always Set 'include_devices = True' for the last component
@@ -1207,7 +1227,11 @@ def _build_device_name_list(*, components, uses_re, device_type, existing_device
                 for dname, dparams in devices.items():
                     name_suffix_new = dname if not name_suffix else (name_suffix + "." + dname)
                     full_name = name_suffix_new if not base_name else (base_name + "." + name_suffix_new)
-                    if re.search(pattern, full_name) and not dparams.get("excluded", False) and condition(dparams):
+                    if (
+                        re.search(pattern, name_suffix_new)
+                        and not dparams.get("excluded", False)
+                        and condition(dparams)
+                    ):
                         device_list.append(full_name)
                     if "components" in dparams:
                         process_devices_full_name(
@@ -1251,6 +1275,197 @@ def _build_device_name_list(*, components, uses_re, device_type, existing_device
         device_list = [device_name]
 
     return device_list
+
+
+def _filter_device_tree(item_dict, allow_patterns, disallow_patterns):
+    """
+    Filter device tree based on sets of patterns for 'allowed' and 'disallowed'
+    devices.
+
+    Parameters
+    ----------
+    item_dict: dict
+        Dictionary that represents a tree of existing devices. Some of the devices
+        may be labeled as excluded: those devices will remain excluded and could be
+        removed from the tree.
+    allowed_patterns: list(str)
+        List of patterns from ``allowed_devices`` section of user group permissions.
+        If the parameter value is ``[]`` or the first list element is ``None``,
+        then it is assumed that all the devices are allowed.
+    disallow_patterns: list(str)
+        List of patterns from ``forbidden_devices`` section of user group permissions.
+        If the parameter value is ``[]`` or the first list element is ``None``,
+        then it is assumed that no devices are forbidden.
+
+    Returns
+    -------
+    allowed_devices: dict
+        Dictionary that represents a tree of devices after filtering. Excluded
+        devices could be labeled as excluded (parameter ``"exclude": True``).
+        Branches that consist of excluded parameters are removed from the tree.
+
+    Raises
+    ------
+        May raise exceptions if provided patterns are invalid and/or filtering
+        can not be completed.
+    """
+
+    # Add temporary flag ('excl': False) to each device
+    def add_excl_flag(devices_dict, exclude_all):
+        """
+        Add temporary ``excl`` parameter to each device and subdevice.
+
+        Parameters
+        ----------
+        devices_dict: dict
+            Dictionary that contains the device tree
+        exclude_all: boolean
+            The value for the ``excl`` parameter.
+        """
+        for _, dparam in devices_dict.items():
+            dparam["excl"] = exclude_all
+            if "components" in dparam:
+                add_excl_flag(dparam["components"], exclude_all)
+
+    def apply_pattern_filter(*, pattern, devices_dict, exclude):
+        """
+        Apply a pattern to the tree of deivce. Pattern can be an explicitly state name
+        such as ``"det"`` or ``"det.val"`` or regular expression, such as ``":^det:val$"``.
+
+        Parameters
+        ----------
+        pattern_item: str
+            Device/subdevice name or regular expression to be applied to the device names.
+        existing_devices: dict
+            Dictionary that represents a tree of devices/subdevices.
+        exclude: boolean
+            True - exclude devices, False - include devices.
+
+        Returns
+        -------
+        None
+        """
+        components, uses_re, device_type = _split_list_element_definition(pattern)
+
+        if uses_re:
+            # Always Set 'include_devices = True' for the last component
+            components = copy.copy(components)
+            _ = components[-1]
+            components[-1] = (_[0], True, _[2], _[3])
+
+            condition = _get_device_type_condition(device_type)
+
+            max_depth = len(components)
+
+            def apply_filter_full_name(devices, name_suffix, pattern, depth, depth_stop, *, exclude):
+                if (depth_stop is None) or (depth < depth_stop):
+                    for dname, dparams in devices.items():
+                        name_suffix_new = dname if not name_suffix else (name_suffix + "." + dname)
+                        if re.search(pattern, name_suffix_new) and condition(dparams):
+                            dparams["excl"] = exclude
+                        if "components" in dparams:
+                            apply_filter_full_name(
+                                devices=dparams["components"],
+                                name_suffix=name_suffix_new,
+                                pattern=pattern,
+                                depth=depth + 1,
+                                depth_stop=depth_stop,
+                                exclude=exclude,
+                            )
+
+            def apply_filter(devices, depth, *, exclude):
+                if (depth < max_depth) and devices:
+                    pattern, include_devices, is_full_re, remaining_depth = components[depth]
+                    if is_full_re:
+                        apply_filter_full_name(
+                            devices=devices,
+                            name_suffix="",
+                            pattern=pattern,
+                            depth=depth,
+                            depth_stop=depth + remaining_depth if remaining_depth else None,
+                            exclude=exclude,
+                        )
+                    else:
+                        for dname, dparams in devices.items():
+                            if re.search(pattern, dname):
+                                if include_devices and condition(dparams):
+                                    dparams["excl"] = bool(exclude)
+                                if "components" in dparams:
+                                    apply_filter(devices=dparams["components"], depth=depth + 1, exclude=exclude)
+
+            apply_filter(devices=devices_dict, depth=0, exclude=exclude)
+
+        else:
+            # 'components' represent an explicitly stated name
+            root = allowed_devices
+            for n, c in enumerate([_[0] for _ in components]):
+                if c in root:
+                    if n == len(components) - 1:
+                        root[c]["excl"] = exclude
+                    if "components" in root[c]:
+                        root = root[c]["components"]
+                    else:
+                        break
+                else:
+                    break
+
+    def trim_device_dict(devices_dict):
+        """
+        Remove ``excl`` parameter from each device. Remove branches that contain only
+        the devices that were excluded. Add ``"excluded": True`` to the devices that
+        were excluded but can not be removed from the tree (``"excl": True``).
+
+        Parameters
+        ----------
+        devices_dict: dict
+            Dictionary representing the tree of devices.
+        """
+        contains_devices = False
+        for dname in list(devices_dict.keys()):
+            dparam = devices_dict[dname]
+
+            exclude_this_device = True
+
+            if "components" in dparam:
+                if trim_device_dict(dparam["components"]):
+                    exclude_this_device = False
+                else:
+                    del dparam["components"]
+
+            if dparam.get("excluded", False) or (dparam["excl"] is True):
+                dparam["excluded"] = True
+            else:
+                exclude_this_device = False
+
+            if exclude_this_device:
+                # Device is excluded and contains no subdevices that were not excluded.
+                del devices_dict[dname]
+            else:
+                del dparam["excl"]
+                contains_devices = True
+
+        return contains_devices
+
+    allowed_devices = copy.deepcopy(item_dict)
+
+    # Process the case when all devices/subdevices are allowed
+    allow_all = len(allow_patterns) and (allow_patterns[0] is None)
+
+    add_excl_flag(allowed_devices, exclude_all=not allow_all)
+
+    # Process 'allow_patterns'
+    if not allow_all:
+        for pattern in allow_patterns:
+            apply_pattern_filter(pattern=pattern, devices_dict=allowed_devices, exclude=False)
+
+    # Process 'disallow_patterns'
+    if len(disallow_patterns) and (disallow_patterns[0] is not None):
+        for pattern in disallow_patterns:
+            apply_pattern_filter(pattern=pattern, devices_dict=allowed_devices, exclude=True)
+
+    trim_device_dict(allowed_devices)
+
+    return allowed_devices
 
 
 def _build_plan_name_list(*, components, uses_re, device_type, existing_plans):
@@ -3181,11 +3396,12 @@ def load_user_group_permissions(path_to_file=None):
     return user_group_permissions
 
 
-def _check_if_item_allowed(item_name, allow_patterns, disallow_patterns):
+def _check_if_plan_or_func_allowed(item_name, allow_patterns, disallow_patterns):
     """
     Check if an item with ``item_name`` is allowed based on ``allow_patterns``
-    and ``disallow_patterns``. If the item name represents a subdevice, then
-    patterns will be applied only to the base name.
+    and ``disallow_patterns``. Patterns may be explicitly listed names and regular expressions.
+    ``None`` may appear only as a first element of the pattern list.
+    The function should be used only with function and plan names.
 
     Parameters
     ----------
@@ -3206,24 +3422,50 @@ def _check_if_item_allowed(item_name, allow_patterns, disallow_patterns):
     """
     item_is_allowed = False
 
-    # Separate the base name (for devices). Patterns are applied only to the base name,
-    #   e.g. if the device name is 'dev1.val', then the pattern should be applied only to 'dev1'
-    item_name = item_name.split(".")[0]
+    def prepare_pattern(pattern):
+        if not isinstance(pattern, str):
+            raise TypeError("Pattern is not a string: {pattern!r} ({allow_patterns})")
+        # Prepare patterns
+        components, uses_re, _ = _split_list_element_definition(pattern)
+        if len(components) != 1:
+            raise ValueError("Name pattern for functions and plans must contain one component: {components}")
+        component = components[0][0]
+        if not uses_re:
+            if not re.search("[_a-zA-Z][_0-9a-zA-Z]*", component):
+                assert ValueError(
+                    f"Plan or function name pattern {component!r} contains invalid characters. "
+                    "The pattern could be a valid regular expression, "
+                    "but it is not labeled with ':' (e.g. ':^count$')"
+                )
+        return component, uses_re
+
     if allow_patterns:
         if allow_patterns[0] is None:
             item_is_allowed = True
         else:
             for pattern in allow_patterns:
-                if re.search(pattern, item_name):
-                    item_is_allowed = True
-                    break
+                component, uses_re = prepare_pattern(pattern)
+                if uses_re:
+                    if re.search(component, item_name):
+                        item_is_allowed = True
+                        break
+                else:
+                    if item_name == component:
+                        item_is_allowed = True
+                        break
 
     if item_is_allowed:
         if disallow_patterns and (disallow_patterns[0] is not None):
             for pattern in disallow_patterns:
-                if re.search(pattern, item_name):
-                    item_is_allowed = False
-                    break
+                component, uses_re = prepare_pattern(pattern)
+                if uses_re:
+                    if re.search(component, item_name):
+                        item_is_allowed = False
+                        break
+                else:
+                    if item_name == component:
+                        item_is_allowed = False
+                        break
 
     return item_is_allowed
 
@@ -3272,21 +3514,21 @@ def check_if_function_allowed(function_name, *, group_name, user_group_permissio
     group_allow_patterns = user_groups[group_name].get("allowed_functions", [])
     group_disallow_patterns = user_groups[group_name].get("forbidden_functions", [])
 
-    return _check_if_item_allowed(
+    return _check_if_plan_or_func_allowed(
         function_name,
         root_allow_patterns,
         root_disallow_patterns,
-    ) and _check_if_item_allowed(
+    ) and _check_if_plan_or_func_allowed(
         function_name,
         group_allow_patterns,
         group_disallow_patterns,
     )
 
 
-def _select_allowed_items(item_dict, allow_patterns, disallow_patterns):
+def _select_allowed_plans(item_dict, allow_patterns, disallow_patterns):
     """
-    Creates the dictionary of items selected from `item_dict` such that item names
-    satisfy re patterns in `allow_patterns` and not satisfy patterns in `disallow_patterns`.
+    Creates the dictionary of items selected from `item_dict` with names names that
+    satisfy patterns in `allow_patterns` and not satisfy patterns in `disallow_patterns`.
     The function does not modify the dictionary, but creates a new dictionary with
     selected items, where item values are deep copies of the values of the original
     dictionary.
@@ -3310,7 +3552,7 @@ def _select_allowed_items(item_dict, allow_patterns, disallow_patterns):
     """
     items_selected = {}
     for item_name in item_dict:
-        if _check_if_item_allowed(item_name, allow_patterns, disallow_patterns):
+        if _check_if_plan_or_func_allowed(item_name, allow_patterns, disallow_patterns):
             items_selected[item_name] = copy.deepcopy(item_dict[item_name])
 
     return items_selected
@@ -3403,13 +3645,13 @@ def load_allowed_plans_and_devices(
         if "root" in user_groups:
             group_permissions_root = user_group_permissions["user_groups"]["root"]
             if existing_devices:
-                devices_root = _select_allowed_items(
+                devices_root = _filter_device_tree(
                     existing_devices,
                     group_permissions_root.get("allowed_devices", []),
                     group_permissions_root.get("forbidden_devices", []),
                 )
             if existing_plans:
-                plans_root = _select_allowed_items(
+                plans_root = _select_allowed_plans(
                     existing_plans,
                     group_permissions_root.get("allowed_plans", []),
                     group_permissions_root.get("forbidden_plans", []),
@@ -3425,14 +3667,14 @@ def load_allowed_plans_and_devices(
                 group_permissions = user_group_permissions["user_groups"][group]
 
                 if existing_devices:
-                    selected_devices = _select_allowed_items(
+                    selected_devices = _filter_device_tree(
                         devices_root,
                         group_permissions.get("allowed_devices", []),
                         group_permissions.get("forbidden_devices", []),
                     )
 
                 if existing_plans:
-                    selected_plans = _select_allowed_items(
+                    selected_plans = _select_allowed_plans(
                         plans_root,
                         group_permissions.get("allowed_plans", []),
                         group_permissions.get("forbidden_plans", []),

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -3150,28 +3150,30 @@ def test_devices_from_nspace():
 # fmt: off
 @pytest.mark.parametrize("element_def, components, uses_re, device_type", [
     # Device/subdevice names
-    ("det1", [("det1", False, False, None)], False, ""),
-    ("det1 ", [("det1", False, False, None)], False, ""),  # Spaces are removed
-    ("det1.val", [("det1", False, False, None), ("val", False, False, None)], False, ""),
-    ("sim_stage.det1.val", [("sim_stage", False, False, None), ("det1", False, False, None),
-     ("val", False, False, None)], False, ""),
+    ("det1", [("det1", True, False, None)], False, ""),
+    ("det1 ", [("det1", True, False, None)], False, ""),  # Spaces are removed
+    ("det1.val", [("det1", True, False, None), ("val", True, False, None)], False, ""),
+    ("sim_stage.det1.val", [("sim_stage", True, False, None), ("det1", True, False, None),
+     ("val", True, False, None)], False, ""),
     # Regular expressions
-    (":^det", [("^det", False, False, None)], True, ""),
-    (":^det:^val$", [("^det", False, False, None), ("^val$", False, False, None)], True, ""),
-    (":+^det:^val$", [("^det", True, False, None), ("^val$", False, False, None)], True, ""),
-    (":+sim_stage:^det:^val$", [("sim_stage", True, False, None), ("^det", False, False, None),
-     ("^val$", False, False, None)], True, ""),
-    ("__READABLE__:.*", [(".*", False, False, None)], True, "__READABLE__"),
-    ("__FLYABLE__:.*", [(".*", False, False, None)], True, "__FLYABLE__"),
-    ("__DETECTOR__:.*:.*", [(".*", False, False, None), (".*", False, False, None)], True, "__DETECTOR__"),
-    ("__MOTOR__:+.*:.*", [(".*", True, False, None), (".*", False, False, None)], True, "__MOTOR__"),
+    (":^det", [("^det", True, False, None)], True, ""),
+    (":^det:^val$", [("^det", True, False, None), ("^val$", True, False, None)], True, ""),
+    (":+^det:+^val$", [("^det", True, False, None), ("^val$", True, False, None)], True, ""),
+    (":-^det:^val$", [("^det", False, False, None), ("^val$", True, False, None)], True, ""),
+    (":-^det:-^val$", [("^det", False, False, None), ("^val$", True, False, None)], True, ""),
+    (":sim_stage:-^det:^val$", [("sim_stage", True, False, None), ("^det", False, False, None),
+     ("^val$", True, False, None)], True, ""),
+    ("__READABLE__:.*", [(".*", True, False, None)], True, "__READABLE__"),
+    ("__FLYABLE__:.*", [(".*", True, False, None)], True, "__FLYABLE__"),
+    ("__DETECTOR__:-.*:.*", [(".*", False, False, None), (".*", True, False, None)], True, "__DETECTOR__"),
+    ("__MOTOR__:.*:.*", [(".*", True, False, None), (".*", True, False, None)], True, "__MOTOR__"),
     # Full-name regular expressions
-    (":?det1", [("det1", False, True, None)], True, ""),
-    (":?^det1$:depth=5", [("^det1$", False, True, 5)], True, ""),
-    (r":?.*\.^val$", [(r".*\.^val$", False, True, None)], True, ""),
-    (r"__READABLE__:?.*\.^val$", [(r".*\.^val$", False, True, None)], True, "__READABLE__"),
-    (":+^det:?^val$", [("^det", True, False, None), ("^val$", False, True, None)], True, ""),
-    (":+^det:?^val$:depth=1", [("^det", True, False, None), ("^val$", False, True, 1)], True, ""),
+    (":?det1", [("det1", True, True, None)], True, ""),
+    (":?^det1$:depth=5", [("^det1$", True, True, 5)], True, ""),
+    (r":?.*\.^val$", [(r".*\.^val$", True, True, None)], True, ""),
+    (r"__READABLE__:?.*\.^val$", [(r".*\.^val$", True, True, None)], True, "__READABLE__"),
+    (":-^det:?^val$", [("^det", False, False, None), ("^val$", True, True, None)], True, ""),
+    (":^det:?^val$:depth=1", [("^det", True, False, None), ("^val$", True, True, 1)], True, ""),
 ])
 # fmt: on
 def test_split_list_element_definition_1(element_def, components, uses_re, device_type):
@@ -3186,11 +3188,11 @@ def test_split_list_element_definition_1(element_def, components, uses_re, devic
 
 # fmt: off
 @pytest.mark.parametrize("element_def, exception_type, msg", [
-    (10, TypeError, "List item 10 has incorrect type"),
-    ("", ValueError, "List item '' is an empty string"),
-    (":", ValueError, "List item ':' contains empty components"),
-    (":^det:", ValueError, "List item ':^det:' contains empty components"),
-    (":^det::val", ValueError, "List item ':^det::val' contains empty components"),
+    (10, TypeError, "Name pattern 10 has incorrect type"),
+    ("", ValueError, "Name pattern '' is an empty string"),
+    (":", ValueError, "Name pattern ':' contains empty components"),
+    (":^det:", ValueError, "Name pattern ':^det:' contains empty components"),
+    (":^det::val", ValueError, "Name pattern ':^det::val' contains empty components"),
     (":*det:val", ValueError, "':*det:val' contains invalid regular expression '*det'"),
     ("__UNSUPPORTED_TYPE__:^det", ValueError, "Device type '__UNSUPPORTED_TYPE__' is not supported."),
     (":?^det:depth=0", ValueError, "Depth (0) must be positive integer greater or equal to 1"),
@@ -3199,11 +3201,11 @@ def test_split_list_element_definition_1(element_def, components, uses_re, devic
     (":?^det:?^val$", ValueError, "'?^det' can be only followed by the depth specification"),
     (":?^det:^val:^val$", ValueError, "'?^det' must be the last"),
     ("det..val", ValueError, "Plan, device or subdevice name in the description 'det..val' is an empty string"),
-    ("det.", ValueError, "Element name pattern 'det.' contains invalid characters"),
-    (".det", ValueError, "Element name pattern '.det' contains invalid characters"),
-    ("d$et", ValueError, "Element name pattern 'd$et' contains invalid characters"),
-    ("d$et.val", ValueError, "Element name pattern 'd$et.val' contains invalid characters"),
-    ("det.v$al", ValueError, "Element name pattern 'det.v$al' contains invalid characters"),
+    ("det.", ValueError, "Name pattern 'det.' contains invalid characters"),
+    (".det", ValueError, "Name pattern '.det' contains invalid characters"),
+    ("d$et", ValueError, "Name pattern 'd$et' contains invalid characters"),
+    ("d$et.val", ValueError, "Name pattern 'd$et.val' contains invalid characters"),
+    ("det.v$al", ValueError, "Name pattern 'det.v$al' contains invalid characters"),
 ])
 # fmt: on
 def test_split_list_element_definition_2_fail(element_def, exception_type, msg):

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -2255,23 +2255,23 @@ _pf4a_processed = {
         "parameters": {
             "p1": {
                 "annotation": "devices1",
-                "devices": {"devices1": ("some_dev", ":motor$:+motor$:det$")},
+                "devices": {"devices1": ("some_dev", ":-motor$:+motor$:det$")},
             },
             "p2": {
                 "annotation": "devices2",
-                "devices": {"devices2": ("some_dev", "__MOTOR__:motor$:+motor$:det$")},
+                "devices": {"devices2": ("some_dev", "__MOTOR__:-motor$:+motor$:det$")},
             },
             "p3": {
                 "annotation": "devices3",
-                "devices": {"devices3": ("some_dev", "__READABLE__:+motor$:motor$:det$")},
+                "devices": {"devices3": ("some_dev", "__READABLE__:motor$:-motor$:det$")},
             },
             "p4": {
                 "annotation": "devices4",
-                "devices": {"devices4": ("__MOTOR__:motor$:+motor$:det$", "__READABLE__:+motor$:motor$:det$")},
+                "devices": {"devices4": ("__MOTOR__:-motor$:motor$:det$", "__READABLE__:motor$:-motor$:det$")},
             },
             "p5": {
                 "annotation": "devices5",
-                "devices": {"devices5": ("__MOTOR__:motor$:+motor$:det$", "__FLYABLE__:.*")},
+                "devices": {"devices5": ("__MOTOR__:-motor$:motor$:det$", "__FLYABLE__:.*")},
             },
         }
     }
@@ -2690,10 +2690,10 @@ def _pf5h_factory():
     (_pf5b, "name 'Plans1' is not defined'"),
     (_pf5c, "Missing default value for the parameter 'detector' in the plan signature"),
     (_pf5d_factory(), "unsupported type of default value in decorator"),
-    (_pf5e_factory(), r"List item ':\*' contains invalid regular expression '\*'"),
-    (_pf5f_factory(), r"List item ':\*' contains invalid regular expression '\*'"),
-    (_pf5g_factory(), r"Element name pattern '\*dev' contains invalid characters"),
-    (_pf5h_factory(), r"Element name pattern '\*plan' contains invalid characters"),
+    (_pf5e_factory(), r"Name pattern ':\*' contains invalid regular expression '\*'"),
+    (_pf5f_factory(), r"Name pattern ':\*' contains invalid regular expression '\*'"),
+    (_pf5g_factory(), r"Name pattern '\*dev' contains invalid characters"),
+    (_pf5h_factory(), r"Name pattern '\*plan' contains invalid characters"),
 ])
 # fmt: on
 def test_process_plan_5_fail(plan_func, err_msg):
@@ -3305,29 +3305,31 @@ def test_is_object_name_in_list_1(device_name, in_list, success, error_type, msg
     (":.+", ["da0_motor", "da1_det"]),
     (":.*", ["da0_motor", "da1_det"]),
     (":+.*", ["da0_motor", "da1_det"]),
-    (":.+:^db0", ["da0_motor.db0_motor", "da1_det.db0_det"]),
-    (":+.+:^db0", ["da0_motor", "da0_motor.db0_motor", "da1_det", "da1_det.db0_det"]),
-    (":+det$:^db0", ["da1_det", "da1_det.db0_det"]),
-    (":.+:+^db0:^dc", ["da0_motor.db0_motor", "da0_motor.db0_motor.dc0_det", "da0_motor.db0_motor.dc1_det",
+    (":-.*", ["da0_motor", "da1_det"]),  # "-" is ignored
+    (":-.+:^db0", ["da0_motor.db0_motor", "da1_det.db0_det"]),
+    (":.+:^db0", ["da0_motor", "da0_motor.db0_motor", "da1_det", "da1_det.db0_det"]),
+    (":+.+:^db0", ["da0_motor", "da0_motor.db0_motor", "da1_det", "da1_det.db0_det"]),  # "+" is not needed
+    (":det$:^db0", ["da1_det", "da1_det.db0_det"]),
+    (":-.+:^db0:^dc", ["da0_motor.db0_motor", "da0_motor.db0_motor.dc0_det", "da0_motor.db0_motor.dc1_det",
      "da0_motor.db0_motor.dc2_det", "da0_motor.db0_motor.dc3_motor", "da1_det.db0_det"]),
-    ("__MOTOR__:.+:+^db0:^dc", ["da0_motor.db0_motor", "da0_motor.db0_motor.dc3_motor"]),
-    ("__DETECTOR__:.+:+^db0:^dc", ["da0_motor.db0_motor.dc0_det", "da0_motor.db0_motor.dc1_det",
+    ("__MOTOR__:-.+:^db0:^dc", ["da0_motor.db0_motor", "da0_motor.db0_motor.dc3_motor"]),
+    ("__DETECTOR__:-.+:^db0:^dc", ["da0_motor.db0_motor.dc0_det", "da0_motor.db0_motor.dc1_det",
      "da0_motor.db0_motor.dc2_det", "da1_det.db0_det"]),
-    ("__READABLE__:.+:+^(db0)|(db2):^dc", [
+    ("__READABLE__:-.+:^(db0)|(db2):^dc", [
         "da0_motor.db0_motor", "da0_motor.db0_motor.dc0_det", "da0_motor.db0_motor.dc1_det",
         "da0_motor.db0_motor.dc2_det", "da0_motor.db0_motor.dc3_motor", "da1_det.db0_det"]),
-    ("__FLYABLE__:.+:+^(db0)|(db2):^dc", ["da0_motor.db2_flyer"]),
-    ("__FLYABLE__:.+:+^db0:^dc", []),
+    ("__FLYABLE__:-.+:^(db0)|(db2):^dc", ["da0_motor.db2_flyer"]),
+    ("__FLYABLE__:-.+:^db0:^dc", []),
     # Full-name patterns
     (":?motor$", ["da0_motor", "da0_motor.db0_motor", "da0_motor.db0_motor.dc3_motor",
      "da0_motor.db0_motor.dc3_motor.dd1_motor", "da0_motor.db1_det.dc1_motor", "da1_det.db1_motor"]),
     (":?motor$:depth=1", ["da0_motor"]),
     (":?motor$:depth=2", ["da0_motor", "da0_motor.db0_motor", "da1_det.db1_motor"]),
-    (":+^da:?motor$:depth=1", ["da0_motor", "da0_motor.db0_motor", "da1_det", "da1_det.db1_motor"]),
-    (":^da:?motor$:depth=2", ["da0_motor.db0_motor", "da0_motor.db0_motor.dc3_motor",
+    (":^da:?motor$:depth=1", ["da0_motor", "da0_motor.db0_motor", "da1_det", "da1_det.db1_motor"]),
+    (":-^da:?motor$:depth=2", ["da0_motor.db0_motor", "da0_motor.db0_motor.dc3_motor",
      "da0_motor.db1_det.dc1_motor", "da1_det.db1_motor"]),
-    (":^da:?^da:depth=2", []),
-    ("__MOTOR__:+^da:?motor$:depth=1", ["da0_motor", "da0_motor.db0_motor", "da1_det.db1_motor"]),
+    (":-^da:?^da:depth=2", []),
+    ("__MOTOR__:^da:?motor$:depth=1", ["da0_motor", "da0_motor.db0_motor", "da1_det.db1_motor"]),
     ("__READABLE__:?.*db0_motor.*:depth=3", [
         "da0_motor.db0_motor", "da0_motor.db0_motor.dc0_det", "da0_motor.db0_motor.dc1_det",
         "da0_motor.db0_motor.dc2_det", "da0_motor.db0_motor.dc3_motor"]),
@@ -3367,6 +3369,9 @@ _allowed_plans_set_1 = {"count", "count_modified", "mycount", "other_plan"}
     (":^count$", ["count"]),
     (":^count", ["count", "count_modified"]),
     (":count$", ["count", "mycount"]),
+    (":+count$", ["count", "mycount"]),
+    (":-count$", ["count", "mycount"]),
+    (":?count$", ["count", "mycount"]),
 ])
 # fmt: on
 def test_build_plan_name_list_1(plan_def, expected_name_list):
@@ -3383,10 +3388,9 @@ def test_build_plan_name_list_1(plan_def, expected_name_list):
 # fmt: off
 @pytest.mark.parametrize("plan_def, exception_type, msg", [
     ("abc.def", ValueError, "may contain only one component. Components: ['abc', 'def']"),
-    (":?abc:depth=5", ValueError, "Depth specification can not be part of the element"),
-    ("__READABLE__:abc", ValueError, "Device type can not be included in the plan description: '__READABLE__:'"),
-    (":+abc", ValueError, "Plus sign (+) can not be used in a pattern for a plan name: '+abc'"),
-    (":?abc", ValueError, "Question mark (?) can not be used in a pattern for a plan name: '?abc'"),
+    (":?abc:depth=5", ValueError, "Depth specification can not be part of the name pattern for a plan"),
+    ("__READABLE__:abc", ValueError,
+     "Device type can not be included in the name pattern for a plan: '__READABLE__:'"),
 ])
 # fmt: on
 def test_build_plan_name_list_2_fail(plan_def, exception_type, msg):
@@ -5327,7 +5331,7 @@ stg_B = SimBundle(name="sim_bundle")  # Used for tests
         },
         "device2": {
             "annotation": "Devices1",
-            "devices": {"Devices1": (":^stg:+^det:A$", ":.*:.+mtrs$:y")}
+            "devices": {"Devices1": (":-^stg:+^det:A$", ":-.*:-.+mtrs$:y")}
         },
         "device3": {
             "annotation": "Devices1",
@@ -5368,7 +5372,7 @@ _user_permissions_subdevices_2 = """user_groups:
     forbidden_plans:
       - null  # Nothing is forbidden
     allowed_devices:
-      - ":+g_B$:?.*"  # Allow 'stg_B'
+      - ":g_B$:?.*"  # Allow 'stg_B'
     forbidden_devices:
       - null  # Nothing is forbidden
 """
@@ -5387,7 +5391,7 @@ _user_permissions_subdevices_3 = """user_groups:
     allowed_devices:
       - ":?.*"  # A different way to allow all
     forbidden_devices:
-      - ":+g_B$:?.*"  # Block 'stg_B'
+      - ":g_B$:?.*"  # Block 'stg_B'
 """
 
 _user_permissions_subdevices_4 = """user_groups:
@@ -5395,7 +5399,7 @@ _user_permissions_subdevices_4 = """user_groups:
     allowed_plans:
       - null  # Everything is allowed
     allowed_devices:
-      - ":+g_B$:?.*"  # Allow 'stg_B'
+      - ":g_B$:?.*"  # Allow 'stg_B'
   admin:  # The group includes beamline staff, includes all or most of the plans and devices
     allowed_plans:
       - ":.*"  # A different way to allow all
@@ -5410,7 +5414,7 @@ _user_permissions_subdevices_5 = """user_groups:
     allowed_devices:
       - null  # Everything is allowed
     forbidden_devices:
-      - ":+g_B$:?.*"  # Block 'stg_B'
+      - ":g_B$:?.*"  # Block 'stg_B'
   admin:  # The group includes beamline staff, includes all or most of the plans and devices
     allowed_plans:
       - ":.*"  # A different way to allow all

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -62,7 +62,7 @@ from bluesky_queueserver.manager.profile_ops import (
     check_if_function_allowed,
     _validate_user_group_permissions_schema,
     prepare_function,
-    _split_list_element_definition,
+    _split_name_pattern,
     _build_device_name_list,
     _build_plan_name_list,
     _find_and_replace_built_in_types,
@@ -3176,11 +3176,11 @@ def test_devices_from_nspace():
     (":^det:?^val$:depth=1", [("^det", True, False, None), ("^val$", True, True, 1)], True, ""),
 ])
 # fmt: on
-def test_split_list_element_definition_1(element_def, components, uses_re, device_type):
+def test_split_name_pattern_1(element_def, components, uses_re, device_type):
     """
     ``_split_list_element_definition``: basic tests
     """
-    _components, _uses_re, _device_type = _split_list_element_definition(element_def)
+    _components, _uses_re, _device_type = _split_name_pattern(element_def)
     assert _components == components
     assert _uses_re == uses_re
     assert _device_type == device_type
@@ -3208,12 +3208,12 @@ def test_split_list_element_definition_1(element_def, components, uses_re, devic
     ("det.v$al", ValueError, "Name pattern 'det.v$al' contains invalid characters"),
 ])
 # fmt: on
-def test_split_list_element_definition_2_fail(element_def, exception_type, msg):
+def test_split_name_pattern_2_fail(element_def, exception_type, msg):
     """
     ``_split_list_element_definition``: failing cases
     """
     with pytest.raises(exception_type, match=re.escape(msg)):
-        _split_list_element_definition(element_def)
+        _split_name_pattern(element_def)
 
 
 # fmt: off
@@ -3338,7 +3338,7 @@ def test_build_device_name_list_1(element_def, expected_name_list):
     """
     ``_build_device_name_list``: basic tests
     """
-    components, uses_re, device_type = _split_list_element_definition(element_def)
+    components, uses_re, device_type = _split_name_pattern(element_def)
     name_list = _build_device_name_list(
         components=components, uses_re=uses_re, device_type=device_type, existing_devices=_allowed_devices_dict_1
     )
@@ -3349,7 +3349,7 @@ def test_build_device_name_list_2_fail():
     """
     ``_build_device_name_list``: failing cases
     """
-    components, uses_re, device_type = _split_list_element_definition("def")
+    components, uses_re, device_type = _split_name_pattern("def")
     with pytest.raises(ValueError, match="Unsupported device type: 'unknown'"):
         _build_device_name_list(
             components=components, uses_re=uses_re, device_type="unknown", existing_devices=_allowed_devices_dict_1
@@ -3373,7 +3373,7 @@ def test_build_plan_name_list_1(plan_def, expected_name_list):
     """
     ``_build_plan_name_list``: basic tests
     """
-    components, uses_re, device_type = _split_list_element_definition(plan_def)
+    components, uses_re, device_type = _split_name_pattern(plan_def)
     name_list = _build_plan_name_list(
         components=components, uses_re=uses_re, device_type=device_type, existing_plans=_allowed_plans_set_1
     )
@@ -3393,7 +3393,7 @@ def test_build_plan_name_list_2_fail(plan_def, exception_type, msg):
     """
     ``_build_plan_name_list``: failing cases
     """
-    components, uses_re, device_type = _split_list_element_definition(plan_def)
+    components, uses_re, device_type = _split_name_pattern(plan_def)
 
     with pytest.raises(exception_type, match=re.escape(msg)):
         _build_plan_name_list(

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -3341,7 +3341,7 @@ user_groups:
       - null  # Nothing is forbidden
   admin:  # The group includes beamline staff, includes all or most of the plans and devices
     allowed_plans:
-      - "^count$"  # 'count plan'
+      - ":^count$"  # 'count plan'
     forbidden_plans:
       - null  # Nothing is forbidden
     allowed_devices:
@@ -3366,7 +3366,7 @@ user_groups:
     allowed_plans:
       - null  # A different way to allow all
     forbidden_plans:
-      - "^count$"  # 'count' plan
+      - ":^count$"  # 'count' plan
     allowed_devices:
       - null  # A different way to allow all
     forbidden_devices:
@@ -3487,7 +3487,7 @@ def test_permissions_reload_3(re_manager_pc_copy, allow_count_plan):  # noqa: F8
 _permissions_dict_not_allow_count = {
     "user_groups": {
         "root": {"allowed_plans": [None], "allowed_devices": [None]},
-        "admin": {"allowed_plans": [None], "forbidden_plans": ["^count$"], "allowed_devices": [None]},
+        "admin": {"allowed_plans": [None], "forbidden_plans": [":^count$"], "allowed_devices": [None]},
     }
 }
 

--- a/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -3,44 +3,44 @@ user_groups:
     allowed_plans:
       - null  # Allow all
     forbidden_plans:
-      - "^_"  # All plans with names starting with '_'
+      - ":^_"  # All plans with names starting with '_'
     allowed_devices:
       - null  # Allow all
     forbidden_devices:
-      - "^_"  # All devices with names starting with '_'
+      - ":?^_"  # All devices with names starting with '_'
     allowed_functions:
       - null  # Allow all
     forbidden_functions:
-      - "^_"  # All devices with names starting with '_'
+      - ":^_"  # All functions with names starting with '_'
   admin:  # The group includes beamline staff, includes all or most of the plans and devices
     allowed_plans:
-      - ".*"  # A different way to allow all
+      - ":.*"  # Different way to allow all plans.
     forbidden_plans:
       - null  # Nothing is forbidden
     allowed_devices:
-      - ".*"  # A different way to allow all
+      - ":?.*:depth=5"  # Allow all device and subdevices. Maximum deepth for subdevices is 5.
     forbidden_devices:
       - null  # Nothing is forbidden
     allowed_functions:
-      - "^function_sleep$"
+      - "function_sleep"  # Explicitly listed name
   test_user:  # Users with limited access capabilities
     allowed_plans:
-      - "^count"  # Use regular expression patterns
-      - "scan$"
+      - ":^count"  # Use regular expression patterns
+      - ":scan$"
     forbidden_plans:
-      - "^adaptive_scan$" # Use regular expression patterns
-      - "^inner_product"
+      - ":^adaptive_scan$" # Use regular expression patterns
+      - ":^inner_product"
     allowed_devices:
-      - "^det"  # Use regular expression patterns
-      - "^motor"
-      - "^sim_bundle_A"
+      - ":+^det:?.*"  # Use regular expression patterns
+      - ":+^motor:?.*"
+      - ":+^sim_bundle_A:?.*"
     forbidden_devices:
-      - "^det[3-5]$" # Use regular expression patterns
-      - "^motor\\d+$"
+      - ":+^det[3-5]$:?.*" # Use regular expression patterns
+      - ":+^motor\\d+$:?.*"
     allowed_functions:
-      - "element$"
-      - "elements$"
-      - "^function_sleep$"
-      - "^clear_buffer$"
+      - ":element$"
+      - ":elements$"
+      - "function_sleep"
+      - "clear_buffer"
     forbidden_functions:
-      - "^_"  # All devices with names starting with '_'
+      - ":^_"  # All devices with names starting with '_'

--- a/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -43,4 +43,4 @@ user_groups:
       - "function_sleep"
       - "clear_buffer"
     forbidden_functions:
-      - ":^_"  # All devices with names starting with '_'
+      - ":^_"  # All functions with names starting with '_'

--- a/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -7,7 +7,7 @@ user_groups:
     allowed_devices:
       - null  # Allow all
     forbidden_devices:
-      - ":?^_"  # All devices with names starting with '_'
+      - ":^_:?.*"  # All devices with names starting with '_'
     allowed_functions:
       - null  # Allow all
     forbidden_functions:

--- a/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -31,12 +31,12 @@ user_groups:
       - ":^adaptive_scan$" # Use regular expression patterns
       - ":^inner_product"
     allowed_devices:
-      - ":+^det:?.*"  # Use regular expression patterns
-      - ":+^motor:?.*"
-      - ":+^sim_bundle_A:?.*"
+      - ":^det:?.*"  # Use regular expression patterns
+      - ":^motor:?.*"
+      - ":^sim_bundle_A:?.*"
     forbidden_devices:
-      - ":+^det[3-5]$:?.*" # Use regular expression patterns
-      - ":+^motor\\d+$:?.*"
+      - ":^det[3-5]$:?.*" # Use regular expression patterns
+      - ":^motor\\d+$:?.*"
     allowed_functions:
       - ":element$"
       - ":elements$"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -195,7 +195,7 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    # 'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     # 'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
     'matplotlib': ('https://matplotlib.org', None),
 }

--- a/docs/source/features_and_config.rst
+++ b/docs/source/features_and_config.rst
@@ -60,44 +60,50 @@ user data and permissions.) The way RE Manager is handling updated permissions i
 Configuring User Group Permissions
 ----------------------------------
 
-Each user group may be assigned permissions. The permission restrict the set of plans that members
-of the group are allowed to execute and a set of devices users may send to plans as parameters.
-The permissions do not restrict plans and devices that could be called from the allowed plans.
-Optionally, permissions may be configured to allow users to execute Python functions defined
-in RE Worker namespace.
+Each user group is assigned a set of permissions, which restrict the plans that users
+are allowed to execute and devices users may submit to plans as parameters.
+The permissions do not influence the code running in RE Worker environment, therefore
+any existing plans and devices could be used from within plans. Optionally, permissions
+may be configured to allow users to execute Python functions defined in RE Worker namespace
+(see :ref:`method_function_execute` API).
 
 User groups names are defined in user permissions dictionary, which could be saved in
 ``user_group_permissions.yaml`` file and loaded on startup or uploaded by the client application
-using :ref:`method_permissions_set` API. The dictionary must define at least one user group
-named ``root``. Restrictions defined for the ``root`` are applied to plans and devices accessible
-by any other defined group (root of the permissions tree). Internally the lists of existing
-plans and devices are initially filtered using ``root`` permissions and eliminating 'junk'
-from the lists may reduce overhead when generating more detailed permissions for other groups.
-It is not recommended to assign members to the ``root`` group or submit plans as ``root``
-(currently there are no restrictions that would prevent from doing it).
+(see :ref:`method_permissions_set` API). The dictionary must define at least one required user group
+named ``root``. Restrictions defined for ``root`` are applied to plans and devices accessible
+by any other defined group (consider it as a root of the tree of permissions). Internally,
+the lists of existing plans and devices are initially filtered using ``root`` permissions
+before the permissions for the other defined groups are applied to create lists of allowed
+plans and devices. Putting common restrictions in the permissions for the ``root`` group
+may reduce time of processing permissions. It is not recommended to assign users to
+the ``root`` group or submit plans as ``root``, but currently there are no restrictions
+that would prevent from doing it.
 
 Permission for each group include lists of allowed and forbidden plans, devices and functions.
-Each lists contains names and/or patterns for filtering of names of device, plan or function
+Each lists contains names and/or patterns for filtering names of device, plan or function
 objects. In order for a device, plan or function to be accessible to users of a group,
 the name of the object must match one of the names or patterns from the 'allowed' list and
-not match any of the names or patterns from the 'forbidden' list. The instructions for writing
-the lists of names and patterns for devices may be found in :ref:`lists_of_device_names` and
-for plans and functions in :ref:`lists_of_plan_names`.
+not match any of the names or patterns from the 'forbidden' list. The guidelines for
+composing lists of names and patterns for devices may be found in :ref:`lists_of_device_names`
+and for plans and functions in :ref:`lists_of_plan_names`.
 
-All the lists are optional. If 'allowed' list is not defined, then no objects are allowed.
-The most efficient method to allow all objects is to set the first element of the 'allowed'
-list ``None`` (it may be the only element of the list, all other elements are ignored).
-Missing 'forbidden' list or the list the first element set to ``None`` means that no
-elements are forbidden.
+All the lists are optional. If 'allowed' list is not defined for a given type of objects
+(plans, devices or functions), then no objects of this type are allowed. The most efficient
+method to allow all objects is to set the first element of the 'allowed' list ``None``
+(it could be the only element of the list, all other elements are ignored). If 'forbidden'
+list is missing or if the first element of the list is ``None``, then no objects are forbidden,
+i.e. all the objects matching the 'allowed' patterns will appear in the list of allowed objects.
+Typically, permissions for a group would contain at least ``allowed_plans`` section to allow
+users to submit some plans to the queue, but it may not be necessary in some workflows.
+Missing ``allowed_devices`` section means that no devices could be passed to plans as parameters.
 
 Following is an example of a trivial user permission dictionary (in YAML format), which
 allows all plans and devices for ``admin`` user group ('admin' is an arbitrarily chosen name).
 Restrictions for the ``root`` group forbid access to all plans and devices starting with local
-names (starting with '_'). Note, that those plans and devices can still be used in the plans.
-The ``root`` permissions are propagated to all other groups, which means that no group
-could be configured to access objects with local names. Permissions for an additional user
-group ``test_user`` were configured with sole purpose of demonstrating what types of
-patterns could be included in the lists.
+names (starting with '_'). Note, that those plans and devices can still be used in plans.
+The ``root`` permissions are applied to all other groups, which means that no group
+could be configured to access objects with local names. Additional user group ``test_user``
+is created with the sole purpose of demonstrating different types of name patterns.
 
 .. code-block::
 
@@ -110,7 +116,7 @@ patterns could be included in the lists.
       allowed_devices:
         - null  # Allow all
       forbidden_devices:
-        - ":?^_"  # All devices with names starting with '_'
+        - ":^_:?.*"  # All devices with names starting with '_' and their subdevices
       allowed_functions:
         - null  # Allow all
       forbidden_functions:
@@ -124,26 +130,24 @@ patterns could be included in the lists.
         - "function_sleep"  # Explicitly listed name
     test_user:  # Some examples of patterns that could be used in lists
       allowed_plans:
-        - ":^count"  # Use regular expression patterns
-        - ":scan$"
+        - ":^count"  # Allow all plan names starting with 'count'
+        - ":scan$"  # Allow all plan names ending with 'scan'
+        - ":product"  # Allow all plans names containing the word 'product'
       forbidden_plans:
-        - ":^adaptive_scan$" # Use regular expression patterns
-        - ":^inner_product"
+        - "adaptive_scan"  # Do not allow the plan 'adaptive_scan'
+        - ":^inner_product"  # Do not allow all plan names starting with 'inner_product'
       allowed_devices:
-        - ":^det:?.*"  # Use regular expression patterns
-        - ":^motor:?.*"
-        - ":^sim_bundle_A:?.*"
+        - ":^det:?.*"  # Allow all devices starting with 'det' and their subdevices
+        - ":^motor:?.*"  # Allow allow all devices starting with 'motor' and their subdevices
+        - ":^sim_bundle_A:?.*"  # Same for devices starting with 'sim_bundle_A'
       forbidden_devices:
-        - ":^det[3-5]$:?.*" # Use regular expression patterns
-        - ":^motor\\d+$:?.*"
-      allowed_functions:
-        - ":element$"
-        - ":elements$"
-        - "function_sleep"  # Function name, not a pattern
-        - "clear_buffer"
-      forbidden_functions:
-        - ":^_"  # All functions with names starting with '_'
+        - ":^det[3-5]$:?.*"  # Do not allow devices 'det3', 'det4' and 'det5' and all subdevices
+        - ":^motor\\d+$:?.*"  # Same for all numbered motors, such as 'motor2' or 'motor256'
 
+It is recommended that new projects are started using the sample file
+`user_group_permissions.yaml <https://github.com/bluesky/bluesky-queueserver/blob/main/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml>`_,
+which could be copied to the directory containing startup files and then modified according
+to the project needs.
 
 Remote Monitoring of Console Output
 -----------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Support for subdevice names in `user_group_permissions.yaml`. Changes in this PR may require replacing or editing the existing `user_group_permissions.yaml`.

## Description
<!--- Describe your changes in detail -->

The PR provides support for patterns that allow filtering (including, excluding) device and subdevice names while generating lists of allowed plans and devices. The syntax for the patterns is identical to syntax for patterns in the lists of plans and devices in `parameter_annotation_decorator` (introduced in PR https://github.com/bluesky/bluesky-queueserver/pull/209). In the older versions, user group permissions were defined using regular expressions, but now they may include explicitly listed names and patterns based on regular expressions. The file `user_group_permissions.yaml` used in projects may need to be updated to work with the new version of the Queue Server:

- If stock version of `user_group_permissions.yaml` is used in the project, then copy the new file to the project. No manual changes are required.

- If the project uses custom `user_group_permissions.yaml`, then insert `:` before each regular expression in the lists (e.g. change `"^count"` to `":^count"`, `"^det"` to `":^det"` etc.). The lists can now include plan, device or subdevice names, such as `"count"`, `"det1"`, `"det1.val"` (there is no need to use regular expressions such as `":^count$"` to allow the plan with the name `count`). To include all subdevices of a devices with names starting with `det` use the pattern `":^det:?.*"`. The maximum depth for subdevices may be specified as `":^det:?.*:depth=2"` (adds subdevices and subdevices of subdevices). See documentation for more detailed instructions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Support for subdevice names in `user_group_permissions.yaml`

### Changed

- The algorithm for processing of user group permissions has changed. The old `user_group_permissions.yaml` may no longer work as expected. If the stock `user_group_permissions.yaml` is used for the project, replace it with the updated file from the repository. Otherwise update the existing file using following guidelines: 

> If the project uses custom `user_group_permissions.yaml`, then insert `:` before each regular expression in the lists (e.g. change `"^count"` to `":^count"`, `"^det"` to `":^det"` etc.). The lists can now include plan, device or subdevice names, such as `"count"`, `"det1"`, `"det1.val"` (there is no need to use regular expressions such as `":^count$"` to allow the plan with the name `count`). To include all subdevices of a devices with names starting with `det` use the pattern `":^det:?.*"`. The maximum depth for subdevices may be specified as `":^det:?.*:depth=2"` (adds subdevices and subdevices of subdevices). See the documentation for more detailed instructions.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Detailed unit tests were implemented.