### PR TITLE
Processing of invalid 0MQ requests

### DIFF
--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -15,13 +15,15 @@ logger = logging.getLogger(__name__)
 _fixed_public_key = "wt8[6a8eoXFRVL<l2JBbOzs(hcI%kRBIr0Do/eLC"
 _fixed_private_key = "=@e7WwVuz{*eGcnv{AL@x2hmX!z^)wP3vKsQ{S7s"
 
+default_zmq_server_address = "tcp://localhost:60615"
+
 
 class CommTimeoutError(TimeoutError):
     """
     Raised when communication error occurs
     """
 
-    pass
+    ...
 
 
 class CommJsonRpcError(RuntimeError):
@@ -556,7 +558,7 @@ class ZMQCommSendThreads:
         if server_public_key is not None:
             validate_zmq_key(server_public_key)
 
-        zmq_server_address = zmq_server_address or "tcp://localhost:60615"
+        zmq_server_address = zmq_server_address or default_zmq_server_address
         self._server_public_key = server_public_key
 
         self._timeout_receive = timeout_recv  # Timeout for 'recv' operation (ms)
@@ -893,7 +895,7 @@ class ZMQCommSendAsync:
     ):
         self._loop = loop if loop else asyncio.get_event_loop()
 
-        zmq_server_address = zmq_server_address or "tcp://localhost:60615"
+        zmq_server_address = zmq_server_address or default_zmq_server_address
         self._server_public_key = server_public_key
 
         self._timeout_receive = timeout_recv  # Timeout for 'recv' operation (ms)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Implemented validation of 0MQ requests and orderly processing of invalid requests. 

## Description
<!--- Describe your changes in detail -->

Queue Server may accidentally receive requests that are not JSON or contain invalid JSON. Those requests must be properly processed and should not influence operation of the server. The PR implements basic processing for such requests. If invalid request is received, the server responds by sending ``success: False`` and error message to the sender. The requests do not influence operation of the server.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It was reported that Queue Server behaves incorrectly if the respective 0MQ port is probed by the security scanner. The changes implemented in this PR may fix the issue. Otherwise the issue will need to be further investigated.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- Implemented proper handling of non-JSON or invalid JSON requests.

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were implemented.
