### PR TITLE
Patching IPython code with comments

### DIFF
--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -1645,7 +1645,7 @@ class PlanQueueOperations:
         async with self._lock:
             return await self._set_next_item_as_running(item=item)
 
-    async def _set_processed_item_as_completed(self, exit_status, run_uids, err_msg):
+    async def _set_processed_item_as_completed(self, *, exit_status, run_uids, err_msg, err_tb):
         """
         See ``self.set_processed_item_as_completed`` method.
         """
@@ -1670,6 +1670,7 @@ class PlanQueueOperations:
             item_cleaned["result"]["time_start"] = item_time_start
             item_cleaned["result"]["time_stop"] = ttime.time()
             item_cleaned["result"]["msg"] = err_msg
+            item_cleaned["result"]["traceback"] = err_tb
             await self._clear_running_item_info()
             if not loop_mode and not immediate_execution:
                 self._uid_dict_remove(item["item_uid"])
@@ -1679,7 +1680,7 @@ class PlanQueueOperations:
             item_cleaned = {}
         return item_cleaned
 
-    async def set_processed_item_as_completed(self, exit_status, run_uids, err_msg):
+    async def set_processed_item_as_completed(self, *, exit_status, run_uids, err_msg, err_tb):
         """
         Moves currently executed item (plan) to history and sets ``exit_status`` key.
         UID is removed from ``self._uid_dict``, so a copy of the item with
@@ -1696,7 +1697,9 @@ class PlanQueueOperations:
         run_uids: list(str)
             A list of uids of completed runs.
         err_msg: str
-            Error message and/or traceback in case of failure.
+            Error message in case of failure.
+        err_tb: str
+            Traceback in case of failure.
 
         Returns
         -------
@@ -1706,10 +1709,10 @@ class PlanQueueOperations:
         """
         async with self._lock:
             return await self._set_processed_item_as_completed(
-                exit_status=exit_status, run_uids=run_uids, err_msg=err_msg
+                exit_status=exit_status, run_uids=run_uids, err_msg=err_msg, err_tb=err_tb
             )
 
-    async def _set_processed_item_as_stopped(self, exit_status, run_uids, err_msg):
+    async def _set_processed_item_as_stopped(self, *, exit_status, run_uids, err_msg, err_tb):
         """
         See ``self.set_processed_item_as_stopped()`` method.
         """
@@ -1718,7 +1721,7 @@ class PlanQueueOperations:
             # Stopped item is considered successful, so it is not pushed back to the beginning
             #   of the queue, and it is added to the back of the queue in LOOP mode.
             item_cleaned = await self._set_processed_item_as_completed(
-                exit_status=exit_status, run_uids=run_uids, err_msg=err_msg
+                exit_status=exit_status, run_uids=run_uids, err_msg=err_msg, err_tb=err_tb
             )
         elif await self._is_item_running():
             item = await self._get_running_item_info()
@@ -1732,6 +1735,7 @@ class PlanQueueOperations:
             item_cleaned["result"]["time_start"] = item_time_start
             item_cleaned["result"]["time_stop"] = ttime.time()
             item_cleaned["result"]["msg"] = err_msg
+            item_cleaned["result"]["traceback"] = err_tb
 
             await self._add_to_history(item_cleaned)
             await self._clear_running_item_info()
@@ -1748,7 +1752,7 @@ class PlanQueueOperations:
             item_cleaned = {}
         return item_cleaned
 
-    async def set_processed_item_as_stopped(self, exit_status, run_uids, err_msg):
+    async def set_processed_item_as_stopped(self, *, exit_status, run_uids, err_msg, err_tb):
         """
         A stopped plan is considered successfully completed (if ``exit_status=="stopped"``) or
         failed (otherwise). All items are added to history with respective ``exit_status``.
@@ -1764,7 +1768,9 @@ class PlanQueueOperations:
         run_uids: list(str)
             A list of uids of completed runs.
         err_msg: str
-            Error message and/or traceback in case of failure.
+            Error message in case of failure.
+        err_tb: str
+            Traceback in case of failure.
 
         Returns
         -------
@@ -1775,7 +1781,7 @@ class PlanQueueOperations:
         """
         async with self._lock:
             return await self._set_processed_item_as_stopped(
-                exit_status=exit_status, run_uids=run_uids, err_msg=err_msg
+                exit_status=exit_status, run_uids=run_uids, err_msg=err_msg, err_tb=err_tb
             )
 
     # =============================================================================================

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -18,7 +18,6 @@ import argparse
 import importlib
 import numbers
 from numpydoc.docscrape import NumpyDocString
