### PR TITLE
Bug fixes: management of failure to start plan, handling of strings in unannotated plan parameters

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -1037,7 +1037,7 @@ def _split_name_pattern(name_pattern):
         components = list(zip(components, components_include, components_full_re, components_depth))
 
     else:
-        if not re.search(r"^[_a-zA-Z][_a-zA-Z0-9\.]*[_a-zA-Z0-9]$", name_pattern):
+        if not re.search(r"^[_a-zA-Z]([_a-zA-Z0-9\.]*[_a-zA-Z0-9])?$", name_pattern):
             raise ValueError(
                 f"Name pattern {name_pattern!r} contains invalid characters. "
                 "The pattern could be a valid regular expression, but it is not labeled with ':' (e.g. ':^det$')"

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -1076,33 +1076,41 @@ def _is_object_name_in_list(object_name, *, allowed_objects):
     Returns
     -------
     bool
-        ``True`` if device was found in the list, ``False`` otherwise.
+        ``True`` if device was found in the list, ``False`` if the device is not in the list or
+        the ``object_name`` is not a valid name for the object.
     """
 
-    components, uses_re, _ = _split_name_pattern(object_name)
-    if uses_re:
-        raise ValueError(f"Device name {object_name!r} can not contain regular expressions")
-
-    components = [_[0] for _ in components]  # We use only the 1st element
-
-    if not components:
-        raise ValueError(f"Device name {object_name!r} contains no components")
-
-    root = None
-    if components[0] in allowed_objects:
-        root = allowed_objects[components[0]]
-        object_in_list = not root.get("excluded", False)
-    else:
+    try:
+        components, uses_re, _ = _split_name_pattern(object_name)
+        object_in_list = True
+    except (TypeError, ValueError):
         object_in_list = False
 
-    if root:
-        for c in components[1:]:
-            if ("components" in root) and (c in root["components"]):
-                root = root["components"][c]
-                object_in_list = not root.get("excluded", False)
-            else:
-                object_in_list = False
-                break
+    if object_in_list and uses_re:
+        object_in_list = False
+
+    if object_in_list:
+        components = [_[0] for _ in components]  # We use only the 1st element
+        if not components:
+            object_in_list = False
+
+    # The object name is valid, so search for the object in the list
+    if object_in_list:
+        root = None
+        if components[0] in allowed_objects:
+            root = allowed_objects[components[0]]
+            object_in_list = not root.get("excluded", False)
+        else:
+            object_in_list = False
+
+        if root:
+            for c in components[1:]:
+                if ("components" in root) and (c in root["components"]):
+                    root = root["components"][c]
+                    object_in_list = not root.get("excluded", False)
+                else:
+                    object_in_list = False
+                    break
 
     return object_in_list
 

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -3408,6 +3408,7 @@ def test_devices_from_nspace():
     ("det1", [("det1", True, False, None)], False, ""),
     ("det1 ", [("det1", True, False, None)], False, ""),  # Spaces are removed
     ("det1.val", [("det1", True, False, None), ("val", True, False, None)], False, ""),
+    ("d", [("d", True, False, None)], False, ""),
     ("sim_stage.det1.val", [("sim_stage", True, False, None), ("det1", True, False, None),
      ("val", True, False, None)], False, ""),
     # Regular expressions

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -3525,30 +3525,27 @@ _allowed_devices_dict_1 = {
 
 
 # fmt: off
-@pytest.mark.parametrize("device_name, in_list, success, error_type, msg", [
-    ("da0_motor", True, True, None, ""),
-    ("not_exist", False, True, None, ""),
-    ("da0_motor.db0_motor", True, True, None, ""),
-    ("da0_motor.db0_motor.dc3_motor.dd1_motor", True, True, None, ""),
-    ("da0_motor.not_exist.dc3_motor.dd1_motor", False, True, None, ""),
-    ("da0_motor.db0_motor.not_exist.dd1_motor", False, True, None, ""),
-    ("da0_motor.db0_motor.dc3_motor.not_exist", False, True, None, ""),
-    ("da2_det", False, True, None, ""),  # excluded
-    ("da0_motor.db0_motor.dc4_motor", False, True, None, ""),  # excluded
-    (":da0_motor", True, False, ValueError,
-     "Device name ':da0_motor' can not contain regular expressions"),
+@pytest.mark.parametrize("device_name, in_list", [
+    ("da0_motor", True),
+    ("not_exist", False),
+    ("da0_motor.db0_motor", True),
+    ("da0_motor.db0_motor.dc3_motor.dd1_motor", True),
+    ("da0_motor.not_exist.dc3_motor.dd1_motor", False),
+    ("da0_motor.db0_motor.not_exist.dd1_motor", False),
+    ("da0_motor.db0_motor.dc3_motor.not_exist", False),
+    ("da2_det", False),  # excluded
+    ("da0_motor.db0_motor.dc4_motor", False),  # excluded
+    (":da0_motor", False),  # Regular expression
+    (50, False),  # Incorrect type
+    ("invalid-name", False),  # Name contains invalid characters
 ])
 # fmt: on
-def test_is_object_name_in_list_1(device_name, in_list, success, error_type, msg):
+def test_is_object_name_in_list_1(device_name, in_list):
     """
     ``_is_object_name_in_list``: basic test (test on devices, but expected to work on plans)
     """
-    if success:
-        res = _is_object_name_in_list(device_name, allowed_objects=_allowed_devices_dict_1)
-        assert res == in_list
-    else:
-        with pytest.raises(error_type, match=msg):
-            _is_object_name_in_list(device_name, allowed_objects=_allowed_devices_dict_1)
+    res = _is_object_name_in_list(device_name, allowed_objects=_allowed_devices_dict_1)
+    assert res == in_list
 
 
 # fmt: off
@@ -4397,6 +4394,12 @@ def _gen_environment_pp2():
          [("one", "two")], {}, {}, False, "value is not a valid enumeration member"),
 
         # Plan has no custom annotation. All strings must be converted to objects whenever possible.
+        ("plan1", {"user_group": "admin", "args": ["a", ":a*", "a-b-c"]}, [],
+         ["a", ":a*", "a-b-c"], {}, {}, True, ""),
+        ("plan7", {"user_group": "admin", "args": ["_pp_dev3", "_pp_dev3"]}, [],
+         [_pp_dev3, "_pp_dev3"], {}, {}, True, ""),
+        ("plan7", {"user_group": "admin", "args": [":_pp_dev3", "_pp_dev3"]}, [],
+         [":_pp_dev3", "_pp_dev3"], {}, {}, True, ""),
         ("plan7", {"user_group": "admin", "args": [["_pp_dev1", "_pp_dev3"], "_pp_dev2"]}, [],
          [[_pp_dev1, _pp_dev3], "_pp_dev2"], {}, {}, True, ""),
         ("plan7", {"user_group": "admin", "args": [["_pp_dev1", "_pp_dev3", "some_str"], "_pp_dev2"]}, [],

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -643,6 +643,7 @@ def unannotated_plan(p):
     ("a", "'a' Type=<class 'str'>"),
     ("a-b-c", "'a-b-c' Type=<class 'str'>"),
     (":^a.*", "':^a.*' Type=<class 'str'>"),
+    (50, "50 Type=<class 'int'>"),  # An integer
     ("det", "Type=<class 'ophyd.sim.SynGauss'>"),  # Existing detector
     ("motor", "Type=<class 'ophyd.sim.SynAxis'>"),  # Existing motor
     ("count", "Type=<class 'function'>"),  # Existing motor

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -636,6 +636,7 @@ def unannotated_plan(p):
     raise Exception(f"Passed object: {p!r} Type={type(p)}")
 """
 
+
 # fmt: off
 @pytest.mark.parametrize("value, err_msg", [
     ("abc", "'abc' Type=<class 'str'>"),
@@ -690,7 +691,6 @@ def test_zmq_api_queue_item_add_06(re_manager, value, err_msg):  # noqa: F811
     resp5, _ = zmq_single_request("environment_close")
     assert resp5["success"] is True
     assert wait_for_condition(time=5, condition=condition_environment_closed)
-
 
 
 def test_zmq_api_queue_item_add_07(re_manager):  # noqa: F811

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -299,14 +299,18 @@ class RunEngineWorker(Process):
             # 'is_resuming' is true (we start a new plan that is supposedly runs to completion
             #   as opposed to aborting/stopping/halting a plan)
         except Exception as ex:
+            logger.exception(ex)
+
             # We want the exception to be raised in the main thread (plan execution)
-            def get_plan(err_msg):
+            def get_plan(ex):
                 def plan():
-                    raise Exception(err_msg)
+                    raise RuntimeError(
+                        "Error occurred while processing plan parameters or starting the plan"
+                    ) from ex
 
-                return plan()
+                return plan
 
-            plan = get_plan(str(ex))
+            plan = get_plan(ex)
 
         self._execution_queue.put((plan, PlanExecOption.NEW))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR include the following changes:

- Fixed management of failures in RE Worker that happen while preparing to start a plan, e.g. preparing plan parameters. Due to a bug (typo), if exception was raised during at stage the plan was not executed, but instead labeled as successful and RE Manager would stay in `executing_plan` state. Now the run engine executes a short plan that reraises the exception that occurred during plan preparation and the error is processed and reported using the same mechanisms as errors that happen during plan execution.
- Fixed a bug that would not allow to pass single character names of devices to plans.
- Improved processing of strings that are passed to plan with parameters that are not annotated (default parameter handling rules). Now the parameter will accept any string. The strings that represent valid plan or device names will be checked against the list of names of available plans and devices and converted to the respective plan functions or device objects if possible. All strings that can not be converted to objects will be passed to the plan as a strings.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- A bug in the code for management of exceptions that occur during preparation of plans for execution.
- A bug that prevented single character device/plan names to be properly handled by the code that converts device/plan names to the respective objects.

### Added

### Changed

- Improved default handling of strings in the parameter processing code. Now any string (any combination of characters) can be passed with a parameter, which does not have type annotation. The strings that match one of the allowed device or plan names are going to be converted to the respective objects.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were added.

<!--
## Screenshots (if appropriate):
-->
