### PR TITLE
Patch `__file__` in startup scripts. Do not automatically look for subdevices of Area Detectors. 

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -146,6 +146,15 @@ def _patch_profile(file_name):
         for lp in patch2_lines:
             stream.write(prefix + lp + "\n")
 
+    def patch__file__(stream, file_name):
+        """
+        Patch ``__file__`` for the current file with ``file_name`` so that
+        the path to the original file name and location could be accessed by
+        the user script.
+        """
+        patch_line = " " * 4 + f"__file__ = '{file_name}'\n"
+        stream.write(patch_line)
+
     def get_prefix(s):
         # Returns the sequence of spaces and tabs at the beginning of the code line
         prefix = ""
@@ -161,6 +170,7 @@ def _patch_profile(file_name):
         fln_out.writelines(_patch1)
         if patch_first:
             apply_patch2(fln_out, "")
+        patch__file__(fln_out, file_name)
         for line in code:
             fln_out.write(" " * 4 + line)
             if is_get_ipython_in_line(line) == GetIPythonUsed.IMPORTED:

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2805,7 +2805,7 @@ def _prepare_plans(plans, *, existing_devices):
     }
 
 
-def _prepare_devices(devices, *, max_depth=0, ignore_all_subdevices_if_one_fails=True):
+def _prepare_devices(devices, *, max_depth=0, ignore_all_subdevices_if_one_fails=True, expand_areadetectors=False):
     """
     Prepare dictionary of existing devices for saving to YAML file.
     ``max_depth`` is the maximum depth for the components. The default value (50)
@@ -2824,6 +2824,10 @@ def _prepare_devices(devices, *, max_depth=0, ignore_all_subdevices_if_one_fails
         be accessed. It saves a lot of time to ignore all components, since
         stale code may contain devices with many components with non-existing PVs
         and respective timeout may amount to substantial waiting time.
+    expand_areadetectors: bool
+        Find subdevices of areadetectors. It may take significant time to expand an
+        areadetector and it is unlikely that the areadetector subdevices should be
+        accessed via plan parameters.
 
     Returns
     -------
@@ -2836,6 +2840,8 @@ def _prepare_devices(devices, *, max_depth=0, ignore_all_subdevices_if_one_fails
         from bluesky import protocols
     except ImportError:
         import bluesky_queueserver.manager._protocols as protocols
+
+    from ophyd.areadetector import ADBase
 
     def get_device_params(device):
         return {
@@ -2859,7 +2865,11 @@ def _prepare_devices(devices, *, max_depth=0, ignore_all_subdevices_if_one_fails
         description = get_device_params(device)
         comps = get_device_component_names(device)
         components = {}
-        if not max_depth or (depth < max_depth - 1):
+
+        is_areadetector = isinstance(device, ADBase)
+        expand = not is_areadetector or expand_areadetectors
+
+        if expand and (not max_depth or (depth < max_depth - 1)):
             ignore_subdevices = False
             for comp_name in comps:
                 try:

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -406,6 +406,36 @@ def test_load_profile_collection_6(tmp_path, monkeypatch):
     _verify_happi_namespace(nspace)
 
 
+code_script__file__1 = """
+file_name1 = __file__
+"""
+
+code_script__file__2 = """
+file_name2 = __file__
+"""
+
+
+def test_load_profile_collection_7(tmp_path):
+    """
+    ``load_profile_collection``: test that the ``__file__`` variable is patched
+    """
+
+    pc_path = os.path.join(tmp_path, "profile_collection")
+    pc_fln_1 = os.path.join(pc_path, "startup_script_1.py")
+    pc_fln_2 = os.path.join(pc_path, "startup_script_2.py")
+    os.makedirs(pc_path, exist_ok=True)
+
+    with open(pc_fln_1, "w") as f:
+        f.writelines(code_script__file__1)
+    with open(pc_fln_2, "w") as f:
+        f.writelines(code_script__file__2)
+
+    nspace = load_profile_collection(pc_path)
+
+    assert nspace["file_name1"] == pc_fln_1
+    assert nspace["file_name2"] == pc_fln_2
+
+
 _startup_script_1 = """
 from ophyd.sim import det1, det2
 from bluesky.plans import count

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -417,7 +417,7 @@ file_name2 = __file__
 
 def test_load_profile_collection_7(tmp_path):
     """
-    ``load_profile_collection``: test that the ``__file__`` variable is patched
+    ``load_profile_collection``: test that the ``__file__`` is patched
     """
 
     pc_path = os.path.join(tmp_path, "profile_collection")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The changes in this PR were implemented to minimize modifications of startup scripts and workflow of SRX beamline:

- The global variable `__file__` is set to the path of the original script, not the temporary file with the patched version of the script. The patching is performed only for IPython-style startup scripts.

- Queue Server is no longer automatically search for components (subdevices) of Area Detectors (subclasses of `ADBase`). Scanning for components of an Area Detector involves instantiation of hundreds of unnecessary classes and attempts to communicate to non-existing PVs and may take multiple minutes. Components of Area Detectors are very unlikely to be used as plan parameters so the change is not expected to influence functionality. Means to override the default behavior, e.g. to include specific subdevice in the list, will be added in the future.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The changes were implemented in the process of preparation of testing the Queue Server at SRX beamline at NSLS-II. 

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Patching of IPython-style startup scripts: `__file__` variable now returns the path to the original unpatched script.

### Changed

- The components of Area Detectors are no longer included in the list of available devices.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Additional unit tests were implemented.
