### PR TITLE
Fix handling of negative indices by 'queue_item_add' API

### DIFF
--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -625,17 +625,19 @@ def test_add_item_to_queue_1():
             await add_plan({"name": "e"}, 5, pos=0)  # front
             await add_plan({"name": "f"}, 6, pos=5)  # back (index == queue size)
             await add_plan({"name": "g"}, 7, pos=5)  # previous to last
-            await add_plan({"name": "h"}, 8, pos=-1)  # previous to last
+            await add_plan({"name": "h"}, 8, pos=-1)  # last
             await add_plan({"name": "i"}, 9, pos=3)  # arbitrary index
             await add_plan({"name": "j"}, 10, pos=100)  # back (index some large number)
-            await add_plan({"name": "k"}, 11, pos=-10)  # front (precisely negative queue size)
-            await add_plan({"name": "l"}, 12, pos=-100)  # front (index some large negative number)
+            await add_plan({"name": "k"}, 11, pos=-11)  # front (precisely)
+            await add_plan({"name": "l"}, 12, pos=-11)  # 2nd element
+            await add_plan({"name": "m"}, 13, pos=-100)  # front (index some large negative number)
+            await add_plan({"name": "n"}, 14, pos=-2)  # previous to lasst
 
-            assert await pq.get_queue_size() == 12
+            assert await pq.get_queue_size() == 14
 
             plans, _ = await pq.get_queue()
             name_sequence = [_["name"] for _ in plans]
-            assert name_sequence == ["l", "k", "e", "d", "a", "i", "b", "c", "g", "h", "f", "j"]
+            assert name_sequence == ["m", "k", "l", "e", "d", "a", "i", "b", "c", "g", "f", "h", "n", "j"]
 
             await pq.clear_queue()
 
@@ -761,8 +763,14 @@ def test_add_item_to_queue_4_fail():
     ({"pos": "back"}, "1234", "567", "1234567"),
     ({"pos": 0}, "1234", "567", "5671234"),
     ({"pos": 1}, "1234", "567", "1567234"),
+    ({"pos": 2}, "1234", "567", "1256734"),
+    ({"pos": 4}, "1234", "567", "1234567"),
     ({"pos": 100}, "1234", "567", "1234567"),
-    ({"pos": -1}, "1234", "567", "1235674"),
+    ({"pos": -1}, "1234", "567", "1234567"),
+    ({"pos": -2}, "1234", "567", "1235674"),
+    ({"pos": -3}, "1234", "567", "1256734"),
+    ({"pos": -4}, "1234", "567", "1567234"),
+    ({"pos": -5}, "1234", "567", "5671234"),
     ({"pos": -100}, "1234", "567", "5671234"),
     ({"before_uid": "1"}, "1234", "567", "5671234"),
     ({"before_uid": "2"}, "1234", "567", "1567234"),

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -602,9 +602,10 @@ def test_queue_mode_set_2_fail(re_manager, plist, exit_code):  # noqa F811
     (2, 2, True),
     (3, 2, True),
     (100, 2, True),
-    (-1, 1, True),
-    (-2, 0, True),
+    (-1, 2, True),
+    (-2, 1, True),
     (-3, 0, True),
+    (-4, 0, True),
     (-100, 0, True),
 ])
 # fmt: on

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -1407,5 +1407,6 @@ def test_qserver_zmq_keys():
 
     # Generated public key based on private key - success
     _, private_key = generate_new_zmq_key_pair()
+    ttime.sleep(1)  # The pause may fix issues with this test
     print(f"Private key used for the test: '{private_key}'")
     assert subprocess.call(["qserver-zmq-keys", "--zmq-private-key", private_key]) == SUCCESS

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -337,9 +337,10 @@ def test_zmq_api_queue_item_add_1(re_manager):  # noqa F811
     (2, 2, True),
     (3, 2, True),
     (100, 2, True),
-    (-1, 1, True),
-    (-2, 0, True),
+    (-1, 2, True),
+    (-2, 1, True),
     (-3, 0, True),
+    (-4, 0, True),
     (-100, 0, True),
 ])
 # fmt: on
@@ -375,6 +376,7 @@ def test_zmq_api_queue_item_add_2(re_manager, pos, pos_result, success):  # noqa
 
     assert len(resp2["items"]) == (3 if success else 2)
     assert resp2["running_item"] == {}
+    print(f"QUEUE ITEMS: {pprint.pformat(resp2['items'])}")
 
     if success:
         assert resp2["items"][pos_result]["args"] == plan2["args"]
@@ -998,7 +1000,7 @@ def test_zmq_api_queue_item_execute_4_fail(re_manager):  # noqa: F811
     ({"pos": 0}, "1234", "567", "5671234", True, "" * 3),
     ({"pos": 1}, "1234", "567", "1567234", True, "" * 3),
     ({"pos": 100}, "1234", "567", "1234567", True, "" * 3),
-    ({"pos": -1}, "1234", "567", "1235674", True, "" * 3),
+    ({"pos": -1}, "1234", "567", "1234567", True, "" * 3),
     ({"pos": -100}, "1234", "567", "5671234", True, "" * 3),
     ({"before_uid": "1"}, "1234", "567", "5671234", True, "" * 3),
     ({"before_uid": "2"}, "1234", "567", "1567234", True, "" * 3),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes to how negative indices passed to `queue_item_add` API are handled. Previously, `pos=-1` would add the new element to the position previous to last. Now the new element will be added to the back of the queue if `pos=-1`, to the position previous to last if `pos=-2` etc. Now `pos` specifies the position of the added element in cases of both positive and negative indices. The changes will not break existing code unless negative indices are used to add new items in the queue.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- Fixed handling of negative item indices by `queue_item_add` API (`pos=-1` now adds an item to the back of the queue).

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
