### PR TITLE
Support for 'environment_destroy' API in 'creating_environment' state of RE Manager

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 
 ## Summary of Changes for Release Notes
 <!--- Brief summary of changes that could be copied to the Release Notes. -->
-<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
+<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
 <!--- PRs with feature changes will not be merged without this section filled. -->
 
 <!--- Group the changes in the following sections: -->

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -640,6 +640,9 @@ Method        **'environment_destroy'**
 ------------  -----------------------------------------------------------------------------------------
 Description   Initiate the operation of destroying of the existing (unresponsive) RE Worker
               environment. The operation fails if there is no existing environment.
+              The request is accepted by the server if status fields **worker_environment_exists** is
+              *True* or **manager_state** is *'creating_environment'*, otherwise the request is 
+              rejected.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    ---
 ------------  -----------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Enable support for `environment_destroy` API in `creating_environment` state of RE Manager. This allows to remotely destroy environment in case execution of the startup script gets stuck in the infinite wait or loop. The changes are not expected to affect execution of the existing code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The operation of destroying the RE Worker environment is intended for remote recovery of the server if the environment becomes unresponsive due to crashing or freezing of the user code. This is possible on the stages of opening the environment (execution of startup scripts) and while running a plan or a task (existing environment). Originally requests to destroy the environment were supported only if the environment existed (loading of startup scripts was completed). The requests were rejected if the environment was in the process of being opened. This PR implements support for the requests in the state when the environment is in the process of being opened.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Support for `environment_destroy` API in `creating_environment` RE Manager state. Now the requests to destroy environment are accepted when `status["worker_environment_exists"] is True` or `status["manager_state"] == "creating_environment"`.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
