### PR TITLE
Renamed parameters of 'permissions_reload' API. 

### DIFF
--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -823,7 +823,7 @@ def create_msg(params):
             method = f"{command}_{params[0]}"
             if len(params) == 2:
                 if params[1] == "lists":
-                    prms["reload_plans_devices"] = True
+                    prms["restore_plans_devices"] = True
                 else:
                     CommandParameterError(f"Request '{command} {params[0]} {params[1]}' is not supported")
 

--- a/bluesky_queueserver/manager/tests/test_profile_tools.py
+++ b/bluesky_queueserver/manager/tests/test_profile_tools.py
@@ -533,7 +533,7 @@ def test_is_re_worker_active_2(re_manager_cmd, tmp_path, monkeypatch, option):  
         assert False, f"Unknown option '{option}'"
 
     # Open environment and execute plan 'sim_plan_1'
-    resp1, _ = zmq_single_request("permissions_reload", {"reload_plans_devices": True})
+    resp1, _ = zmq_single_request("permissions_reload", {"restore_plans_devices": True})
     assert resp1["success"] is True, f"resp={resp1}"
 
     # Add plan to the queue

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -1245,9 +1245,9 @@ def trivial_plan_for_unit_test():
 
 
 # fmt: off
-@pytest.mark.parametrize("reload_plans_devices", [True, False])
+@pytest.mark.parametrize("restore_plans_devices", [True, False])
 # fmt: on
-def test_qserver_permissions_reload_1(re_manager_pc_copy, tmp_path, reload_plans_devices):  # noqa F811
+def test_qserver_permissions_reload_1(re_manager_pc_copy, tmp_path, restore_plans_devices):  # noqa F811
     """
     Tests for ``qserver permissions reload [lists]`` API.
     """
