### PR TITLE
Make API for generation of encryption keys importable directly from the 'bluesky_queueserver'

### DIFF
--- a/bluesky_queueserver/__init__.py
+++ b/bluesky_queueserver/__init__.py
@@ -3,7 +3,14 @@ from ._version import get_versions
 __version__ = get_versions()["version"]
 del get_versions
 
-from .manager.comms import ZMQCommSendAsync, ZMQCommSendThreads, CommTimeoutError  # noqa: E402, F401
+from .manager.comms import (  # noqa: E402, F401
+    ZMQCommSendAsync,
+    ZMQCommSendThreads,
+    CommTimeoutError,
+    generate_new_zmq_key_pair as generate_zmq_keys,
+    generate_zmq_public_key,
+    validate_zmq_key,
+)
 from .manager.annotation_decorator import parameter_annotation_decorator  # noqa: E402, F401
 from .manager.output_streaming import ReceiveConsoleOutput, ReceiveConsoleOutputAsync  # noqa: E402, F401
 

--- a/bluesky_queueserver/__init__.py
+++ b/bluesky_queueserver/__init__.py
@@ -7,7 +7,7 @@ from .manager.comms import (  # noqa: E402, F401
     ZMQCommSendAsync,
     ZMQCommSendThreads,
     CommTimeoutError,
-    generate_new_zmq_key_pair as generate_zmq_keys,
+    generate_zmq_keys,
     generate_zmq_public_key,
     validate_zmq_key,
 )

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -1050,6 +1050,9 @@ def zmq_single_request(method, params=None, *, zmq_server_address=None, server_p
     params: dict or None
         Dictionary of parameters (payload of the message). If ``None`` then
         the message is sent with empty payload: ``params = {}``.
+    zmq_server_address: str or None
+        Address of the ZMQ control socket of RE Manager. Default address is used if the
+        value is ``None``.
     server_public_key: str or None
         Server public key (z85-encoded 40 character string). The Valid public key from the server
         public/private key pair must be passed if encryption is enabled at the 0MQ server side.

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -431,7 +431,7 @@ class PipeJsonRpcSendAsync:
 #                      Generation and validation of ZMQ key pairs
 
 
-def generate_new_zmq_key_pair():
+def generate_zmq_keys():
     """
     Generates new public-private key pair for ZMQ encryption.
 

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -13,7 +13,7 @@ from .comms import (
     zmq_single_request,
     validate_zmq_key,
     generate_zmq_public_key,
-    generate_new_zmq_key_pair,
+    generate_zmq_keys,
     default_zmq_control_address,
 )
 
@@ -1181,7 +1181,7 @@ def qserver_zmq_keys():
             public_key = generate_zmq_public_key(private_key)
             msg = "Private key generated based on provided private key."
         else:
-            public_key, private_key = generate_new_zmq_key_pair()
+            public_key, private_key = generate_zmq_keys()
             msg = "New public-private key pair."
 
         print("====================================================================================")

--- a/bluesky_queueserver/manager/tests/test_comms.py
+++ b/bluesky_queueserver/manager/tests/test_comms.py
@@ -13,7 +13,7 @@ from bluesky_queueserver.manager.comms import (
     CommJsonRpcError,
     ZMQCommSendThreads,
     ZMQCommSendAsync,
-    generate_new_zmq_key_pair,
+    generate_zmq_keys,
     generate_zmq_public_key,
     validate_zmq_key,
 )
@@ -676,9 +676,9 @@ def test_PipeJsonRpcSendAsync_7_fail():
 
 def test_generate_zmq_keys():
     """
-    Functions ``generate_new_zmq_key_pair()``, ``generate_zmq_public_key()`` and ``validate_zmq_key()``.
+    Functions ``generate_zmq_keys()``, ``generate_zmq_public_key()`` and ``validate_zmq_key()``.
     """
-    key_public, key_private = generate_new_zmq_key_pair()
+    key_public, key_private = generate_zmq_keys()
     assert isinstance(key_public, str)
     assert len(key_public) == 40
     assert isinstance(key_private, str)
@@ -715,7 +715,7 @@ def test_validate_zmq_key(key):
 def _gen_server_keys(*, encryption_enabled):
     """Generate server keys and a set of kwargs."""
     if encryption_enabled:
-        public_key, private_key = generate_new_zmq_key_pair()
+        public_key, private_key = generate_zmq_keys()
         server_kwargs = {"private_key": private_key}
     else:
         public_key, private_key = None, None

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -5,7 +5,7 @@ import os
 import yaml
 
 from bluesky_queueserver.manager.profile_ops import gen_list_of_plans_and_devices
-from bluesky_queueserver.manager.comms import generate_new_zmq_key_pair
+from bluesky_queueserver.manager.comms import generate_zmq_keys
 
 from .common import (
     patch_first_startup_file,
@@ -1339,7 +1339,7 @@ def test_qserver_secure_1(monkeypatch, re_manager_cmd, test_mode):  # noqa: F811
     Test operation of `qserver` CLI tool with enabled encryption. Test options to
     set the private key used by `qserver` using the environment variable.
     """
-    public_key, private_key = generate_new_zmq_key_pair()
+    public_key, private_key = generate_zmq_keys()
 
     if test_mode == "none":
         pass
@@ -1454,6 +1454,6 @@ def test_qserver_zmq_keys():
     assert subprocess.call(["qserver-zmq-keys", "--zmq-private-key", "abc"]) == EXCEPTION_OCCURRED
 
     # Generated public key based on private key - success
-    _, private_key = generate_new_zmq_key_pair()
+    _, private_key = generate_zmq_keys()
     print(f"Private key used for the test: '{private_key}'")
     assert subprocess.call(["qserver-zmq-keys", f"--zmq-private-key={private_key}"]) == SUCCESS

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -31,7 +31,7 @@ from ..comms import (
     ZMQCommSendThreads,
     ZMQCommSendAsync,
     CommTimeoutError,
-    generate_new_zmq_key_pair,
+    generate_zmq_keys,
     default_zmq_control_address,
 )
 
@@ -4711,7 +4711,7 @@ def test_zmq_api_queue_execution_3(monkeypatch, re_manager_cmd, test_mode):  # n
     Test operation of RE Manager and 0MQ API with enabled encryption. Test options to
     set the server (RE Manager) private key using the environment variable.
     """
-    public_key, private_key = generate_new_zmq_key_pair()
+    public_key, private_key = generate_zmq_keys()
 
     if test_mode == "none":
         # No encryption


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Make API for generation of encryption key pairs (`generate_zmq_keys`, `generate_zmq_public_key`, `validate_zmq_key`) importable from `bluesky_queueserver`. 

The changes also include minor fixes to docstrings and minor refactoring of `zmq_secure_request` function used in unit tests.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- API functions `generate_zmq_keys`, `generate_zmq_public_key`, `validate_zmq_key` can now be imported directly from `bluesky_queueserver`.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