-import re
 import traceback
 
 import logging

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -18,6 +18,7 @@ import argparse
 import importlib
 import numbers
 from numpydoc.docscrape import NumpyDocString
+import re
 import traceback
 
 import logging
@@ -102,8 +103,14 @@ def _patch_script_code(code_str):
     for n in range(len(s_list)):
         line = s_list[n]
         if is_get_ipython_imported_in_line(line):
-            line += "; get_ipython = get_ipython_patch"
-            s_list[n] = line
+            # The line may have comments. The patch should be inserted before the comment.
+            line_split = re.split("#", line)
+            # Do not patch empty lines that have only comments
+            if line_split[0]:
+                line = line_split[0] + "; get_ipython = get_ipython_patch"
+                if len(line_split) > 1:
+                    line += "  #" + "#".join(line_split[1:])
+                s_list[n] = line
 
     return "\n".join(s_list)
 

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -157,6 +157,26 @@ if True:
 
 """, True, ""),
 
+    # Patching an a statement with acomment
+    ("""
+\n
+from IPython import get_ipython  # Some comment
+get_ipython().user_ns
+
+from IPython import get_ipython# Some comment
+get_ipython().user_ns
+if True:
+    # No comment
+    from IPython import get_ipython  #
+    get_ipython().user_ns
+
+    from IPython import get_ipython# Some comment
+    get_ipython().user_ns
+
+    from IPython import get_ipython# Some comment # Another comment
+    get_ipython().user_ns
+""", True, ""),
+
     # Patched as expected ('get_ipython()' is not imported)
     ("""
 \n

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -2800,7 +2800,7 @@ def test_zmq_api_function_execute_8_fail(re_manager):  # noqa: F811
     assert result["success"] is False, pprint.pformat(result)
     msg = "Function 'non_existing_element' is not found in the worker namespace"
     assert msg in result["msg"]
-    assert "not found in the worker namespace" in result["return_value"]
+    assert msg in result["traceback"]
 
     resp6, _ = zmq_single_request("environment_close")
     assert resp6["success"] is True, f"resp={resp6}"

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -846,18 +846,17 @@ class RunEngineWorker(Process):
                         except Exception as ex_json:
                             raise ValueError(f"Task result can not be serialized as JSON: {ex_json}") from ex_json
 
-                        success, msg = True, ""
+                        success, err_msg, err_tb = True, "", ""
                     except Exception as ex:
                         s = f"Error occurred while executing {name!r}"
+                        err_msg = f"{s}: {str(ex)}"
                         if hasattr(ex, "tb"):  # ScriptLoadingError
-                            tb = str(ex.tb)
-                            logger.error("%s:\n%s\n", s, str(ex.tb))
+                            err_tb = str(ex.tb)
                         else:
-                            tb = traceback.format_exc()
-                            logger.exception("%s: %s.", s, str(ex))
+                            err_tb = traceback.format_exc()
+                        logger.error("%s:\n%s\n", err_msg, err_tb)
 
-                        return_value = tb
-                        success, msg = False, f"Exception: {str(ex)}"
+                        return_value, success = None, False
                     finally:
                         if not run_in_background:
                             self._env_state = EState.IDLE