@@ -1266,12 +1266,12 @@ def test_qserver_permissions_reload_1(re_manager_pc_copy, tmp_path, reload_plans
 
     # Reload profile collection
     params = ["permissions", "reload"]
-    if reload_plans_devices:
+    if restore_plans_devices:
         params.append("lists")
     assert subprocess.call(["qserver", *params]) == SUCCESS
 
     # Attempt to add the plan to the queue. It should be successful now.
-    res_expected = SUCCESS if reload_plans_devices else REQ_FAILED
+    res_expected = SUCCESS if restore_plans_devices else REQ_FAILED
     assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == res_expected
 
 

--- a/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -238,7 +238,7 @@ def test_cli_update_existing_plans_devices_01(
 
     # Reload the list of existing plans and devices from disk and make sure the new device/plan
     #   is loaded/not loaded depending on the update mode.
-    resp6, _ = zmq_single_request("permissions_reload", params={"reload_plans_devices": True})
+    resp6, _ = zmq_single_request("permissions_reload", params={"restore_plans_devices": True})
     assert resp6["success"] is True
 
     new_plan_added = new_plan_added and update_existing_plans_devices != "NEVER"

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -3358,16 +3358,16 @@ def test_zmq_api_queue_mode_set_3_loop_mode(re_manager):  # noqa: F811
 #                              Method 'permissions_reload'
 
 # fmt: off
-@pytest.mark.parametrize("reload_plans_devices", [False, True])
+@pytest.mark.parametrize("restore_plans_devices", [False, True])
 # fmt: on
-def test_permissions_reload_1(re_manager_pc_copy, tmp_path, reload_plans_devices):  # noqa: F811
+def test_permissions_reload_1(re_manager_pc_copy, tmp_path, restore_plans_devices):  # noqa: F811
     """
     Comprehensive test for ``permission_reload`` API: create a copy of startup files,
     generate the lists of existing plans and devices, start RE Manager (loads the list
     of existing plans and devices from disk), add a device and a plan to startup scripts,
     generate the new lists of existing plans and devices, call ``permissions_reload``,
     check if the new device and the new plan was added to the lists of allowed plans
-    and devices (if ``reload_plans_devices`` is ``True``, then the device and the plan
+    and devices (if ``restore_plans_devices`` is ``True``, then the device and the plan
     are expected to be in the list).
     """
 
@@ -3405,7 +3405,7 @@ def test_permissions_reload_1(re_manager_pc_copy, tmp_path, reload_plans_devices
     assert "count50" not in plans_allowed
     assert "det50" not in devices_allowed
 
-    resp2, _ = zmq_single_request("permissions_reload", {"reload_plans_devices": reload_plans_devices})
+    resp2, _ = zmq_single_request("permissions_reload", {"restore_plans_devices": restore_plans_devices})
     assert resp2["success"] is True, f"resp={resp2}"
 
     # Check that 'plans_allowed_uid' and 'devices_allowed_uid' changed while permissions were reloaded
@@ -3430,7 +3430,7 @@ def test_permissions_reload_1(re_manager_pc_copy, tmp_path, reload_plans_devices
     assert plans_allowed_uid2 != plans_allowed_uid
     assert devices_allowed_uid2 != devices_allowed_uid
 
-    if reload_plans_devices:
+    if restore_plans_devices:
         assert "count50" in plans_allowed2
         assert "det50" in devices_allowed2
     else:
@@ -3489,7 +3489,7 @@ user_groups:
 # fmt: on
 def test_permissions_reload_2(re_manager_pc_copy, reload_permissions_from_disk):  # noqa: F811
     """
-    Tests for ``permissions_reload`` API: check if parameter ``reload_permissions`` works correctly.
+    Tests for ``permissions_reload`` API: check if parameter ``restore_permissions`` works correctly.
     """
     _, pc_path = re_manager_pc_copy
 
@@ -3502,7 +3502,7 @@ def test_permissions_reload_2(re_manager_pc_copy, reload_permissions_from_disk):
     # Now reload permissions. The new lists of allowed plans and devices must be generated
     params = {}
     if reload_permissions_from_disk in (True, False):
-        params["reload_permissions"] = reload_permissions_from_disk
+        params["restore_permissions"] = reload_permissions_from_disk
 
     resp1, _ = zmq_single_request("permissions_reload", params=params)
     assert resp1["success"] is True, f"resp={resp1}"
@@ -4028,7 +4028,7 @@ def test_re_runs_1(re_manager_pc_copy, tmp_path, test_with_manager_restart):  # 
     plans_allowed_uid = status["plans_allowed_uid"]
     devices_allowed_uid = status["devices_allowed_uid"]
 
-    resp1, _ = zmq_single_request("permissions_reload", {"reload_plans_devices": True})
+    resp1, _ = zmq_single_request("permissions_reload", {"restore_plans_devices": True})
     assert resp1["success"] is True, f"resp={resp1}"
 
     # Check that 'plans_allowed_uid' and 'devices_allowed_uid' changed while permissions were reloaded

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -106,7 +106,7 @@ The parameter allows to select between the following modes for updating the list
   devices that could be used during the current session, but it will not be saved to the file.
   The next time Queue Server is started, the original lists of existing plans and devices
   is loaded from disk. :ref:`method_permissions_reload` 0MQ API called with parameter
-  ``reload_plans_devices=True`` will also reload the original list from disk. Restarting
+  ``restore_plans_devices=True`` will also reload the original list from disk. Restarting
   the RE Manager process while the environment is open will not read the list of existing
   plans and devices from disk. This option may be used in workflows with 'static', rarely
   changed startup scripts where it is preferred that the lists of existing plans and devices

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -1530,7 +1530,7 @@ Description   Returns the status of one or more tasks executed by the worker pro
               the method will return the task status as *'not_found'*.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **task_uid**: *str* or *list(str)*
-                  Task UID.
+                  Task UID or a list of task UIDs.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1538,13 +1538,13 @@ Returns       **success**: *boolean*
               **msg**: *str*
                   error message in case of failure, empty string ('') otherwise.
 
-              **task_uid**: *str* or *None*
-                  task UID (expected to be the same as the input parameter) or *None* if
-                  the request failed.
+              **task_uid**: *str*, *list(str)* or *None*
+                  task UID or a list of task UIDs (expected to be the same as the input parameter).
+                  May be *None* if the request fails.
 
               **status**: *str* or *dict*
                   status of the task(s) or *None* if the request (not task) failed. If **task_uid**
-                  is a string representing single UID, then **status** is a string that may be one
+                  is a string representing single UID, then **status** is a string, which is one of
                   of *'running'*, *'completed'* or *'not_found'*. If **task_uid** is a list of strings,
                   then *'status'* is a dictionary that maps task UIDs to status of the respective tasks.
 ------------  -----------------------------------------------------------------------------------------
@@ -1575,8 +1575,8 @@ Returns       **success**: *boolean*
                   error message in case of failure, empty string ('') otherwise.
 
               **task_uid**: *str* or *None*
-                  task UID (expected to be the same as the input parameter) or *None* if
-                  the request failed.
+                  task UID (expected to be the same as the input parameter). May be *None* if
+                  the request fails.
 
               **status**: *'running'*, *'completed'*, *'not_found'* or *None*
                   status of the task or *None* if the request (not task) failed.

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -724,7 +724,7 @@ Parameters    **item**: *dict*
                   the name of the user group (e.g. 'admin').
 
               **user**: *str*
-                  the name of the user (e.g. 'John Doe'). The name is included in the item metadata
+                  the name of the user (e.g. 'Default User'). The name is included in the item metadata
                   and may be used to identify the user who added the item to the queue. It is not
                   passed to the Run Engine or included in run metadata.
 
@@ -784,7 +784,7 @@ Parameters    **items**: *list*
                   the name of the user group (e.g. 'admin').
 
               **user**: *str*
-                  the name of the user (e.g. 'John Doe'). The name is included in the item metadata
+                  the name of the user (e.g. 'Default User'). The name is included in the item metadata
                   and may be used to identify the user who added the item to the queue. It is not
                   passed to the Run Engine or included in run metadata.
 
@@ -861,7 +861,7 @@ Parameters    **item**: *dict*
                   the name of the user group (e.g. 'admin').
 
               **user**: *str*
-                  the name of the user (e.g. 'John Doe'). The name is included in the item metadata
+                  the name of the user (e.g. 'Default User'). The name is included in the item metadata
                   and may be used to identify the user who added the item to the queue. It is not
                   passed to the Run Engine or included in run metadata.
 
@@ -1157,7 +1157,7 @@ Parameters    **item**: *dict*
                   the name of the user group (e.g. 'admin').
 
               **user**: *str*
-                  the name of the user (e.g. 'John Doe'). The name is included in the item metadata
+                  the name of the user (e.g. 'Default User'). The name is included in the item metadata
                   and may be used to identify the user who added the item to the queue. It is not
                   passed to the Run Engine or included in run metadata.
 ------------  -----------------------------------------------------------------------------------------
@@ -1479,7 +1479,7 @@ Parameters    **item**: *dict*
                   the name of the user group (e.g. 'admin').
 
               **user**: *str*
-                  the name of the user (e.g. 'John Doe'). The name is included in the item metadata
+                  the name of the user (e.g. 'Default User'). The name is included in the item metadata
                   and may be used to identify the user who submitted the item.
 
               **run_in_background**: *boolean* (optional, default *False*)

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -215,6 +215,9 @@ Returns       **msg**: *str*
                  UID for the list of existing devices in RE Worker namespace. Similar to
                  **plans_allowed_uid**.
 
+              **'run_list_uid'** - UID of the list of the active runs. Monitor this UID and
+                  load the updated list of active runs once the UID is changed.
+
               **manager_state**: *str*
                   state of RE Manager. Supported states:
 
@@ -238,11 +241,6 @@ Returns       **msg**: *str*
 
                   - **'destroying_environment'** - RE Worker environment is in the process of being
                     destroyed (emergency).
-
-                  - **'re_state'** - state of Run Engine (see Bluesky documentation).
-
-                  - **'run_list_uid'** - UID of the list of the active runs. Monitor this UID and
-                    load the updated list of active runs once the UID is changed.
 
               **re_state**: *str* or *None*
                   current state of Bluesky Run Engine (see Blue Sky documentation) or *None* if

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -1139,9 +1139,7 @@ Description   Immediately start execution of the submitted item. The item may be
               in RE Worker environment. Interactive workflows may be used for calibration of
               the instrument, while the queue may be used to run sequences of scheduled experiments.
 
-              Internally the API request adds the submitted item to the front of the queue
-              and immediately attempts to start its execution. The item is removed from the queue
-              almost immediately and never pushed back into the queue. If the item is a plan,
+              The item is not added to the queue or change the existing queue. If the item is a plan,
               the results of execution are added to plan history as usual. The respective history
               item could be accessed to check if the plan was executed successfully.
 
@@ -1168,12 +1166,11 @@ Returns       **success**: *boolean*
                   error message in case of failure, empty string ('') otherwise.
 
               **qsize**: *int* or *None*
-                  the number of items in the plan queue after the plan was added if
-                  the operation was successful, *None* otherwise
+                  the number of items in the plan queue, *None* if request fails otherwise.
 
               **item**: *dict* or *None* (optional)
                   the inserted item. The item contains the assigned item UID. In case of error
-                  the item may be returned without modification (with assigned UID). *None* will be
+                  the item may be returned without modification (with assigned UID). *None* is
                   returned if request does not contain item parameters.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -422,14 +422,14 @@ Description   Reload user group permissions from the default location or the loc
               command line parameters and generate lists of allowed plans and devices based on
               the lists of existing plans and devices. By default, the method will use current lists
               of existing plans and devices stored in memory. Optionally the method can reload the
-              lists from the disk file (see *reload_plans_devices* parameter). The method always
+              lists from the disk file (see *restore_plans_devices* parameter). The method always
               updates UIDs of the lists of allowed plans and devices even if the contents remain
               the same.
 ------------  -----------------------------------------------------------------------------------------
-Parameters    **reload_plans_devices**: *boolean* (optional)
+Parameters    **restore_plans_devices**: *boolean* (optional)
                   reload the lists of existing plans and devices from disk if *True*, otherwise
                   use current lists stored in memory. Default: *False*.
-              **reload_permissions**: *boolean* (optional)
+              **restore_permissions**: *boolean* (optional)
                   reload user group permissions from disk if *True*, otherwise use current permissions.
                   Default: *True*.
 ------------  -----------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Renamed parameters of `permissions_reload` API. The parameters control if permissions or existing plans and devices are reloaded from disk files (or Redis):  `reload_permissions` is renamed to `restore_permissions`, `reload_plans_devices` is renamed to `restore_plans_devices`.
- Minor fixes to API documentation.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

- Renamed parameters of `permissions_reload` API: `reload_permissions` is renamed to `restore_permissions`, `reload_plans_devices` is renamed to `restore_plans_devices`.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests are modified to work with updated parameter names.

<!--
## Screenshots (if appropriate):
-->
