### PR TITLE
Revisit the code for reporting 'exit_status' and error message for plans

### DIFF
--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -318,20 +318,21 @@ def test_qserver_re_pause_continue(re_manager, option_pause, option_continue):  
         assert wait_for_condition(time=3, condition=condition_manager_idle)
 
         n_plans, is_plan_running, n_history = get_reduced_state_info()
-        assert n_plans == 2, "Incorrect number of plans in the queue"
+        assert n_plans == (1 if option_continue == "stop" else 2), "Incorrect number of plans in the queue"
         assert is_plan_running is False
         assert n_history == 1
 
         assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
 
-        n_history_expected = 3  # Includes entry related to 1 stopped plan
+        # Includes entry related to 1 aborted or halted plan
+        n_history_expected = (2 if option_continue == "stop" else 3)
 
     ttime.sleep(1)
 
     n_plans, is_plan_running, n_history = get_reduced_state_info()
-    assert n_plans == 1, "Incorrect number of plans in the queue"
+    assert n_plans == (0 if option_continue == "stop" else 1), "Incorrect number of plans in the queue"
     assert is_plan_running is True
-    assert n_history == n_history_expected - 2
+    assert n_history == n_history_expected - (1 if option_continue == "stop" else 2)
 
     assert wait_for_condition(
         time=60, condition=condition_queue_processing_finished

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -325,7 +325,7 @@ def test_qserver_re_pause_continue(re_manager, option_pause, option_continue):  
         assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
 
         # Includes entry related to 1 aborted or halted plan
-        n_history_expected = (2 if option_continue == "stop" else 3)
+        n_history_expected = 2 if option_continue == "stop" else 3
 
     ttime.sleep(1)
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -4094,12 +4094,8 @@ def test_zmq_api_re_pause_3(re_manager, continue_option, loop_mode):  # noqa: F8
     resp4, _ = zmq_single_request("history_get")
     assert resp4["success"] is True
     result = resp4["items"][0]["result"]
-    assert result["exit_status"] == {
-        "re_resume": "completed",
-        "re_stop": "stopped",
-        "re_abort": "aborted",
-        "re_halt": "halted",
-    }[continue_option]
+    result_options = {"re_resume": "completed", "re_stop": "stopped", "re_abort": "aborted", "re_halt": "halted"}
+    assert result["exit_status"] == result_options[continue_option]
     assert result["msg"] == ""
     assert isinstance(result["time_start"], float)
     assert isinstance(result["time_stop"], float)

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -4503,7 +4503,7 @@ def test_zmq_api_queue_execution_2(re_manager):  # noqa: F811
     assert wait_for_condition(time=20, condition=condition_manager_paused)
     uid_checker.verify_uid_changes(pq_changed=False, ph_changed=False)
 
-    resp5b, _ = zmq_single_request("re_stop")
+    resp5b, _ = zmq_single_request("re_abort")
     assert resp5b["success"] is True, str(resp5b)
 
     assert wait_for_condition(time=20, condition=condition_manager_idle)

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -196,13 +196,13 @@ class RunEngineWorker(Process):
                 # Clear the list of active runs
                 self._active_run_list.clear()
 
-        except BaseException as ex:
+        except BaseException:
             with self._re_report_lock:
 
                 self._re_report = {
                     "action": "plan_exit",
                     "result": "",
-                    "err_msg": str(ex),
+                    "err_msg": traceback.format_exc(),
                 }
 
                 if self._RE._state == "paused":

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -519,6 +519,26 @@ Returns       **success**: *boolean*
                   list of items in the plan history, each item is represented by a dictionary of
                   item parameters. Currently the plan history may contain only plans.
 
+                  The dictionary contains a copy of the original item parameters and dictionary with results of
+                  execution (**'result'** key), which contains the following keys:
+
+                  - **exit_status** - exit status of the plan. The values are **'completed'** (the plan execution
+                    is successfully completed), **'failed'** (the plan execution failed; a plan can fail due to
+                    multiple reasons, including internal error of RE Manager; see the error message to determine
+                    the reason of failure), **'stopped'** (the plan was paused, then stopped; the plan is considered
+                    successfully executed), **'abort'** and **'halt'** (the plan was paused, then aborted or halted;
+                    the plan is considered failed), **'unknown'** (the exit status information is lost, e.g. due
+                    to restart of RE Manager process, but plan information still needs to be placed in the history;
+                    this is very unlikely to happen in practice);
+
+                  - **run_uids** - list of UIDs of runs executed by the plan;
+
+                  - **time_start** and **time_stop** - time of start and completion of the plan (not runs),
+                    floating point number returned by *time.time()*.
+
+                  - **msg** - error message and/or trace back in case of plan failure, empty string if no
+                    message is returned.
+
               **plan_history_uid**: *str*
                   current plan history UID.
 ------------  -----------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Revised the set of `exit_status` values included in plan history. The original set of `exit_status` values was excessive, incomplete and not systematic. Now exit status may take values: `completed`, `stopped` (successful completion) and `failed`, `aborted`, `halted` (failed). Additionally `exit_status` may take the value `unknown` in case the status completion data is lost, for example if during startup or restart RE Manager detects a plan that was set for execution, but not completed and no information on the results of execution could be loaded from RE Worker environment. This is should not happen often in practice. 

The `stopped` plans are considered successful and no longer pushed back in the queue. The `stopped` plans are inserted in the back of the queue in LOOP mode.

Additionally, error message (`msg`) is included in the plan results. If a plan fails, the error message may contain full traceback.

## Description
<!--- Describe your changes in detail -->

The following is an example of the result of execution of `count` plan returned as part of the plan history. 
```
'items': [{'args': [['det1', 'det2']],
            'item_type': 'plan',
            'item_uid': '41822de0-7436-4dca-a68c-18d4a2b07c6e',
            'kwargs': {'delay': 1, 'num': 10},
            'name': 'count',
            'result': {'exit_status': 'completed',
                       'msg': '',
                       'run_uids': ['9e3a263b-25d2-4254-b89b-4e935b53b335'],
                       'time_start': 1650396524.1242433,
                       'time_stop': 1650396534.5154896},
            'user': 'qserver-cli',
            'user_group': 'admin'}],
```
In this PR a set of values returned as `items[0]["result"]["exit_status"]` is revised: `completed`, `failed`, `stopped`, `aborted`, `halted`, `unknown`. The error message `items[0]["result"]["msg"]` is added to the result section. The error message includes full traceback in case of plan failure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The code had to be revisited to implement complete set of `exit_status` values.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Plan results (in plan history) now include error message (`msg` key), which contains error message or full traceback in case of failing plan.

### Changed

- The plan `exit_status` (in plan history) now takes values `completed`, `failed`, `stopped`, `aborted`, `halted`, `unknown`.

- The `stopped` plans (`re_stop` API) are considered successful and no longer pushed back in the queue. The `stopped` plans are inserted in the back of the queue in LOOP mode.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