@@ -869,7 +868,8 @@ class RunEngineWorker(Process):
                         task_res = {
                             "task_uid": task_uid,
                             "success": success,
-                            "msg": msg,
+                            "msg": err_msg,
+                            "traceback": err_tb,
                             "return_value": return_value,
                             "time_start": time_start,
                             "time_stop": ttime.time(),

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -226,6 +226,7 @@ class RunEngineWorker(Process):
 
                     # Clear the list of active runs (don't clean the list for the paused plan).
                     self._active_run_list.clear()
+                    logger.error("The plan failed: %s", self._re_report["err_msg"])
 
                 # Include RE state
                 self._re_report["re_state"] = str(self._RE._state)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,7 +85,7 @@ release = bluesky_queueserver.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -536,8 +536,9 @@ Returns       **success**: *boolean*
                   - **time_start** and **time_stop** - time of start and completion of the plan (not runs),
                     floating point number returned by *time.time()*.
 
-                  - **msg** - error message and/or trace back in case of plan failure, empty string if no
-                    message is returned.
+                  - **msg** - error message if the plan failed, empty string otherwise.
+
+                  - **traceback** - full traceback if the plan failed, empty string otherwise.
 
               **plan_history_uid**: *str*
                   current plan history UID.
@@ -641,7 +642,7 @@ Method        **'environment_destroy'**
 Description   Initiate the operation of destroying of the existing (unresponsive) RE Worker
               environment. The operation fails if there is no existing environment.
               The request is accepted by the server if status fields **worker_environment_exists** is
-              *True* or **manager_state** is *'creating_environment'*, otherwise the request is 
+              *True* or **manager_state** is *'creating_environment'*, otherwise the request is
               rejected.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    ---
@@ -1483,9 +1484,10 @@ Description   Start execution of a function in RE Worker namespace. The function
 
               The method allows to pass parameters (*args* and *kwargs*) to the function. Once the task
               is completed, the results of the function execution, including the return value, can be
-              loaded using *task_result* method. If the task fails, the return value is a string
-              with full traceback of the raised exception. The data types of parameters and return
-              values must be JSON serializable. The task fails if the return value can not be serialized.
+              loaded using *task_result* method. If the task fails, the return value is *None* and
+              the error message and traceback are included in the result. The data types of
+              parameters and return values must be JSON serializable. The task fails if the return
+              value can not be serialized.
 
               The method only **initiates** execution of the function. If the request is successful
               (*success=True*), the server starts the task, which attempts to execute the function
@@ -1613,9 +1615,10 @@ Returns       **success**: *boolean*
                   - **'running'** - Keys: *'task_uid'*, *'start_time'* and *'run_in_background'*.
 
                   - **'completed'** - Keys: *'task_uid'*, *'success'* (*True*/*False*),
-                    *'msg'* (error message), *'return_value'* (value returned by the function
-                    or a string with full traceback if the task failed), *'time_start'* and
-                    *'time_stop'*.
+                    *'msg'* (short error message, empty string if execution was successful),
+                    *'traceback'* (full traceback in case of error, empty string otherwise),
+                    *'return_value'* (value returned by the task, e.g. by the executed function,
+                    *None* if the task failed), *'time_start'* and *'time_stop'*.
 
                   - **'not_found'** - Empty dictionary.
 ------------  -----------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Minor improvement of the code for loading IPython-style startup code. Since in the new version of loading code implemented in https://github.com/bluesky/bluesky-queueserver/pull/239 the script is patched without adding new lines by inserting patches in the existing lines, the patch should be added to the line before the first `#` if the line contains comments (otherwise the patch is added to the comment).

Minor change in API: if a plan or a task fail, the full traceback is returned as a separate parameter. It used to be part of the error message (`"msg"`) for the plan results (in plan history) and return value (`"return_value"`) for the tasks (returned by `task_result` API).

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

- Minor change in representation of plan execution results in items of the plan history. If plan execution fails, the `msg` parameter contains a brief message that identify the error (may not be helpful) and `traceback` parameter contains full traceback. The parameters are empty strings in case the plan succeeds. 
- Similar change to representation of task execution results returned by `task_result` API. Now `return_value` is `None` in case the task fails and `msg` and `traceback` contain brief error message and traceback of the raised exception.

### Removed

