### PR TITLE
'script_upload' API: new parameter 'update-lists'

### DIFF
--- a/bluesky_queueserver/manager/profile_tools.py
+++ b/bluesky_queueserver/manager/profile_tools.py
@@ -281,7 +281,7 @@ def load_devices_from_happi(device_names, *, namespace, **kwargs):
                 # `r.metadata` contains expanded metadata (it is probably not used, but it
                 #   is a good idea to change it as well for consistency. We don't touch `_id`.
                 # The modified data is not expected to be saved to the database.
-                setattr(r._device, "name", name_ns)
+                setattr(r._item, "name", name_ns)
                 r.metadata["name"] = name_ns
             # Instantiate the object
             results.append(r)

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -147,6 +147,8 @@ Example of JSON specification of a function ("args" and "kwargs" are optional):
 qserver script upload <path-to-file>              # Upload a script to RE Worker environment
 qserver script upload <path-to-file> background   # ... in the background
 qserver script upload <path-to-file> update-re    # ... allow 'RE' and 'db' to be updated
+qserver script upload <path-to-file> keep-lists   # ... leave lists of allowed and existing plans and devices
+                                                  #   unchanged (saves processing time)
 
 qserver task result <task-uid>  # Load status or result of a task with the given UID
 qserver task status <task-uid>  # Check status of a task with the given UID
@@ -874,7 +876,8 @@ def create_msg(params):
 
             run_in_background = False
             update_re = False
-            allowed_values = ("background", "update-re")
+            update_lists = True
+            allowed_values = ("background", "update-re", "keep-lists")
 
             for p in params[2:]:
                 if p not in allowed_values:
@@ -885,9 +888,16 @@ def create_msg(params):
                     run_in_background = True
                 elif p == "update-re":
                     update_re = True
+                elif p == "keep-lists":
+                    update_lists = False
 
             method = f"{command}_{params[0]}"
-            prms = {"script": script, "run_in_background": run_in_background, "update_re": update_re}
+            prms = {
+                "script": script,
+                "run_in_background": run_in_background,
+                "update_re": update_re,
+                "update_lists": update_lists,
+            }
 
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -399,11 +399,13 @@ class RunEngineWorker(Process):
                 existing_devices=existing_devices,
             )
 
-    def _load_script_into_environment(self, *, script, update_re):
+    def _load_script_into_environment(self, *, script, update_lists, update_re):
         """
         Load script passed as a string variable (``script``) into RE environment namespace.
         Boolean variable ``update_re`` controls whether ``RE`` and ``db`` are updated if
-        the new values are defined in the script.
+        the new values are defined in the script. Boolean variable ``update_lists`` controls
+        if lists of existing and available plans and devices are updated after execution
+        of the script.
         """
         startup_dir = self._config_dict.get("startup_dir", None)
         startup_module_name = self._config_dict.get("startup_module_name", None)
@@ -437,29 +439,38 @@ class RunEngineWorker(Process):
                 self._db = self._re_namespace["db"]
                 logger.info("Data Broker instance ('db') was replaced while executing the uploaded script.")
 
-        epd = existing_plans_and_devices_from_nspace(nspace=self._re_namespace)
-        existing_plans, existing_devices, plans_in_nspace, devices_in_nspace = epd
+        if update_lists:
+            logger.info("Updating lists of existing and available plans and devices ...")
 
-        self._existing_plans_and_devices_changed = not compare_existing_plans_and_devices(
-            existing_plans=existing_plans,
-            existing_devices=existing_devices,
-            existing_plans_ref=self._existing_plans,
-            existing_devices_ref=self._existing_devices,
-        )
+            epd = existing_plans_and_devices_from_nspace(nspace=self._re_namespace)
+            existing_plans, existing_devices, plans_in_nspace, devices_in_nspace = epd
 
-        # Dictionaries of references to plans and devices from the namespace (may change even
-        #   if the list of existing plans and devices was not changed)
-        self._plans_in_nspace = plans_in_nspace
-        self._devices_in_nspace = devices_in_nspace
+            self._existing_plans_and_devices_changed = not compare_existing_plans_and_devices(
+                existing_plans=existing_plans,
+                existing_devices=existing_devices,
+                existing_plans_ref=self._existing_plans,
+                existing_devices_ref=self._existing_devices,
+            )
 
