### PR TITLE
ENH: catch exceptions for components that are not accessible

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2795,7 +2795,7 @@ def _prepare_plans(plans, *, existing_devices):
     }
 
 
-def _prepare_devices(devices, *, max_depth=0, ignore_unaccessible_subdevices=True):
+def _prepare_devices(devices, *, max_depth=0, ignore_all_subdevices_if_one_fails=True):
     """
     Prepare dictionary of existing devices for saving to YAML file.
     ``max_depth`` is the maximum depth for the components. The default value (50)
@@ -2809,7 +2809,7 @@ def _prepare_devices(devices, *, max_depth=0, ignore_unaccessible_subdevices=Tru
     max_depth: int
         Maximum depth for the device search: 0 - infinite depth, 1 - only top level
         devices, 2 - device and subdevices etc.
-    ignore_unaccessible_subdevice: bool
+    ignore_all_subdevices_if_one_fails: bool
         Ignore all components of devices if at least one component (PVs) can not
         be accessed. It saves a lot of time to ignore all components, since
         stale code may contain devices with many components with non-existing PVs
@@ -2858,7 +2858,7 @@ def _prepare_devices(devices, *, max_depth=0, ignore_unaccessible_subdevices=Tru
                         desc = create_device_description(c, device_name + "." + comp_name, depth=depth + 1)
                         components[comp_name] = desc
                 except Exception as ex:
-                    ignore_subdevices = ignore_unaccessible_subdevices
+                    ignore_subdevices = ignore_all_subdevices_if_one_fails
                     logger.warning(
                         f"Device '%s': component {comp_name!r} can not be processed: %s", device_name, ex
                     )

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2830,15 +2830,15 @@ def _prepare_devices(devices, *, max_depth=50):
         components = {}
         if depth <= max_depth:
             for comp_name in comps:
-                if hasattr(device, comp_name):
-                    try:
+                try:
+                    if hasattr(device, comp_name):
                         c = getattr(device, comp_name)
                         desc = create_device_description(c, device_name + comp_name, depth=depth + 1)
                         components[comp_name] = desc
-                    except Exception as ex:
-                        logger.warning(
-                            f"Device '%s': component {comp_name!r} can not be processed: %s", device_name, ex
-                        )
+                except Exception as ex:
+                    logger.warning(
+                        f"Device '%s': component {comp_name!r} can not be processed: %s", device_name, ex
+                    )
         if components:
             description["components"] = components
         return description

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2829,16 +2829,16 @@ def _prepare_devices(devices, *, max_depth=50):
         comps = get_device_component_names(device)
         components = {}
         if depth <= max_depth:
-            for comp_name in comps:
-                try:
+            try:
+                for comp_name in comps:
                     if hasattr(device, comp_name):
                         c = getattr(device, comp_name)
                         desc = create_device_description(c, device_name + comp_name, depth=depth + 1)
                         components[comp_name] = desc
-                except Exception as ex:
-                    logger.warning(
-                        f"Device '%s': component {comp_name!r} can not be processed: %s", device_name, ex
-                    )
+            except Exception as ex:
+                logger.warning(
+                    f"Device '%s': component {comp_name!r} can not be processed: %s", device_name, ex
+                )
         if components:
             description["components"] = components
         return description

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2833,7 +2833,7 @@ def _prepare_devices(devices, *, max_depth=50):
                 for comp_name in comps:
                     if hasattr(device, comp_name):
                         c = getattr(device, comp_name)
-                        desc = create_device_description(c, device_name + comp_name, depth=depth + 1)
+                        desc = create_device_description(c, device_name + "." + comp_name, depth=depth + 1)
                         components[comp_name] = desc
             except Exception as ex:
                 logger.warning(

--- a/bluesky_queueserver/profile_collection_sim/99-custom.py
+++ b/bluesky_queueserver/profile_collection_sim/99-custom.py
@@ -221,3 +221,5 @@ def count_bundle_test(detectors, num=1, delay=None, *, per_shot=None, md=None):
 
 
 # =======================================================================================
+
+raise Exception("Hello")

--- a/bluesky_queueserver/profile_collection_sim/99-custom.py
+++ b/bluesky_queueserver/profile_collection_sim/99-custom.py
@@ -221,5 +221,3 @@ def count_bundle_test(detectors, num=1, delay=None, *, per_shot=None, md=None):
 
 
 # =======================================================================================
-
-raise Exception("Hello")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
After the PR https://github.com/bluesky/bluesky-queueserver/pull/209, RE Manager allows to pass subdevice names as parameters to plan. The current parameter validation code requires that the full tree of subdevices for each existing is created after startup files are loaded. Testing at the beamline exposed issues with this procedure. Particularly, AD subdevices are instantiated only when they are accessed and they attempt to access PVs in the process. In practice many of the PVs do not exist, resulting in exceptions being raised and environment failing to open. This PR contains fix for the issue. Now the subdevices devices that fail to instantiate are ignored and not included in the tree. In order to minimize loading time, all subdevices of a device (or subdevice) are ignored if only one PV is not accessible. 

Changes in this PR does not affect the existing code, except that the subdevices that fail to instantiate are not included in the tree (which would cause the old version to crash and not load the environment). 

It is understood, that the current approach, which requires building the complete tree of subdevices, may not be the best for all workflows, so the validation code will be revisited and some of the existing options will be parametrized.
