### PR TITLE
PERF: Disable plots in best effort callback

### DIFF
--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1024,6 +1024,7 @@ class RunEngineWorker(Process):
                         # Documents from each run are routed to an independent
                         #   instance of BestEffortCallback
                         bec = BestEffortCallback()
+                        bec.disable_plots()
                         return [bec], []
 
                     # Subscribe to Best Effort Callback in the way that works with multi-run plans.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Disable plots as they are not used anyway
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Plotting incurs a significant (~150 ms per read, more if you have more channels) time delay that serves no real purpose as the queueserver is running headless and does not save the plots to images either.

This still has the live table (with BEC determined columns).

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed
- No longer plot with best effort callback (improves performance)

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
