### PR TITLE
Fixed capture of console output with special sequences in Python 3.8, 3.9

### DIFF
--- a/bluesky_queueserver/manager/output_streaming.py
+++ b/bluesky_queueserver/manager/output_streaming.py
@@ -38,6 +38,7 @@ class ConsoleOutputStream(io.TextIOBase):
         Overrides the method of ``io.TextIOBase``.
         """
         s = str(s)
+
         msg = {"time": ttime.time(), "msg": s}
         self._msg_queue.put(msg)
         return len(s)
@@ -69,6 +70,19 @@ def setup_console_output_redirection(msg_queue):
     if msg_queue:
         fobj = ConsoleOutputStream(msg_queue=msg_queue)
         redirect_output_streams(fobj)
+
+        # Disable 'colorama' (used by Bluesky). We don't need it in Queue Server.
+        #   Colorama overrides 'sys.stdout' and interferes with capturing console output.
+        def do_nothing(*args, **kwargs):
+            ...
+
+        try:
+            import colorama
+
+            colorama.init = do_nothing
+            colorama.reinit = do_nothing
+        except Exception:
+            pass
 
 
 _default_zmq_console_topic = "QS_Console"

--- a/bluesky_queueserver/profile_collection_sim/99-custom.py
+++ b/bluesky_queueserver/profile_collection_sim/99-custom.py
@@ -221,3 +221,58 @@ def count_bundle_test(detectors, num=1, delay=None, *, per_shot=None, md=None):
 
 
 # =======================================================================================
+#                Plans for testing visualization of Progress Bars
+
+from bluesky.utils import ProgressBar
+
+
+class StatusPlaceholder:
+    "Just enough to make ProgressBar happy. We will update manually."
+
+    def __init__(self):
+        self.done = False
+
+    def watch(self, _):
+        ...
+
+
+def plan_test_progress_bars(n_progress_bars: int = 1):
+    """
+    Test visualization of progress bars.
+
+    Parameters
+    ----------
+    n_progress_bars: int
+        The number of progress bars to display.
+    """
+    # Display at least one progress bar
+    n_progress_bars = max(n_progress_bars, 1)
+
+    # where the status object computes the fraction
+    st_list = [StatusPlaceholder() for _ in range(n_progress_bars)]
+    pbar = ProgressBar(st_list)
+
+    v_min = 0
+    v_max = 1
+
+    n_pts = 10
+    step = (v_max - v_min) / n_pts
+
+    print(f"TESTING {n_progress_bars} PROGRESS BARS ...\n")
+
+    for n in range(n_pts):
+        yield from bps.sleep(0.5)
+        v = v_min + (n + 1) * step
+        for n_pb in range(n_progress_bars):
+            pbar.update(n_pb, name=f"TEST{n_pb + 1}", current=v, initial=v_min, target=v_max, fraction=n / n_pts)
+
+    for st in st_list:
+        st.done = True
+    for n_pb in range(n_progress_bars):
+        pbar.update(n_pb, name=f"TEST{n_pb + 1}", current=1, initial=0, target=1, fraction=1)
+
+    s = "\n" * n_progress_bars
+    print(f"{s}\nTEST COMPLETED ...")
+
+
+# =======================================================================================

--- a/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
+++ b/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
@@ -2045,6 +2045,20 @@ existing_plans:
       step: '0.01'
     properties:
       is_generator: true
+  plan_test_progress_bars:
+    description: Test visualization of progress bars.
+    name: plan_test_progress_bars
+    parameters:
+    - annotation:
+        type: int
+      default: '1'
+      description: The number of progress bars to display.
+      kind:
+        name: POSITIONAL_OR_KEYWORD
+        value: 1
+      name: n_progress_bars
+    properties:
+      is_generator: true
   ramp_plan:
     description: Take data while ramping one or more positioners.
     module: bluesky.plans


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix the mechanism of capturing console output with special sequences in Python 3.8, 3.9. It was discovered that `colorama` package replaces `sys.stdout` and removes some special sequences from captured output. Progress bars were not displayed by RE Manager or remote monitor as a result. 

Additional plan `plan_test_progress_bars()` was added to the simulated profile collection. The plan displays multiple dynamically changing progress bars and could be used to verify if progress bars are correctly displayed by the Queue Server or remote monitor.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- Console output containing dynamically changing progress bars is now properly captured and displayed under Python 3.8, 3.9.

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