-        if self._existing_plans_and_devices_changed:
-            # Descriptions of existing plans and devices
-            with self._existing_items_lock:
-                self._existing_plans, self._existing_devices = existing_plans, existing_devices
-            self._generate_lists_of_allowed_plans_and_devices()
-            self._update_existing_pd_file(options=("ALWAYS",))
+            # Dictionaries of references to plans and devices from the namespace (may change even
+            #   if the list of existing plans and devices was not changed)
+            self._plans_in_nspace = plans_in_nspace
+            self._devices_in_nspace = devices_in_nspace
 
-        logger.info("The script was successfully loaded into RE environment")
+            if self._existing_plans_and_devices_changed:
+                # Descriptions of existing plans and devices
+                with self._existing_items_lock:
+                    self._existing_plans, self._existing_devices = existing_plans, existing_devices
+                self._generate_lists_of_allowed_plans_and_devices()
+                self._update_existing_pd_file(options=("ALWAYS",))
+
+            logger.info("The script was successfully loaded into RE environment")
+
+        else:
+            # The script was executed, but the lists were not updated and may be out of sync.
+            #   This option saves time, but should be used only to run scripts that do not add,
+            #   delete or modify plans and devices. The script may add functions to the namespace.
+            logger.info("The script was successfully executed in RE environment")
 
     def _execute_function_in_environment(self, *, func_info):
         """
@@ -750,7 +761,7 @@ class RunEngineWorker(Process):
         msg_out = {"status": status, "err_msg": err_msg, "task_uid": task_uid, "payload": payload}
         return msg_out
 
-    def _command_load_script(self, script, update_re, run_in_background):
+    def _command_load_script(self, script, update_lists, update_re, run_in_background):
         """
         Load the script passed as a string variable into the existing RE environment.
         The task could be started in the background (when a plan or another foreground task
@@ -759,7 +770,7 @@ class RunEngineWorker(Process):
         status, err_msg, task_uid, payload = self._run_in_separate_thread(
             name="Load script",
             target=self._load_script_into_environment,
-            kwargs={"script": script, "update_re": update_re},
+            kwargs={"script": script, "update_lists": update_lists, "update_re": update_re},
             run_in_background=run_in_background,
         )
         msg_out = {"status": status, "err_msg": err_msg, "task_uid": task_uid, "payload": payload}

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -1434,6 +1434,13 @@ Parameters    **script**: *str*
                   as for Bluesky startup scripts. The script can use objects already existing in
                   the RE Worker namespace.
 
+              **update_lists**: *boolean* (optional, default *True*)
+                  Update lists of existing and available plans and devices after execution of the script.
+                  It is required to update the lists if the script adds or modifies plans and/or devices
+                  in RE Worker namespace, but it is more efficient to disable the update for other scripts,
+                  e.g. the scripts that print or modify variables in the namespace during iteractive debug
+                  session.
+
               **update_re**: *boolean* (optional, default *False*)
                   The uploaded scripts may replace Run Engine (*'RE'*) and Data Broker (*'db'*)
                   instances in the namespace. In most cases this operation should not be allowed,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ black
 codecov
 coverage
 flake8
-happi
+happi>=1.14.0
 pytest
 pytest-xprocess
 sphinx


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

New boolean parameter `update-lists` (default value is `True`) for `script_upload` API. The parameter allows to disable update of the lists of existing and allowed plans and devices after execution of the script. The lists need to be updated only if the uploaded script adds or modifies plans and/or devices that exist in namespace, but may be disabled otherwise. Generating the lists after execution of each script may be costly if workflow requires execution of large number of short scripts, e.g. during interactive debugging session.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The API for uploading and executing scripts was initially intended for adding/removing/modifying plans and devices in RE Worker namespace, which requires updating lists of existing and allowed plans and devices. It is also possible to use scripts for other unrelated purposes, for example interactively probing states of the variables for debugging. Updating the lists after execution of each script, which does not change the plans or devices, is a waste of resources and should be avoided.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- Support for `happi v1.14.0` (minor change).

### Added

- New parameter `update-lists` added to `script_upload` API. The parameter accepts boolean value (`True` by default) and allows to disable update of lists of existing and allowed plans and devices after execution of the script. The parameter allows to improve efficiency of execution of scripts that do not add or modify plans and devices in RE worker namespace. Update of the lists may be disabled from CLI as `qserver script upload <path-to-file> keep-lists`.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
