### PR TITLE
New 0MQ API ('task_status')

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -8,6 +8,7 @@ import enum
 import uuid
 import copy
 
+import bluesky_queueserver
 from .comms import PipeJsonRpcSendAsync, CommTimeoutError, validate_zmq_key
 from .profile_ops import (
     load_allowed_plans_and_devices,
@@ -25,6 +26,8 @@ from .task_results import TaskResults
 import logging
 
 logger = logging.getLogger(__name__)
+
+qserver_version = bluesky_queueserver.__version__
 
 
 def _generate_uid():
@@ -1274,6 +1277,7 @@ class RunEngineManager(Process):
         n_items_in_history = await self._plan_queue.get_history_size()
 
         # Prepared output data
+        response_msg = f"RE Manager v{qserver_version}"
         items_in_queue = n_pending_items
         items_in_history = n_items_in_history
         running_item_uid = running_item_info["item_uid"] if running_item_info else None
@@ -1298,7 +1302,7 @@ class RunEngineManager(Process):
         # TODO: consider different levels of verbosity for ping or other command to
         #       retrieve detailed status.
         msg = {
-            "msg": "RE Manager",
+            "msg": response_msg,
             "items_in_queue": items_in_queue,
             "items_in_history": items_in_history,
             "running_item_uid": running_item_uid,

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -2360,6 +2360,45 @@ class RunEngineManager(Process):
 
         return {"success": success, "msg": msg, "task_uid": task_uid, "status": status, "result": result}
 
+    async def _task_status_handler(self, request):
+        """
+        Returns the status of one or more tasks executed by the worker process. The request must contain
+        one or more valid task UIDs, returned by one of APIs that starts tasks. A single UID is passed
+        as a string, multiple UIDs - as a list of strings. If a UID is passed as a string, then
+        the returned status is also a string, if a list of one or more UIDs is passed, then
+        the status is a dictionary that maps task UIDs and their status.
+
+        Returned parameters: ``success`` and ``msg`` indicate success of the API call and error message in
+        case of API call failure; ``status`` is the status of the tasks (``running``, ``completed``,
+        ``not_found``).
+        """
+        logger.debug("Request the status of one or more tasks executed by RE Worker ...")
+
+        task_uid = None
+
+        try:
+            supported_param_names = ["task_uid"]
+            self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            task_uid = request.get("task_uid", None)
+            if task_uid is None:
+                raise ValueError("Required 'task_uid' parameter is missing in the API call.")
+
+            if isinstance(task_uid, str):
+                status = (await self._task_results.get_task_info(task_uid=task_uid))[0]
+            elif isinstance(task_uid, list):
+                status = {_: (await self._task_results.get_task_info(task_uid=_))[0] for _ in task_uid}
+            else:
+                raise Exception(
+                    f"'task_uid' must be a string or a list of strings: type(task_uid)={type(task_uid)!r}"
+                )
+            success, msg = True, ""
+
+        except Exception as ex:
+            success, msg, status = False, f"Error: {ex}", None
+
+        return {"success": success, "msg": msg, "task_uid": task_uid, "status": status}
+
     async def _queue_start_handler(self, request):
         """
         Start execution of the loaded queue. Additional runs can be added to the queue while
@@ -2624,6 +2663,7 @@ class RunEngineManager(Process):
             "script_upload": "_script_upload_handler",
             "function_execute": "_function_execute_handler",
             "task_result": "_task_result_handler",
+            "task_status": "_task_status_handler",
             "queue_mode_set": "_queue_mode_set_handler",
             "queue_item_add": "_queue_item_add_handler",
             "queue_item_add_batch": "_queue_item_add_batch_handler",

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -143,6 +143,7 @@ qserver script upload <path-to-file> background   # ... in the background
 qserver script upload <path-to-file> update-re    # ... allow 'RE' and 'db' to be updated
 
 qserver task result <task-uid>  # Load status or result of a task with the given UID
+qserver task status <task-uid>  # Check status of a task with the given UID
 
 qserver manager stop           # Safely exit RE Manager application
 qserver manager stop safe on   # Safely exit RE Manager application
@@ -890,6 +891,10 @@ def create_msg(params):
         if len(params) != 2:
             raise CommandParameterError(f"Request '{command}' must include at 3 parameters")
         if params[0] == "result":
+            task_uid = str(params[1])
+            method = f"{command}_{params[0]}"
+            prms = {"task_uid": task_uid}
+        elif params[0] == "status":
             task_uid = str(params[1])
             method = f"{command}_{params[0]}"
             prms = {"task_uid": task_uid}

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -1217,17 +1217,20 @@ def test_function_execute_2_fail(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "function", "execute", item, "invalid_param"]) == PARAM_ERROR
 
 
-def test_task_result_1(re_manager):  # noqa: F811
+def test_task_result_status_1(re_manager):  # noqa: F811
     """
-    Tests for 'qserver task result_get'.
+    Tests for 'qserver task result' and 'qserver task status.
     """
     # The request should be successful for any 'task_uid'.
     task_uid = "01e80342-5e36-44de-bc86-9bd8d57c9885"
+    assert subprocess.call(["qserver", "task", "status", task_uid]) == SUCCESS
     assert subprocess.call(["qserver", "task", "result", task_uid]) == SUCCESS
 
     # Some cases of invalid parameters
+    assert subprocess.call(["qserver", "task", "status"]) == PARAM_ERROR
     assert subprocess.call(["qserver", "task", "result"]) == PARAM_ERROR
     assert subprocess.call(["qserver", "task", "something"]) == PARAM_ERROR
+    assert subprocess.call(["qserver", "task", "status", task_uid, "extra_param"]) == PARAM_ERROR
     assert subprocess.call(["qserver", "task", "result", task_uid, "extra_param"]) == PARAM_ERROR
 
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -10,6 +10,8 @@ import json
 import numpy as np
 import yaml
 
+import bluesky_queueserver
+
 from bluesky_queueserver.manager.profile_ops import (
     get_default_startup_dir,
     load_allowed_plans_and_devices,
@@ -47,6 +49,8 @@ from .common import (
     # clear_redis_pool,
 )
 from .common import re_manager, re_manager_pc_copy, re_manager_cmd, db_catalog  # noqa: F401
+
+qserver_version = bluesky_queueserver.__version__
 
 # Plans used in most of the tests: '_plan1' and '_plan2' are quickly executed '_plan3' runs for 5 seconds.
 _plan1 = {"name": "count", "args": [["det1", "det2"]], "item_type": "plan"}
@@ -158,7 +162,7 @@ def test_zmq_api_asyncio_based(re_manager):  # noqa F811
 # fmt: on
 def test_zmq_api_ping_status(re_manager, api_name):  # noqa F811
     resp, _ = zmq_single_request(api_name)
-    assert resp["msg"] == "RE Manager"
+    assert resp["msg"] == f"RE Manager v{qserver_version}"
     assert resp["manager_state"] == "idle"
     assert resp["items_in_queue"] == 0
     assert resp["running_item_uid"] is None

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -160,7 +160,7 @@ def test_zmq_api_asyncio_based(re_manager):  # noqa F811
 # fmt: off
 @pytest.mark.parametrize("api_name", ["ping", "status"])
 # fmt: on
-def test_zmq_api_ping_status(re_manager, api_name):  # noqa F811
+def test_zmq_api_ping_status_01(re_manager, api_name):  # noqa F811
     resp, _ = zmq_single_request(api_name)
     assert resp["msg"] == f"RE Manager v{qserver_version}"
     assert resp["manager_state"] == "idle"
@@ -182,6 +182,17 @@ def test_zmq_api_ping_status(re_manager, api_name):  # noqa F811
 
     assert isinstance(resp["plan_queue_mode"], dict)
     assert resp["plan_queue_mode"]["loop"] is False
+
+
+# fmt: off
+@pytest.mark.parametrize("api_name", ["ping", "status"])
+# fmt: on
+def test_zmq_api_ping_status_02(re_manager, api_name):  # noqa F811
+    """
+    Check that extra parameters, such as 'reload' are ignored by the API.
+    """
+    resp, _ = zmq_single_request(api_name, params={"reload": True})
+    assert resp["msg"] == f"RE Manager v{qserver_version}"
 
 
 # =======================================================================================

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -2087,6 +2087,99 @@ def test_zmq_api_script_upload_9_fail(re_manager, test_with_plan):  # noqa: F811
 
 
 # ===========================================================================================
+#                                'task_status' API
+
+
+def test_zmq_api_task_status_1(re_manager):  # noqa: F811
+    """
+    ``task_status``: basic test.
+    """
+    resp1, _ = zmq_single_request("environment_open")
+    assert resp1["success"] is True
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    status, _ = zmq_single_request("status")
+    assert status["worker_background_tasks"] == 0
+
+    func_item = {"name": "function_sleep", "item_type": "function", "args": [2.0]}
+    params = {"item": func_item, "run_in_background": True, "user": _user, "user_group": _test_user_group}
+
+    task_uids = []
+    for _ in range(3):
+        resp1, _ = zmq_single_request("function_execute", params=params)
+        assert resp1["success"] is True
+        task_uids.append(resp1["task_uid"])
+
+    assert len(task_uids) == 3
+
+    resp2, _ = zmq_single_request("task_status", params={"task_uid": task_uids[0]})
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+    assert resp2["status"] == "running"
+
+    resp3, _ = zmq_single_request("task_status", params={"task_uid": [task_uids[0]]})
+    assert resp3["success"] is True
+    assert resp3["msg"] == ""
+    assert resp3["status"] == {task_uids[0]: "running"}
+
+    resp4, _ = zmq_single_request("task_status", params={"task_uid": (task_uids[0], task_uids[1])})
+    assert resp4["success"] is True
+    assert resp4["msg"] == ""
+    assert resp4["status"] == {task_uids[0]: "running", task_uids[1]: "running"}
+
+    resp5, _ = zmq_single_request("task_status", params={"task_uid": task_uids})
+    assert resp5["success"] is True
+    assert resp5["msg"] == ""
+    assert resp5["status"] == {_: "running" for _ in task_uids}
+
+    result = wait_for_task_result(10, task_uids[-1])
+    assert result["success"] is True, pprint.pformat(result)
+
+    resp6, _ = zmq_single_request("environment_close")
+    assert resp6["success"] is True, f"resp={resp6}"
+    assert wait_for_condition(time=5, condition=condition_environment_closed)
+
+
+def test_zmq_api_task_status_2(re_manager):  # noqa: F811
+    """
+    ``task_status``: some special successfull cases.
+    """
+    resp1, _ = zmq_single_request("task_status", params={"task_uid": "some_uid"})
+    assert resp1["success"] is True
+    assert resp1["msg"] == ""
+    assert resp1["status"] == "not_found"
+
+    resp2, _ = zmq_single_request("task_status", params={"task_uid": ["uid1", "uid2"]})
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+    assert resp2["status"] == {"uid1": "not_found", "uid2": "not_found"}
+
+    resp3, _ = zmq_single_request("task_status", params={"task_uid": ["uid1", "uid1"]})
+    assert resp3["success"] is True
+    assert resp3["msg"] == ""
+    assert resp3["status"] == {"uid1": "not_found"}
+
+
+# fmt: off
+@pytest.mark.parametrize("params, err_msg", [
+    ({}, "Required 'task_uid' parameter is missing in the API call"),
+    ({"some_param": 10}, "API request contains unsupported parameters: 'some_param'"),
+    ({"task_uid": 10}, "'task_uid' must be a string or a list of strings"),
+    ({"task_uid": "uid1", "some_param": 10},
+     "API request contains unsupported parameters: 'some_param'"),
+])
+# fmt: on
+def test_zmq_api_task_status_3_fail(re_manager, params, err_msg):  # noqa: F811
+    """
+    ``task_status``: failing cases.
+    """
+    resp1, _ = zmq_single_request("task_status", params=params)
+    assert resp1["success"] is False
+    assert err_msg in resp1["msg"], pprint.pformat(resp1)
+    assert resp1["status"] is None
+
+
+# ===========================================================================================
 #                             'function_execute' API
 
 

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -126,6 +126,7 @@ Run tasks in RE Worker namespace:
 
 - :ref:`method_script_upload`
 - :ref:`method_function_execute`
+- :ref:`method_task_status`
 - :ref:`method_task_result`
 
 Stopping RE Manager (mostly used in testing):
@@ -174,7 +175,7 @@ Description   Returns status of RE Manager.
 Parameters    ---
 ------------  -----------------------------------------------------------------------------------------
 Returns       **msg**: *str*
-                  always returns 'RE Manager'
+                 application name and version, e.g. 'RE Manager v0.0.10'
 
               **items_in_queue**: *int*
                  the number of items in the plan queue
@@ -1500,11 +1501,52 @@ Returns       **success**: *boolean*
                   the assigned *item_uid* is equal to *task_uid*, but it may change in the future.
 
               **task_uid**: *str* or *None*
-                  Task UID can be used to check status of the task and download results once the task
+                  task UID can be used to check status of the task and download results once the task
                   is completed (see *task_result* API). *None* is returned if the request fails.
 ------------  -----------------------------------------------------------------------------------------
 Execution     The method initiates the operation. Monitor *task_results_uid* status field and call
               *task_result* API to check for success.
+============  =========================================================================================
+
+
+.. _method_task_status:
+
+**'task_status'**
+^^^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'task_status'**
+------------  -----------------------------------------------------------------------------------------
+Description   Returns the status of one or more tasks executed by the worker process. The request
+              must contain one or more valid task UIDs, returned by one of APIs that starts tasks.
+              A single UID may be passed as a string, multiple UIDs must be passed as as a list of
+              strings. If a UID is passed as a string, then the returned status is also a string,
+              if a list of one or more UIDs is passed, then the status is a dictionary that maps
+              task UIDs and their status. The completed tasks are stored at the server at least
+              for the period determined by retention time (currently 120 seconds after completion
+              of the task). The expired results could be automatically deleted at any time and
+              the method will return the task status as *'not_found'*.
+------------  -----------------------------------------------------------------------------------------
+Parameters    **task_uid**: *str* or *list(str)*
+                  Task UID.
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+
+              **task_uid**: *str* or *None*
+                  task UID (expected to be the same as the input parameter) or *None* if
+                  the request failed.
+
+              **status**: *str* or *dict*
+                  status of the task(s) or *None* if the request (not task) failed. If **task_uid**
+                  is a string representing single UID, then **status** is a string that may be one
+                  of *'running'*, *'completed'* or *'not_found'*. If **task_uid** is a list of strings,
+                  then *'status'* is a dictionary that maps task UIDs to status of the respective tasks.
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================
 
 
@@ -1531,11 +1573,11 @@ Returns       **success**: *boolean*
                   error message in case of failure, empty string ('') otherwise.
 
               **task_uid**: *str* or *None*
-                  Task UID (expected to be the same as the input parameter) or *None* if
+                  task UID (expected to be the same as the input parameter) or *None* if
                   the request failed.
 
               **status**: *'running'*, *'completed'*, *'not_found'* or *None*
-                  Status of the task or *None* if the request (not task) failed.
+                  status of the task or *None* if the request (not task) failed.
 
               **result**: *dict* or *None*
                   Dictionary containing the information on a running task, results of the completed

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -228,6 +228,8 @@ Returns       **msg**: *str*
 
                   - **'creating_environment'** - RE Worker environment is in the process of being created.
 
+                  - **'starting_queue'** - preparing to execute the queue.
+
                   - **'executing_queue'** - queue is being executed.
 
                   - **'closing_environment'** - RE Worker environment is in the process of being

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -1403,7 +1403,8 @@ Description   Upload and execute script in RE Worker namespace. The script may a
               updates the lists of existing and allowed plans and devices if necessary. Changes in
               the lists will be indicated by changed list UIDs. Use *'task_result'* API to check
               if the script was loaded correctly. Note, that if the task fails, the script is
-              still executed to the point where the exception is raised, changing the environment.
+              still executed to the point where the exception is raised and the respective changes
+              to the environment are applied.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **script**: *str*
                   The string that contains the Python script. The rules for the script are the same
@@ -1423,7 +1424,8 @@ Parameters    **script**: *str*
                   (while a plan or another foreground task is running). Generally, it is not
                   recommended to update RE Worker namespace in the background. Background tasks
                   are executed in separate threads and only thread-safe scripts should be uploaded
-                  in the background.
+                  in the background. **Developers of data acquisition workflows and/or user
+                  specific code are responsible for thread safety.**
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1468,7 +1470,7 @@ Description   Start execution of a function in RE Worker namespace. The function
               with given name and parameters. The function may still fail start (e.g. if the user is
               permitted to execute function with the given name, but the function is not defined
               in the namespace). Use *'task_result'* method with the returned *task_uid* to
-              check the status of the taks and load the result upon completion.
+              check the status of the tasks and load the result upon completion.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **item**: *dict*
                   the dictionary that contains function name and parameters. The structure of
@@ -1487,6 +1489,8 @@ Parameters    **item**: *dict*
                   started and executed while a plan or another foreground task is running.
                   If workflow requires executing background tasks, user code should be analyzed
                   for thread safety to ensure there are no potential threading issues.
+                  **Developers of data acquisition workflows and/or user specific code are
+                  responsible for thread safety.**
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Minor fixes in documentation. Extra tests for `status` API. Implementation of the new API `task_status`, which returns the status of one or more tasks executed by the server. The API is needed for completeness.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New `task_status` API. The API may be called for a single task from CLI as `qserver task status <task-uid>`.

### Changed

- `status` API is now returning Queue Server version number as part of `msg`, e.g. `"RE Manager v0.0.10"`.

### Removed

## How Has This Been Tested?

Unit tests were implemented.