### PR TITLE
New API: 'lock', 'unlock', 'lock_info'

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1153,6 +1153,7 @@ class RunEngineManager(Process):
 
     async def _save_lock_info_to_redis(self):
         try:
+            logger.debug("Saving lock info to Redis ...")
             lock_info = self._lock_info.to_dict()
             await self._plan_queue.lock_info_save(lock_info)
         except Exception as ex:
@@ -1160,6 +1161,7 @@ class RunEngineManager(Process):
 
     async def _load_lock_info_from_redis(self):
         try:
+            logger.debug("Loading lock info from Redis ...")
             lock_info = await self._plan_queue.lock_info_retrieve()
             if lock_info:  # The lock info may or may not be saved to Redis.
                 self._lock_info.from_dict(lock_info)
@@ -2905,7 +2907,7 @@ class RunEngineManager(Process):
                     environment=environment, queue=queue, lock_key=lock_key, note=note, user_name=user_name
                 )
                 lock_info = self._format_lock_info()
-                self._save_lock_info_to_redis()
+                await self._save_lock_info_to_redis()
             else:
                 raise ValueError(f"RE Manager was locked with a different key: \n{self._lock_info.to_str()}")
 
@@ -2964,7 +2966,7 @@ class RunEngineManager(Process):
             elif self._lock_info.check_lock_key(lock_key, use_emergency_key=True):
                 self._lock_info.clear()
                 lock_info = self._format_lock_info()
-                self._save_lock_info_to_redis()
+                await self._save_lock_info_to_redis()
             else:
                 lock_info = self._format_lock_info()
                 raise ValueError(self._lock_key_invalid_msg())

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -927,7 +927,7 @@ class RunEngineManager(Process):
         return success, err_msg
 
     def _queue_stop_activate(self):
-        if self._manager_state != MState.EXECUTING_QUEUE:
+        if self._manager_state not in (MState.EXECUTING_QUEUE, MState.STARTING_QUEUE):
             msg = f"Failed to pause the queue. Queue is not running. Manager state: {self._manager_state}"
             return False, msg
         else:
@@ -2517,6 +2517,8 @@ class RunEngineManager(Process):
         the task and load the result.
         """
         logger.debug("Starting execution of a function in RE Worker namespace ...")
+
+        item = None
         try:
             supported_param_names = ["item", "user_group", "user", "run_in_background", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -2867,6 +2867,8 @@ class RunEngineManager(Process):
             if "lock_key" not in request:
                 raise ValueError("Request contains no lock key: 'lock_key' parameter is required")
             lock_key = request["lock_key"]
+            if not isinstance(lock_key, str) or not lock_key:
+                raise ValueError(f"Lock key must be a non-empty string: lock_key = {lock_key!r}")
 
             if not self._lock_info.is_set():
                 lock_info = self._format_lock_info()

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -2616,6 +2616,39 @@ class RunEngineManager(Process):
 
         return {"success": success, "msg": msg, "run_list": run_list, "run_list_uid": run_list_uid}
 
+    async def _lock_handler(self, request):
+        success, msg = True, ""
+
+        try:
+            supported_param_names = ["lock_key", "note", "environment", "queue", "user"]
+            self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+        except Exception as ex:
+            success, msg = False, f"Error: {ex}"
+
+        return {"success": success, "msg": msg}
+
+    async def _lock_info_handler(self, request):
+        success, msg = True, ""
+
+        try:
+            supported_param_names = ["lock_key"]
+            self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+        except Exception as ex:
+            success, msg = False, f"Error: {ex}"
+
+        return {"success": success, "msg": msg}
+
+    async def _unlock_handler(self, request):
+        success, msg = True, ""
+
+        try:
+            supported_param_names = ["lock_key"]
+            self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+        except Exception as ex:
+            success, msg = False, f"Error: {ex}"
+
+        return {"success": success, "msg": msg}
+
     async def _manager_stop_handler(self, request):
         """
         Stop RE Manager in orderly way. The method may be called with option
@@ -2721,6 +2754,9 @@ class RunEngineManager(Process):
             "re_abort": "_re_abort_handler",
             "re_halt": "_re_halt_handler",
             "re_runs": "_re_runs_handler",
+            "lock": "_lock_handler",
+            "lock_info": "_lock_info_handler",
+            "unlock": "_unlock_handler",
             "manager_stop": "_manager_stop_handler",
             "manager_kill": "_manager_kill_handler",
         }

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1624,8 +1624,10 @@ class RunEngineManager(Process):
         """
         logger.info("Reloading lists of allowed plans and devices ...")
         try:
-            supported_param_names = ["restore_plans_devices", "restore_permissions"]
+            supported_param_names = ["restore_plans_devices", "restore_permissions", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             # Do not reload the lists of existing plans and devices from disk file by default
             restore_plans_devices = request.get("restore_plans_devices", False)
@@ -1660,8 +1662,10 @@ class RunEngineManager(Process):
     async def _permissions_set_handler(self, request):
         logger.info("Request to set user group permission ...")
         try:
-            supported_param_names = ["user_group_permissions"]
+            supported_param_names = ["user_group_permissions", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             if "user_group_permissions" not in request:
                 raise KeyError("Parameter 'user_group_permissions' is missing")
@@ -1904,8 +1908,10 @@ class RunEngineManager(Process):
 
         success, msg = True, ""
         try:
-            supported_param_names = ["mode"]
+            supported_param_names = ["mode", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             if "mode" not in request:
                 raise Exception(f"Parameter 'mode' is not found in request {request}")
@@ -1945,8 +1951,10 @@ class RunEngineManager(Process):
         item_type, item, qsize, msg = None, None, None, ""
 
         try:
-            supported_param_names = ["user_group", "user", "item", "pos", "before_uid", "after_uid"]
+            supported_param_names = ["user_group", "user", "item", "pos", "before_uid", "after_uid", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             item, item_type, _success, _msg = self._get_item_from_request(request=request)
             if not _success:
@@ -2008,8 +2016,10 @@ class RunEngineManager(Process):
         success, msg, item_list, results, qsize = True, "", [], [], None
 
         try:
-            supported_param_names = ["user_group", "user", "items", "pos", "before_uid", "after_uid"]
+            supported_param_names = ["user_group", "user", "items", "pos", "before_uid", "after_uid", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             # Prepare items
             if "items" not in request:
@@ -2096,8 +2106,10 @@ class RunEngineManager(Process):
         success, msg, qsize, item, item_type = True, "", 0, None, None
 
         try:
-            supported_param_names = ["user_group", "user", "item", "replace"]
+            supported_param_names = ["user_group", "user", "item", "replace", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             item, item_type, _success, _msg = self._get_item_from_request(request=request)
             if not _success:
@@ -2159,8 +2171,10 @@ class RunEngineManager(Process):
         logger.info("Removing item from the queue ...")
         item, qsize, msg = {}, None, ""
         try:
-            supported_param_names = ["pos", "uid"]
+            supported_param_names = ["pos", "uid", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             pos = request.get("pos", None)
             uid = request.get("uid", None)
@@ -2184,8 +2198,10 @@ class RunEngineManager(Process):
         logger.info("Removing a batch of items from the queue ...")
         items, qsize, msg = [], None, ""
         try:
-            supported_param_names = ["uids", "ignore_missing"]
+            supported_param_names = ["uids", "ignore_missing", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             uids = request.get("uids", None)
             ignore_missing = request.get("ignore_missing", True)
@@ -2214,8 +2230,10 @@ class RunEngineManager(Process):
         logger.info("Moving a queue item ...")
         item, qsize, msg = {}, None, ""
         try:
-            supported_param_names = ["pos", "uid", "pos_dest", "before_uid", "after_uid"]
+            supported_param_names = ["pos", "uid", "pos_dest", "before_uid", "after_uid", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             pos = request.get("pos", None)
             uid = request.get("uid", None)
@@ -2250,8 +2268,10 @@ class RunEngineManager(Process):
         logger.info("Moving a batch of queue items ...")
         items, qsize, msg = [], None, ""
         try:
-            supported_param_names = ["uids", "pos_dest", "before_uid", "after_uid", "reorder"]
+            supported_param_names = ["uids", "pos_dest", "before_uid", "after_uid", "reorder", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             uids = request.get("uids", None)
             pos_dest = request.get("pos_dest", None)
@@ -2302,8 +2322,10 @@ class RunEngineManager(Process):
         item_type, item, qsize, msg = None, None, None, ""
 
         try:
-            supported_param_names = ["item", "user_group", "user"]
+            supported_param_names = ["item", "user_group", "user", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             item, item_type, _success, _msg = self._get_item_from_request(request=request)
             if not _success:
@@ -2334,8 +2356,10 @@ class RunEngineManager(Process):
         """
         logger.info("Clearing the queue ...")
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             await self._plan_queue.clear_queue()
             success, msg = True, ""
@@ -2366,8 +2390,10 @@ class RunEngineManager(Process):
         """
         logger.info("Clearing the plan execution history ...")
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_queue=True)
 
             await self._plan_queue.clear_history()
             success, msg = True, ""
@@ -2382,8 +2408,10 @@ class RunEngineManager(Process):
         """
         logger.info("Opening the new RE environment ...")
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             success, msg = await self._start_re_worker()
         except Exception as ex:
@@ -2398,8 +2426,10 @@ class RunEngineManager(Process):
         """
         logger.info("Closing existing RE environment ...")
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             success, msg = await self._stop_re_worker()
         except Exception as ex:
@@ -2414,8 +2444,10 @@ class RunEngineManager(Process):
         """
         logger.info("Destroying current RE environment ...")
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             success, msg = await self._kill_re_worker()
         except Exception as ex:
@@ -2438,8 +2470,10 @@ class RunEngineManager(Process):
         """
         logger.info("Uploading script to RE environment ...")
         try:
-            supported_param_names = ["script", "update_lists", "update_re", "run_in_background"]
+            supported_param_names = ["script", "update_lists", "update_re", "run_in_background", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             script = request.get("script", None)
             if script is None:
@@ -2482,8 +2516,10 @@ class RunEngineManager(Process):
         """
         logger.debug("Starting execution of a function in RE Worker namespace ...")
         try:
-            supported_param_names = ["item", "user_group", "user", "run_in_background"]
+            supported_param_names = ["item", "user_group", "user", "run_in_background", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             item, item_type, _success, _msg = self._get_item_from_request(
                 request=request, supported_item_types=("function",)
@@ -2585,8 +2621,10 @@ class RunEngineManager(Process):
         """
         logger.info("Starting queue processing ...")
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             success, msg = await self._start_plan()
         except Exception as ex:
@@ -2604,8 +2642,10 @@ class RunEngineManager(Process):
         """
         logger.info("Activating 'stop queue' sequence ...")
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             success, msg = self._queue_stop_activate()
         except Exception as ex:
@@ -2621,8 +2661,10 @@ class RunEngineManager(Process):
         """
         logger.info("Deactivating 'stop queue' sequence ...")
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             success, msg = self._queue_stop_deactivate()
         except Exception as ex:
@@ -2638,8 +2680,10 @@ class RunEngineManager(Process):
         logger.info("Pausing the queue (currently running plan) ...")
 
         try:
-            supported_param_names = ["option"]
+            supported_param_names = ["option", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             option = request.get("option", "deferred")
             available_options = ("deferred", "immediate")
@@ -2670,8 +2714,10 @@ class RunEngineManager(Process):
         logger.info("Resuming paused plan ...")
 
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             success, msg = await self._continue_run_engine(option="resume")
         except Exception as ex:
@@ -2685,8 +2731,10 @@ class RunEngineManager(Process):
         """
         logger.info("Stopping paused plan ...")
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             success, msg = await self._continue_run_engine(option="stop")
         except Exception as ex:
@@ -2700,8 +2748,10 @@ class RunEngineManager(Process):
         """
         logger.info("Aborting paused plan ...")
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             success, msg = await self._continue_run_engine(option="abort")
         except Exception as ex:
@@ -2715,8 +2765,10 @@ class RunEngineManager(Process):
         """
         logger.info("Halting paused plan ...")
         try:
-            supported_param_names = []
+            supported_param_names = ["lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
+
+            self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
             success, msg = await self._continue_run_engine(option="halt")
         except Exception as ex:
@@ -2758,9 +2810,35 @@ class RunEngineManager(Process):
         return {"success": success, "msg": msg, "run_list": run_list, "run_list_uid": run_list_uid}
 
     def _lock_key_invalid_msg(self):
+        """
+        Format error message, which reports an invalid lock key.
+        """
         return f"Invalid lock key: \n{self._lock_info.to_str()}"
 
+    def _validate_lock_key(self, lock_key, *, check_environment=False, check_queue=False):
+        """
+        Validate the lock key if the environment and/or queue are locked. The choice
+        of ``check_environment`` and ``check_queue`` depend on whether an API is locked
+        by ``environment`` or ``queue`` option.
+        """
+        # Decide if the API is locked
+        locked = check_environment and self._lock_info.environment
+        locked = locked or (check_queue and self._lock_info.queue)
+
+        if lock_key is None:
+            if locked:
+                raise ValueError(self._lock_key_invalid_msg())
+        elif isinstance(lock_key, str):
+            if locked:
+                if not self._lock_info.check_lock_key(lock_key):
+                    raise ValueError(self._lock_key_invalid_msg())
+        else:
+            raise ValueError(f"Lock key must be a non-empty string or None: lock_key = {lock_key!r}")
+
     def _format_lock_info(self):
+        """
+        Format lock info as a dictionary, which is returned as ``lock_info`` by multiple API.
+        """
         return {
             "environment": self._lock_info.environment,
             "queue": self._lock_info.queue,
@@ -2837,6 +2915,15 @@ class RunEngineManager(Process):
         return {"success": success, "msg": msg, "lock_info": lock_info}
 
     async def _lock_info_handler(self, request):
+        """
+        Return information on the status of RE Manager lock. Optionally, it can validate the lock key.
+        If the value of the optional parameter ``lock_key`` has a string value and RE Manager is locked,
+        then the function verifies if the string matches current lock key used to lock the manager.
+        The API call succeeds (``'success': True``) if the keys match and fails otherwise. If ``lock_key``
+        is missing or ``None``, then the API call always succeeds. The API call always succeeds if
+        RE Manager is unlocked. The function does not match ``lock_key`` with the emergency lock key,
+        which is used only to unlock RE Manager if the lock key is lost.
+        """
         success, msg, lock_info = True, "", {}
 
         try:
@@ -2845,8 +2932,8 @@ class RunEngineManager(Process):
 
             lock_info = self._format_lock_info()
             lock_key = request.get("lock_key", None)
-            if (lock_key is not None) and not self._lock_info.check_lock_key(lock_key):
-                raise ValueError(self._lock_key_invalid_msg())
+            if lock_key is not None:
+                self._validate_lock_key(lock_key, check_environment=True, check_queue=True)
 
         except Exception as ex:
             success, msg = False, f"Error: {ex}"
@@ -2855,8 +2942,10 @@ class RunEngineManager(Process):
 
     async def _unlock_handler(self, request):
         """
-        RE Manager may be unlocked with the emergency key. The emergency lock key is not accepted
-        by any other API.
+        Unlock RE Manager using ``lock_key``. The ``lock_key`` must match the key used to lock
+        the environment and/or the queue. Optionally, RE Manager may be unlocked with
+        the emergency lock key (set using  ``QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER`` environment
+        variable).
         """
         success, msg, lock_info = True, "", {}
 

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -1817,6 +1817,9 @@ class PlanQueueOperations:
         ugp_json = await self._r_pool.get(self._name_user_group_permissions)
         return json.loads(ugp_json) if ugp_json else None
 
+    # =============================================================================================
+    #         Methods for saving and retrieving lock info.
+
     async def lock_info_clear(self):
         """
         Clear lock info saved in Redis.

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -78,6 +78,7 @@ class PlanQueueOperations:
         #   The class contains only the functions for saving and retrieving the data, which is
         #   not used by other functions of the class.
         self._name_user_group_permissions = "user_group_permissions"
+        self._name_lock_info = "lock_info"
 
         # The list of allowed item parameters used for parameter filtering. Filtering operation
         #   involves removing all parameters that are not in the list.
@@ -1815,3 +1816,32 @@ class PlanQueueOperations:
         """
         ugp_json = await self._r_pool.get(self._name_user_group_permissions)
         return json.loads(ugp_json) if ugp_json else None
+
+    async def lock_info_clear(self):
+        """
+        Clear lock info saved in Redis.
+        """
+        await self._r_pool.delete(self._name_lock_info)
+
+    async def lock_info_save(self, lock_info):
+        """
+        Save lock info to Redis.
+
+        Parameters
+        ----------
+        lock_info: dict
+            A dictionary containing lock info.
+        """
+        await self._r_pool.set(self._name_lock_info, json.dumps(lock_info))
+
+    async def lock_info_retrieve(self):
+        """
+        Retreive saved lock info.
+
+        Returns
+        -------
+        dict or None
+            Returns dictionary with saved lock info or ``None`` if no lock info is saved.
+        """
+        lock_info_json = await self._r_pool.get(self._name_lock_info)
+        return json.loads(lock_info_json) if lock_info_json else None

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -153,6 +153,16 @@ qserver script upload <path-to-file> keep-lists   # ... leave lists of allowed a
 qserver task result <task-uid>  # Load status or result of a task with the given UID
 qserver task status <task-uid>  # Check status of a task with the given UID
 
+qserver lock environment  -k 90g94                   # Lock the environment
+qserver lock environment "Locked for 1 hr" -k 90g94  # Add a text note
+qserver lock queue -k 90g94                          # Lock the queue
+qserver lock all -k 90g94                            # Lock environment and the queue
+
+qserver lock info                        # Load lock status
+qserver lock info -k 90g94               # Load lock status and validate the key
+
+qserver unlock -k 90g94                  # Unlock RE Manager
+
 qserver manager stop           # Safely exit RE Manager application
 qserver manager stop safe on   # Safely exit RE Manager application
 qserver manager stop safe off  # Force RE Manager application to stop
@@ -514,7 +524,7 @@ def msg_function_execute(params, *, cmd_opt):
     return method, prms
 
 
-def msg_queue_item(params):
+def msg_queue_item(params, *, lock_key):
     """
     Generate outgoing message for `queue item` command. The supported options are ``get``,
     ``move`` and ``remove``.
@@ -594,6 +604,10 @@ def msg_queue_item(params):
 
     method = f"{command}_{params[0]}_{params[1]}"
     prms = addr_param
+
+    if p_item_type in ("remove", "move"):
+        if lock_key:
+            prms["lock_key"] = lock_key
 
     return method, prms
 
@@ -735,22 +749,25 @@ def msg_re_pause(params):
     return method, prms
 
 
-def create_msg(params):
+def create_msg(params, *, lock_key):
     """
     Create outgoing message based on command-line arguments.
 
     Parameters
     ----------
-    params : list
+    params: list
         List of parameters (positional arguments) supplied via command line.
+
+    lock_key: str or None
+        Lock key
 
     Returns
     -------
-    method : str
+    method: str
         The name of the method.
-    prms : dict
+    prms: dict
         The dictionary of method parameters.
-    monitoring_mode : bool
+    monitoring_mode: bool
         Indicates if monitoring mode is enabled.
 
     Raises
@@ -797,6 +814,8 @@ def create_msg(params):
         supported_params = ("open", "close", "destroy")
         if params[0] in supported_params:
             method = f"{command}_{params[0]}"
+            if lock_key:
+                prms["lock_key"] = lock_key
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
 
@@ -832,6 +851,8 @@ def create_msg(params):
             if len(params) == 2:
                 if params[1] == "lists":
                     prms["restore_plans_devices"] = True
+                    if lock_key:
+                        prms["lock_key"] = lock_key
                 else:
                     CommandParameterError(f"Request '{command} {params[0]} {params[1]}' is not supported")
 
@@ -855,6 +876,8 @@ def create_msg(params):
                     f"Request '{command}': failed to read the user group permissions from file '{file_name}': {ex}"
                 )
             prms["user_group_permissions"] = permissions_dict
+            if lock_key:
+                prms["lock_key"] = lock_key
 
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
@@ -897,6 +920,7 @@ def create_msg(params):
                 "run_in_background": run_in_background,
                 "update_re": update_re,
                 "update_lists": update_lists,
+                "lock_key": lock_key,
             }
 
         else:
@@ -923,6 +947,8 @@ def create_msg(params):
             raise CommandParameterError(f"Request '{command}' must include at least one parameter")
         if params[0] == "execute":
             method, prms = msg_function_execute(params, cmd_opt=params[0])
+            if lock_key:
+                prms["lock_key"] = lock_key
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
 
@@ -934,20 +960,29 @@ def create_msg(params):
         if params[0] in supported_params:
             if params[0] in ("add", "update", "replace", "execute"):
                 method, prms = msg_queue_add_update(params, cmd_opt=params[0])
+                if lock_key:
+                    prms["lock_key"] = lock_key
 
             elif params[0] in ("get", "clear", "start"):
                 if len(params) != 1:
                     raise CommandParameterError(f"Request '{command} {params[0]}' must include only one parameter")
                 method, prms = f"{command}_{params[0]}", {}
+                if params[0] in ("clear", "start"):
+                    if lock_key:
+                        prms["lock_key"] = lock_key
 
             elif params[0] == "stop":
                 method, prms = msg_queue_stop(params)
+                if lock_key:
+                    prms["lock_key"] = lock_key
 
             elif params[0] == "item":
-                method, prms = msg_queue_item(params)
+                method, prms = msg_queue_item(params, lock_key=lock_key)
 
             elif params[0] == "mode":
                 method, prms = msg_queue_mode(params)
+                if lock_key:
+                    prms["lock_key"] = lock_key
 
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
@@ -971,6 +1006,10 @@ def create_msg(params):
                     )
             else:
                 method, prms = f"{command}_{params[0]}", {}
+
+            if lock_key:
+                prms["lock_key"] = lock_key
+
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
 
@@ -980,6 +1019,9 @@ def create_msg(params):
         supported_params = ("get", "clear")
         if params[0] in supported_params:
             method, prms = f"{command}_{params[0]}", {}
+            if params[0] == "clear":
+                if lock_key:
+                    prms["lock_key"] = lock_key
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
 
@@ -1007,6 +1049,46 @@ def create_msg(params):
                 )
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
+
+    elif command == "lock":
+        if params[0] == "info":
+            if len(params) != 1:
+                raise CommandParameterError(
+                    f"Too many parameters (only one expected): {format_list_as_command(params)}"
+                )
+            method = "lock_info"
+            if lock_key:
+                prms["lock_key"] = lock_key
+        elif params[0] in ("environment", "queue", "all"):
+            if len(params) > 2:
+                raise CommandParameterError(
+                    f"Too many parameters (1 or 2 are expected): {format_list_as_command(params)}"
+                )
+            if (len(params) == 2) and (params[1] in ("environment", "queue", "all")):
+                raise CommandParameterError(
+                    f"Unsupported combination of parameters:  {format_list_as_command(params)}"
+                )
+            method = "lock"
+            if params[0] in ("environment", "all"):
+                prms["environment"] = True
+            if params[0] == ("queue", "all"):
+                prms["queue"] = True
+            if len(params) == 2:
+                prms["note"] = params[1]
+            if lock_key:
+                prms["lock_key"] = lock_key
+            prms["user"] = default_user
+        else:
+            raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
+
+    elif command == "unlock":
+        if len(params) != 0:
+            raise CommandParameterError(
+                f"The command accepts no extra parameters: {format_list_as_command(params)}"
+            )
+        method = "unlock"
+        if lock_key:
+            prms["lock_key"] = lock_key
 
     else:
         raise CommandParameterError(f"Unrecognized command '{command}'")
@@ -1092,6 +1174,16 @@ def qserver():
         help="The parameter is deprecated and will be removed. Use --zmq-control-addr instead.",
     )
 
+    parser.add_argument(
+        "--lock-key",
+        "-k",
+        dest="lock_key",
+        action="store",
+        default=None,
+        help="Lock key. The key is an arbitrary string is used to lock and unlock RE Manager "
+        "('lock' and 'unlock' API) and control the manager when the environment or the queue is locked.",
+    )
+
     args = parser.parse_args()
     print(f"Arguments: {args.command}")
 
@@ -1107,6 +1199,13 @@ def qserver():
         # If the address is not specified, then use the default address
         address = address or default_zmq_control_address
 
+        lock_key = args.lock_key
+        if lock_key is not None:
+            if not isinstance(lock_key, str) or not lock_key:
+                raise CommandParameterError(
+                    f"Lock key must be a non-empty string: submitted lock key is {lock_key!r}"
+                )
+
         # Read public key from the environment variable, then check if the CLI parameter exists
         zmq_public_key = os.environ.get("QSERVER_ZMQ_PUBLIC_KEY", None)
         zmq_public_key = zmq_public_key if zmq_public_key else None  # Case of key==""
@@ -1116,7 +1215,7 @@ def qserver():
             except Exception as ex:
                 raise CommandParameterError(f"ZMQ public key is improperly formatted: {ex}")
 
-        method, params, monitoring_mode = create_msg(args.command)
+        method, params, monitoring_mode = create_msg(args.command, lock_key=lock_key)
         if monitoring_mode:
             print("Running QServer monitor. Press Ctrl-C to exit ...")
 

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -1051,7 +1051,9 @@ def create_msg(params, *, lock_key):
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
 
     elif command == "lock":
-        if params[0] == "info":
+        if len(params) == 0:
+            raise CommandParameterError("Command {command!r} requires at least one parameter.")
+        elif params[0] == "info":
             if len(params) != 1:
                 raise CommandParameterError(
                     f"Too many parameters (only one expected): {format_list_as_command(params)}"
@@ -1071,7 +1073,7 @@ def create_msg(params, *, lock_key):
             method = "lock"
             if params[0] in ("environment", "all"):
                 prms["environment"] = True
-            if params[0] == ("queue", "all"):
+            if params[0] in ("queue", "all"):
                 prms["queue"] = True
             if len(params) == 2:
                 prms["note"] = params[1]

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -670,6 +670,9 @@ def start_manager():
         return 1
     config_manager["redis_addr"] = redis_addr
 
+    lock_key_emergency = os.environ.get("QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER", None)
+    config_manager["lock_key_emergency"] = lock_key_emergency
+
     wp = WatchdogProcess(
         config_worker=config_worker, config_manager=config_manager, msg_queue=msg_queue, log_level=log_level
     )

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -327,6 +327,7 @@ def clear_redis_pool():
         await pq.start()
         await pq.delete_pool_entries()
         await pq.user_group_permissions_clear()
+        await pq.lock_info_clear()
 
     asyncio.run(run())
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -29,6 +29,7 @@ class PQ:
         # Clear any pool entries
         await self._pq.delete_pool_entries()
         await self._pq.user_group_permissions_clear()
+        await self._pq.lock_info_clear()
         return self._pq
 
     async def __aexit__(self, exc_t, exc_v, exc_tb):
@@ -38,6 +39,7 @@ class PQ:
         # Don't leave any test entries in the pool
         await self._pq.delete_pool_entries()
         await self._pq.user_group_permissions_clear()
+        await self._pq.lock_info_clear()
 
 
 # fmt: off
@@ -2322,5 +2324,30 @@ def test_user_group_permissions_1():
 
             await pq.user_group_permissions_clear()
             assert await pq.user_group_permissions_retrieve() is None
+
+    asyncio.run(testing())
+
+
+# ==============================================================================================
+#                           Saving and retrieving lock info
+def test_lock_info_1():
+    """
+    Test for saving and retrieving and clearing user group permissions, which are backed up in Redis.
+    """
+    lock_info_1 = {"environment": False, "queue": True, "lock_key": "abcde"}
+    lock_info_2 = {"environment": True, "queue": False, "lock_key": "fghijk"}
+
+    async def testing():
+        async with PQ() as pq:
+            assert await pq.lock_info_retrieve() is None
+
+            await pq.lock_info_save(lock_info_1)
+            assert await pq.lock_info_retrieve() == lock_info_1
+
+            await pq.lock_info_save(lock_info_2)
+            assert await pq.lock_info_retrieve() == lock_info_2
+
+            await pq.lock_info_clear()
+            assert await pq.lock_info_retrieve() is None
 
     asyncio.run(testing())

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -4772,6 +4772,60 @@ def test_zmq_api_lock_2(monkeypatch, re_manager_cmd, set_em_key, unlock_with_em_
 
 
 # fmt: off
+@pytest.mark.parametrize("lock_options", [
+    {"environment": True},
+    {"queue": True},
+    {"environment": True, "queue": True},
+])
+@pytest.mark.parametrize("test_option", [
+    None,
+    "kill",
+    "restart"
+])
+# fmt: on
+def test_zmq_api_lock_3(re_manager_cmd, lock_options, test_option):  # noqa: F811
+    """
+    ``lock`` API: verify, that lock presists when RE Manager is restarted.
+    """
+    manager = re_manager_cmd([])
+
+    custom_key = "custom-key"
+
+    # Lock RE Manager
+    params = {**lock_options, "lock_key": custom_key, "user": _user}
+    resp1, _ = zmq_single_request("lock", params=params)
+    assert resp1["success"] is True, f"resp={resp1}"
+    assert resp1["msg"] == "", f"resp={resp1}"
+
+    lock_info = resp1["lock_info"]
+    params = {k: lock_info[k] for k in lock_options}
+    assert params == lock_options
+
+    if test_option == "kill":
+        zmq_single_request("manager_kill")
+        ttime.sleep(6)
+        assert wait_for_condition(10, condition=condition_manager_idle)
+    elif test_option == "restart":
+        manager.stop_manager(cleanup=False)
+        manager.start_manager(cleanup=False)
+        assert wait_for_condition(10, condition=condition_manager_idle)
+    elif test_option is None:
+        pass
+    else:
+        assert False, f"Unknown test option: {test_option}"
+
+    resp3, _ = zmq_single_request("lock_info")
+    assert resp3["success"] is True
+    assert resp3["msg"] == ""
+    assert resp3["lock_info"] == lock_info
+
+    # Unlock RE Manager with an invalid key
+    resp4, _ = zmq_single_request("unlock", params={"lock_key": custom_key})
+    assert resp4["success"] is True, f"resp={resp4}"
+    assert resp4["msg"] == "", f"resp={resp4}"
+
+
+# fmt: off
 @pytest.mark.parametrize("params, success, msg", [
     # No option ('environment' or 'queue') is selected
     ({"lock_key": "custom-key", "user": _user}, False, "environment and/or queue must be selected"),
@@ -4794,7 +4848,7 @@ def test_zmq_api_lock_2(monkeypatch, re_manager_cmd, set_em_key, unlock_with_em_
      False, "Note must be a string or None"),
 ])
 # fmt: on
-def test_zmq_api_lock_3_fail(re_manager, params, success, msg):  # noqa: F811
+def test_zmq_api_lock_4_fail(re_manager, params, success, msg):  # noqa: F811
     """
     ``lock`` API: failing cases
     """
@@ -4813,7 +4867,7 @@ def test_zmq_api_lock_3_fail(re_manager, params, success, msg):  # noqa: F811
     ({"lock_key": "proper-key"}, True, ""),
 ])
 # fmt: on
-def test_zmq_api_unlock_1_fail(re_manager, params, success, msg):  # noqa: F811
+def test_zmq_api_lock_5_fail(re_manager, params, success, msg):  # noqa: F811
     """
     ``unlock`` API: failing cases
     """
@@ -4823,6 +4877,106 @@ def test_zmq_api_unlock_1_fail(re_manager, params, success, msg):  # noqa: F811
         assert msg == ""
     else:
         assert msg in resp1["msg"]
+
+
+# fmt: off
+@pytest.mark.parametrize("unlock", [False, True])
+@pytest.mark.parametrize("lock_options, is_locked", [
+    ({}, False),
+    ({"environment": True}, False),
+    ({"queue": True}, True),  # Queue is locked
+    ({"environment": True, "queue": True}, True),  # Queue is locked
+])
+# fmt: on
+def test_zmq_api_lock_6(re_manager, lock_options, is_locked, unlock):  # noqa: F811
+    """
+    ``lock`` API: check that the appropriate API are locked while the queue is locked
+    """
+    custom_key = "custom-key"
+    unlock_params = {"lock_key": custom_key} if unlock else {}
+
+    # Add 4 plans to the queue
+    params = {"items": [_plan1, _plan2, _plan3, _plan4], "user": _user, "user_group": _user_group}
+    resp0, _ = zmq_single_request("queue_item_add_batch", params=params)
+    assert resp0["success"] is True
+
+    def check_reply(reply):
+        success = not is_locked or unlock
+        assert reply["success"] is success, f"resp={reply}"
+        if success:
+            assert reply["msg"] == "", f"resp={reply}"
+        else:
+            assert "Invalid lock key" in reply["msg"], f"resp={reply}"
+
+    if lock_options:
+        params = {**lock_options, "lock_key": custom_key, "user": _user}
+        resp1, _ = zmq_single_request("lock", params=params)
+        assert resp1["success"] is True, f"resp={resp1}"
+
+    # API for uploading permissions
+    resp2, _ = zmq_single_request("permissions_reload", params={**unlock_params})
+    check_reply(resp2)
+
+    resp3, _ = zmq_single_request("permissions_get")
+    permissions = resp3["user_group_permissions"]
+
+    params = {"user_group_permissions": permissions, **unlock_params}
+    resp4, _ = zmq_single_request("permissions_set", params=params)
+    check_reply(resp4)
+
+    # Setting queue mode
+    params = {"mode": {"loop": False}, **unlock_params}
+    resp5, _ = zmq_single_request("queue_mode_set", params=params)
+    check_reply(resp5)
+
+    # Adding items to the queue
+    params = {"item": _plan1, "user": _user, "user_group": _user_group, **unlock_params}
+    resp6, _ = zmq_single_request("queue_item_add", params=params)
+    check_reply(resp6)
+
+    params = {"items": [_plan2, _plan3, _plan4], "user": _user, "user_group": _user_group, **unlock_params}
+    resp7, _ = zmq_single_request("queue_item_add_batch", params=params)
+    check_reply(resp7)
+
+    # Read the plan queue
+    resp8, _ = zmq_single_request("queue_get")
+    assert resp8["success"] is True
+    plan_queue = resp8["items"]
+    assert len(plan_queue) >= 4  # It must contain at least 4 plans
+
+    # Updating a queue item
+    plan = plan_queue[0]
+    params = {"item": plan, "user": _user, "user_group": _user_group, **unlock_params}
+    resp9, _ = zmq_single_request("queue_item_update", params=params)
+    check_reply(resp9)
+
+    # Move queue items
+    params = {"pos": 0, "pos_dest": 1, **unlock_params}
+    resp10, _ = zmq_single_request("queue_item_move", params=params)
+    check_reply(resp10)
+
+    uids = [_["item_uid"] for _ in plan_queue[2:4]]
+    params = {"uids": uids, "pos_dest": "front", **unlock_params}
+    resp11, _ = zmq_single_request("queue_item_move_batch", params=params)
+    check_reply(resp11)
+
+    # Remove queue items
+    params = {"pos": 3, **unlock_params}
+    resp12, _ = zmq_single_request("queue_item_remove", params=params)
+    check_reply(resp12)
+
+    params = {"uids": uids, **unlock_params}
+    resp13, _ = zmq_single_request("queue_item_remove_batch", params=params)
+    check_reply(resp13)
+
+    # Clearing the history and the queue
+    resp14, _ = zmq_single_request("history_clear", params={**unlock_params})
+    check_reply(resp14)
+    resp15, _ = zmq_single_request("queue_clear", params={**unlock_params})
+    check_reply(resp15)
+
+    resp99, _ = zmq_single_request("unlock", params={"lock_key": custom_key})
+    assert resp99["success"] is True, f"resp={resp99}"
 
 
 # =======================================================================================

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -5036,6 +5036,10 @@ def test_zmq_api_lock_7(re_manager, lock_options, is_locked, unlock):  # noqa: F
         resp6, _ = zmq_single_request("queue_start", params=unlock_params)
         check_reply(resp6)
 
+        # Wait until the queue starts. Otherwise 'queue_stop' may stop the queue
+        #   before execution of the first plan is started and the test will fail
+        ttime.sleep(0.5)
+
         resp7, _ = zmq_single_request("queue_stop", params=unlock_params)
         check_reply(resp7)
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -4806,6 +4806,25 @@ def test_zmq_api_lock_3_fail(re_manager, params, success, msg):  # noqa: F811
         assert msg in resp1["msg"]
 
 
+# fmt: off
+@pytest.mark.parametrize("params, success, msg", [
+    ({}, False, "Request contains no lock key"),
+    ({"lock_key": None}, False, "Lock key must be a non-empty string"),
+    ({"lock_key": "proper-key"}, True, ""),
+])
+# fmt: on
+def test_zmq_api_unlock_1_fail(re_manager, params, success, msg):  # noqa: F811
+    """
+    ``unlock`` API: failing cases
+    """
+    resp1, _ = zmq_single_request("unlock", params=params)
+    assert resp1["success"] is success, f"resp={resp1}"
+    if success:
+        assert msg == ""
+    else:
+        assert msg in resp1["msg"]
+
+
 # =======================================================================================
 #            Tests that involve restarting the manager process
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -4979,6 +4979,107 @@ def test_zmq_api_lock_6(re_manager, lock_options, is_locked, unlock):  # noqa: F
     assert resp99["success"] is True, f"resp={resp99}"
 
 
+# fmt: off
+@pytest.mark.parametrize("unlock", [False, True])
+@pytest.mark.parametrize("lock_options, is_locked", [
+    ({}, False),
+    ({"queue": True}, False),
+    ({"environment": True}, True),  # Environment is locked
+    ({"environment": True, "queue": True}, True),  # Environment is locked
+])
+# fmt: on
+def test_zmq_api_lock_7(re_manager, lock_options, is_locked, unlock):  # noqa: F811
+    """
+    ``lock`` API: check that the appropriate API are locked while the environment is locked.
+    This test will work propery only if the key is validated before the state of the manager
+    is checked, which is how APIs are implemented.
+    """
+    custom_key = "custom-key"
+    unlock_params = {"lock_key": custom_key} if unlock else {}
+
+    def check_reply(reply):
+        success = not is_locked or unlock
+        assert reply["success"] is success, f"resp={reply}"
+        if success:
+            assert reply["msg"] == "", f"resp={reply}"
+        else:
+            assert "Invalid lock key" in reply["msg"], f"resp={reply}"
+
+    if lock_options:
+        params = {**lock_options, "lock_key": custom_key, "user": _user}
+        resp1, _ = zmq_single_request("lock", params=params)
+        assert resp1["success"] is True, f"resp={resp1}"
+
+    # Open and destroy the environment
+    resp2, _ = zmq_single_request("environment_open", params={**unlock_params})
+    check_reply(resp2)
+    cond = condition_environment_created if not is_locked or unlock else condition_manager_idle
+    assert wait_for_condition(20, condition=cond)
+
+    resp3, _ = zmq_single_request("environment_destroy", params={**unlock_params})
+    # resp3, _ = zmq_single_request("environment_close", params={**unlock_params})
+    check_reply(resp3)
+    assert wait_for_condition(20, condition=condition_environment_closed)
+
+    # Open the environment again
+    resp4, _ = zmq_single_request("environment_open", params={**unlock_params})
+    check_reply(resp4)
+    cond = condition_environment_created if not is_locked or unlock else condition_manager_idle
+    assert wait_for_condition(20, condition=cond)
+
+    for api_to_test in ("re_resume", "re_stop", "re_abort", "re_halt"):
+        # Always add the plan (not part of the test, but necessary for the test to complete)
+        params = {"item": _plan3, "user": _user, "user_group": _user_group, "lock_key": custom_key}
+        resp5, _ = zmq_single_request("queue_item_add", params=params)
+        assert resp5["success"] is True
+
+        resp6, _ = zmq_single_request("queue_start", params=unlock_params)
+        check_reply(resp6)
+
+        resp7, _ = zmq_single_request("queue_stop", params=unlock_params)
+        check_reply(resp7)
+
+        resp8, _ = zmq_single_request("queue_stop_cancel", params=unlock_params)
+        check_reply(resp8)
+
+        ttime.sleep(1)
+
+        resp9, _ = zmq_single_request("re_pause", params=unlock_params)
+        check_reply(resp9)
+
+        cond = condition_manager_paused if not is_locked or unlock else condition_manager_idle
+        assert wait_for_condition(20, condition=cond)
+
+        resp10, _ = zmq_single_request(api_to_test, params=unlock_params)
+        check_reply(resp10)
+
+        assert wait_for_condition(20, condition=condition_manager_idle)
+
+    params = {"item": _plan1, "user": _user, "user_group": _user_group, **unlock_params}
+    resp11, _ = zmq_single_request("queue_item_execute", params=params)
+    check_reply(resp11)
+    assert wait_for_condition(20, condition=condition_manager_idle)
+
+    params = {"script": "", **unlock_params}
+    resp12, _ = zmq_single_request("script_upload", params=params)
+    check_reply(resp12)
+    assert wait_for_condition(20, condition=condition_manager_idle)
+
+    func_item = {"name": "function_sleep", "args": [0.5], "item_type": "function"}
+    params = {"item": func_item, "user": _user, "user_group": _user_group, **unlock_params}
+    resp13, _ = zmq_single_request("function_execute", params=params)
+    check_reply(resp13)
+    assert wait_for_condition(20, condition=condition_manager_idle)
+
+    # Close the environment
+    resp98, _ = zmq_single_request("environment_close", params={**unlock_params})
+    check_reply(resp98)
+    assert wait_for_condition(20, condition=condition_environment_closed)
+
+    resp99, _ = zmq_single_request("unlock", params={"lock_key": custom_key})
+    assert resp99["success"] is True, f"resp={resp99}"
+
+
 # =======================================================================================
 #            Tests that involve restarting the manager process
 

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -351,7 +351,7 @@ periodically requests and displays the status of Queue Server.
                   command [command ...]
 
     Command-line tool for communicating with RE Monitor.
-    bluesky-queueserver version 0.0.15
+    bluesky-queueserver version 0.0.16
 
     positional arguments:
       command           a sequence of keywords and parameters that define the command
@@ -486,6 +486,16 @@ periodically requests and displays the status of Queue Server.
 
     qserver task result <task-uid>  # Load status or result of a task with the given UID
     qserver task status <task-uid>  # Check status of a task with the given UID
+
+    qserver lock environment  -k 90g94                   # Lock the environment
+    qserver lock environment "Locked for 1 hr" -k 90g94  # Add a text note
+    qserver lock queue -k 90g94                          # Lock the queue
+    qserver lock all -k 90g94                            # Lock environment and the queue
+
+    qserver lock info                        # Load lock status
+    qserver lock info -k 90g94               # Load lock status and validate the key
+
+    qserver unlock -k 90g94                  # Unlock RE Manager
 
     qserver manager stop           # Safely exit RE Manager application
     qserver manager stop safe on   # Safely exit RE Manager application
@@ -652,3 +662,36 @@ to 0MQ socket by default. Publishing can be enabled by starting RE Manager with 
       --zmq-subscribe-addr ZMQ_SUBSCRIBE_ADDR
                         The parameter is deprecated and will be removed. Use --zmq-info-addr
                         instead.
+
+
+.. _qserver_clear_lock_cli:
+
+qserver-clear-lock
+------------------
+
+``qserver-clear-lock`` allows to clear RE Manager lock stored in Redis. The manager lock
+is not cleared by restarting the manager: it must be explicitly cleared using
+a valid lock key (used to lock the manager) or an emergency lock key (optional).
+If the key is lost and the emergency lock key is not set or known, then the lock
+could be cleared by running ``qserver-clear-lock`` and restarting RE Manager application
+or service. The utility needs access to Redis server used by RE Manager. If Redis
+address is different from default, the correct address must be passed using the parameter
+``--redis-addr``.
+
+.. code-block::
+
+  $ qserver-clear-lock -h
+  usage: qserver-clear-lock [-h] [--redis-addr REDIS_ADDR]
+
+  Bluesky-QServer: Clear RE Manager lock.
+  bluesky-queueserver version 0.0.16.
+
+  Recover locked RE Manager if the lock key is lost. The utility requires access to Redis
+  used by RE Manager. Provide the address of Redis service using '--redis-addr' parameter.
+  Restart the RE Manager service after clearing the lock.
+
+  optional arguments:
+    -h, --help        show this help message and exit
+    --redis-addr REDIS_ADDR
+                      The address of Redis server, e.g. 'localhost', '127.0.0.1',
+                      'localhost:6379' (default: localhost).

--- a/docs/source/features_and_config.rst
+++ b/docs/source/features_and_config.rst
@@ -154,29 +154,29 @@ to the project needs.
 Locking RE Manager
 ------------------
 
-Users and client applications can temporarily lock RE Manager. When the manager is locked, users 
+Users and client applications can temporarily lock RE Manager. When the manager is locked, users
 can access certain groups of API only by pass a *lock key* with API requests. The *lock key* is
-an arbitrary string selected by the user who locks RE Manager and stays valid until the manager 
+an arbitrary string selected by the user who locks RE Manager and stays valid until the manager
 is unlocked. The key could be shared with other users who need to control the locked manager.
 The lock status is stored in Redis. Restarting the manager does not reset the lock. If the manager
-is locked, it needs to be unlocked using valid lock key. Optionally, the emergency key may be set 
-using the environment variable ``QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER``. The emergency key allows 
+is locked, it needs to be unlocked using valid lock key. Optionally, the emergency key may be set
+using the environment variable ``QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER``. The emergency key allows
 to unlock the manager in case the lock key is lost. It can not be used to control the locked RE Manager.
 
 The :ref:`method_lock` API allows to lock the API that control RE Worker environment and/or the queue.
-The lock does not affect *read-only* API, therefore monitoring client applications will continue 
+The lock does not affect *read-only* API, therefore monitoring client applications will continue
 working when the manager is locked. The full list of API affected by locking the environment and
 the queue can be found in the documentation for :ref:`method_lock` API.
 
-The lock is not designed to be used for access control. The typical use case scenarios: 
+The lock is not designed to be used for access control. The typical use case scenarios:
 
 - A beamline scientist or on-site user locks the environment before entering the hutch to change samples.
-  This prevents remote users, autonomous agents etc. to open/close the environment, start the queue and 
-  execute plans and tasks. If necessary, the scientist who locked the environment may still perform 
+  This prevents remote users, autonomous agents etc. to open/close the environment, start the queue and
+  execute plans and tasks. If necessary, the scientist who locked the environment may still perform
   those operations using the secret lock key without unlocking the manager. Since the queue is not locked,
   the remote users and autonomous agents are still free to edit the queue or add plans to the queue.
 
-- A beamline scientist is performing maintenance or calibration and locks both the environment and 
+- A beamline scientist is performing maintenance or calibration and locks both the environment and
   the queue to have exclusive control of the manager.
 
 API for controlling and monitoring lock status of the manager:
@@ -185,21 +185,23 @@ API for controlling and monitoring lock status of the manager:
   the name of the user who locks the manager (required) and a text note to other users (optional).
   This information is returned as part of the lock info and included in all relevant error messages.
 
-- :ref:`method_unlock` - unlock the manager using the valid lock key (it must be the same key as 
-  for locking the manager) or the emergency lock key (if set).
+- :ref:`method_unlock` - unlock the manager using the valid lock key (it must be the same key as
+  for locking the manager) or the emergency lock key (if set). If the key is lost and the emergency
+  key is not set or unknown, the lock can be cleared using :ref:`qserver_clear_lock_cli` CLI tool
+  and restarting RE Manager application or service.
 
-- :ref:`method_lock_info` - load the manager lock status. The lock status is assigned a UID, which 
+- :ref:`method_lock_info` - load the manager lock status. The lock status is assigned a UID, which
   is updated each time the status is changed. The UID is included in the manager status (:ref:`method_status` API),
   which simplifies monitoring of the lock status. The manager status also contains *'lock'* parameter,
-  which indicates if the environment and/or the queue are currently locked. 
+  which indicates if the environment and/or the queue are currently locked.
 
-The operations of locking and unlocking RE Manager using CLI tool could be found in the tutorial 
+The operations of locking and unlocking RE Manager using CLI tool could be found in the tutorial
 :ref:`locking_re_manager_tutorial`.
 
 .. note::
 
-  The :ref:`method_lock` API controls access to other API, not internal operation of the server. 
-  For example, if the server is executing the queue, the queue will continue running after 
+  The :ref:`method_lock` API controls access to other API, not internal operation of the server.
+  For example, if the server is executing the queue, the queue will continue running after
   the manager is locked until it runs out of plans or stopped.
 
 

--- a/docs/source/features_and_config.rst
+++ b/docs/source/features_and_config.rst
@@ -149,6 +149,60 @@ It is recommended that new projects are started using the sample file
 which could be copied to the directory containing startup files and then modified according
 to the project needs.
 
+.. _locking_re_manager:
+
+Locking RE Manager
+------------------
+
+Users and client applications can temporarily lock RE Manager. When the manager is locked, users 
+can access certain groups of API only by pass a *lock key* with API requests. The *lock key* is
+an arbitrary string selected by the user who locks RE Manager and stays valid until the manager 
+is unlocked. The key could be shared with other users who need to control the locked manager.
+The lock status is stored in Redis. Restarting the manager does not reset the lock. If the manager
+is locked, it needs to be unlocked using valid lock key. Optionally, the emergency key may be set 
+using the environment variable ``QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER``. The emergency key allows 
+to unlock the manager in case the lock key is lost. It can not be used to control the locked RE Manager.
+
+The :ref:`method_lock` API allows to lock the API that control RE Worker environment and/or the queue.
+The lock does not affect *read-only* API, therefore monitoring client applications will continue 
+working when the manager is locked. The full list of API affected by locking the environment and
+the queue can be found in the documentation for :ref:`method_lock` API.
+
+The lock is not designed to be used for access control. The typical use case scenarios: 
+
+- A beamline scientist or on-site user locks the environment before entering the hutch to change samples.
+  This prevents remote users, autonomous agents etc. to open/close the environment, start the queue and 
+  execute plans and tasks. If necessary, the scientist who locked the environment may still perform 
+  those operations using the secret lock key without unlocking the manager. Since the queue is not locked,
+  the remote users and autonomous agents are still free to edit the queue or add plans to the queue.
+
+- A beamline scientist is performing maintenance or calibration and locks both the environment and 
+  the queue to have exclusive control of the manager.
+
+API for controlling and monitoring lock status of the manager:
+
+- :ref:`method_lock` - lock the environment and/or the queue using a lock key. The API also accepts
+  the name of the user who locks the manager (required) and a text note to other users (optional).
+  This information is returned as part of the lock info and included in all relevant error messages.
+
+- :ref:`method_unlock` - unlock the manager using the valid lock key (it must be the same key as 
+  for locking the manager) or the emergency lock key (if set).
+
+- :ref:`method_lock_info` - load the manager lock status. The lock status is assigned a UID, which 
+  is updated each time the status is changed. The UID is included in the manager status (:ref:`method_status` API),
+  which simplifies monitoring of the lock status. The manager status also contains *'lock'* parameter,
+  which indicates if the environment and/or the queue are currently locked. 
+
+The operations of locking and unlocking RE Manager using CLI tool could be found in the tutorial 
+:ref:`locking_re_manager_tutorial`.
+
+.. note::
+
+  The :ref:`method_lock` API controls access to other API, not internal operation of the server. 
+  For example, if the server is executing the queue, the queue will continue running after 
+  the manager is locked until it runs out of plans or stopped.
+
+
 Remote Monitoring of Console Output
 -----------------------------------
 

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -448,9 +448,14 @@ Description   Reload user group permissions from the default location or the loc
 Parameters    **restore_plans_devices**: *boolean* (optional)
                   reload the lists of existing plans and devices from disk if *True*, otherwise
                   use current lists stored in memory. Default: *False*.
+
               **restore_permissions**: *boolean* (optional)
                   reload user group permissions from disk if *True*, otherwise use current permissions.
                   Default: *True*.
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -503,6 +508,10 @@ Description   Uploads the dictionary of user group permissions. If the uploaded 
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **user_group_permissions**: *dict*
                   dictionary, which contains user group permissions.
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -578,7 +587,9 @@ Description   Clear the contents of the plan history.
 
               *The request always succeeds*.
 ------------  -----------------------------------------------------------------------------------------
-Parameters    ---
+Parameters    **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -604,7 +615,9 @@ Description   Initiate the creation of a new RE Worker environment. The request 
               the environment, close the existing environment first by sending 'environment_close'
               request. To destroy 'frozen' environment, use 'environment_destroy' method.
 ------------  -----------------------------------------------------------------------------------------
-Parameters    ---
+Parameters    **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -633,7 +646,9 @@ Description   Initiate the operation of closing the existing RE Worker environme
               is no existing environment or if RE Manager is not in 'idle' state. Use
               'environment_destroy' method to close a non-responsive RE Worker environment.
 ------------  -----------------------------------------------------------------------------------------
-Parameters    ---
+Parameters    **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -664,7 +679,9 @@ Description   Initiate the operation of destroying of the existing (unresponsive
               *True* or **manager_state** is *'creating_environment'*, otherwise the request is
               rejected.
 ------------  -----------------------------------------------------------------------------------------
-Parameters    ---
+Parameters    **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -700,6 +717,10 @@ Description   Sets parameters that define the mode of plan queue execution. The 
 Parameters    **mode**: *dict* or *str*
                   the dictionary of queue mode parameters or *'default'* string. Supported keys of
                   the dictionary: *'loop'* (*boolean*).
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -782,6 +803,10 @@ Parameters    **item**: *dict*
               **before_uid**, **after_uid**: *str* (optional)
                   insert the item before or after the item with the given item UID.
 
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
+
               *Parameters 'pos', 'before_uid' and 'after_uid' are mutually exclusive.*
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
@@ -842,6 +867,10 @@ Parameters    **items**: *list*
 
               **before_uid**, **after_uid**: *str* (optional)
                   insert the batch of items before or after the item with the given item UID.
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 
               *Parameters 'pos', 'before_uid' and 'after_uid' are mutually exclusive.*
 ------------  -----------------------------------------------------------------------------------------
@@ -913,6 +942,10 @@ Parameters    **item**: *dict*
               **replace**: *boolean* (optional)
                   replace the updated item UID with the new random UID (True) or keep the original
                   UID (False). Default value is (False).
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -989,6 +1022,10 @@ Parameters    **pos**: *int*, *'front'* or *'back'* (optional)
               **uid**: *str* (optional)
                   uid of the requested item.
 
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
+
               *Parameters 'pos' and 'uid' are mutually exclusive.*
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
@@ -1033,6 +1070,10 @@ Parameters    **uids**: *list(str)* (*required*)
                   items or some of the batch items are not found in the queue. If *'True'* (default),
                   then the method attempts to remove all items in the batch and ignores missing items.
                   The method returns the list of items that were removed from the queue.
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1074,6 +1115,10 @@ Parameters    **pos**: *int*, *'front'* or *'back'*
               **before_uid**, **after_uid**: *str*
                   UID of an existing item in the queue. The selected item will be moved
                   before or after this item.
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 
               *Parameters 'pos' and 'uid' are mutually exclusive, but at least one of them must
               be specified.*
@@ -1140,6 +1185,10 @@ Parameters    **uids**: *list(str)* (*required*)
                   Arranged moved items in the order of UIDs in the *'uids'* list
                   (*False*) or according to the original item positions in the queue (*True*).
 
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
+
               *Parameters 'pos_dest', 'before_uid' and 'after_uid' are mutually exclusive,
               but at least one of them must be specified.*
 ------------  -----------------------------------------------------------------------------------------
@@ -1205,6 +1254,10 @@ Parameters    **item**: *dict*
                   the name of the user (e.g. 'Default User'). The name is included in the item metadata
                   and may be used to identify the user who added the item to the queue. It is not
                   passed to the Run Engine or included in run metadata.
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1236,7 +1289,9 @@ Description   Remove all items from the plan queue. The currently running plan d
               the queue and is not affected by this operation. If the plan fails or its execution
               is stopped, it will be pushed to the beginning of the queue.
 ------------  -----------------------------------------------------------------------------------------
-Parameters    ---
+Parameters    **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the queue** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1260,7 +1315,9 @@ Description   Start execution of the queue. The operation succeeds only if RE Ma
               'idle' state and RE Worker environment exists. This operation only initiates
               the process of starting the execution of the queue.
 ------------  -----------------------------------------------------------------------------------------
-Parameters    ---
+Parameters    **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1292,7 +1349,9 @@ Description   Request RE Manager to stop execution of the queue after completion
               ('manager_state' status field has value 'executing_queue'). The 'queue_stop_pending'
               status field can be used at any time to verify if the request is pending.
 ------------  -----------------------------------------------------------------------------------------
-Parameters    ---
+Parameters    **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1317,7 +1376,9 @@ Description   Cancel the pending request to stop execution of the queue after th
 
               *The request always succeeds*.
 ------------  -----------------------------------------------------------------------------------------
-Parameters    ---
+Parameters    **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1355,6 +1416,10 @@ Description   Request Run Engine to pause currently running plan. The request wi
 Parameters    **option**: *'immediate'* or *'deferred'* (optional)
                   pause the plan immediately (roll back to the previous checkpoint) or continue
                   to the next checkpoint. Default: *'deferred'*.
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1385,6 +1450,10 @@ Returns       **success**: *boolean*
 
               **msg**: *str*
                   error message in case of failure, empty string ('') otherwise.
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Execution     The request only initiates the operation. Wait until the plan is paused by monitoring
               'manager_state' status field (expected value is 'executing_queue' if execution is
@@ -1475,6 +1544,10 @@ Parameters    **script**: *str*
                   are executed in separate threads and only thread-safe scripts should be uploaded
                   in the background. **Developers of data acquisition workflows and/or user
                   specific code are responsible for thread safety.**
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1541,6 +1614,10 @@ Parameters    **item**: *dict*
                   for thread safety to ensure there are no potential threading issues.
                   **Developers of data acquisition workflows and/or user specific code are
                   responsible for thread safety.**
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted 
+                  with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1667,7 +1744,7 @@ Description   Lock RE Manager with the provided lock key to prevent other client
               does not influence internal operation of the manager, e.g. the running queue will continue 
               running and has to be explicitly stopped if needed.
 
-              Each lockable API has an optional ``lock_key`` parameter. Passing a valid lock key
+              Each lockable API has an optional parameter **'lock_key'**. Passing a valid lock key
               (used to lock RE Manager) with the API requests allows to control RE Manager while it is 
               locked. This supports the scenarios when a beamline scientists locks RE Manager with 
               a unique code before entering the hutch to change samples or make adjustments and then 
@@ -1675,38 +1752,38 @@ Description   Lock RE Manager with the provided lock key to prevent other client
               agents or remote users. A remote operators may still control locked RE Manager if 
               the beamline scientists provides them with the lock key.
 
-              The API parameters allow to choose between locking **environment**, **queue** or both.
-              Locking **the environment** affects the following API: 
+              The API parameters allow to choose between locking the **environment**, the **queue** or both.
+              Locking the **environment** affects the following API: 
 
-              - **environment_open**
-              - **environment_close** 
-              - **environment_destroy**
-              - **queue_start** 
-              - **queue_stop**
-              - **queue_stop_cancel** 
-              - **queue_item_execute**
-              - **re_pause** 
-              - **re_resume**
-              - **re_stop**
-              - **re_abort** 
-              - **re_halt** 
-              - **script_upload** 
-              - **function_execute**
+              - :ref:`method_environment_open`
+              - :ref:`method_environment_close` 
+              - :ref:`method_environment_destroy`
+              - :ref:`method_queue_start`
+              - :ref:`method_queue_stop`
+              - :ref:`method_queue_stop_cancel` 
+              - :ref:`method_queue_item_execute`
+              - :ref:`method_re_pause` 
+              - :ref:`'re_resume' <method_re_resume_stop_abort_halt>`
+              - :ref:`'re_stop' <method_re_resume_stop_abort_halt>`
+              - :ref:`'re_abort' <method_re_resume_stop_abort_halt>` 
+              - :ref:`'re_halt' <method_re_resume_stop_abort_halt>` 
+              - :ref:`method_script_upload` 
+              - :ref:`method_function_execute`
 
-              Locking **the queue** affects the following API: 
+              Locking the **queue** affects the following API: 
               
-              - **queue_mode_set** 
-              - **queue_item_add**
-              - **queue_item_add_batch** 
-              - **queue_item_update** 
-              - **queue_item_remove**
-              - **queue_item_remove_batch** 
-              - **queue_item_move** 
-              - **queue_item_move_batch**
-              - **queue_clear** 
-              - **history_clear** 
-              - **permissions_reload** 
-              - **permissions_set**
+              - :ref:`method_queue_mode_set` 
+              - :ref:`method_queue_item_add`
+              - :ref:`method_queue_item_add_batch` 
+              - :ref:`method_queue_item_update` 
+              - :ref:`method_queue_item_remove`
+              - :ref:`method_queue_item_remove_batch` 
+              - :ref:`method_queue_item_move` 
+              - :ref:`method_queue_item_move_batch`
+              - :ref:`method_queue_clear` 
+              - :ref:`method_history_clear` 
+              - :ref:`method_permissions_reload` 
+              - :ref:`method_permissions_set`
 
               The additional parameters include the name of the user (**user**, required) who locked
               RE Manager and the message to other users (**note**, optional) which may explain
@@ -1717,6 +1794,11 @@ Description   Lock RE Manager with the provided lock key to prevent other client
               ``QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER`` environment variable. The emergency key
               could be used to unlock RE Manager if the lock key is lost. The emergency lock key is
               accepted only by the **unlock** API.
+
+              .. note:: 
+                
+                Restarting RE Manager does not change the lock status. The manager has to be unlocked
+                using the valid lock key or the emergency lock key.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **lock_key**: *str*
                   The lock key is an arbitrary non-empty string. Users/clients are expected to keep
@@ -1786,12 +1868,12 @@ Execution     Immediate: no follow-up requests are required.
 Method        **'lock_info'**
 ------------  -----------------------------------------------------------------------------------------
 Description   Load the lock status of RE Manager and optionally validate the lock key. Monitor 
-              *lock_info_uid* field of RE Manager status (see documentation for the **status** API) 
-              to detect changes in lock status and download the lock status only when the UID changes.
+              *lock_info_uid* field of RE Manager status (see documentation for the :ref:`method_status` 
+              API) to detect changes in lock status and download the lock status only when the UID changes.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **lock_key**: *str* or *None* (optional, default: *None*)
                   The parameter is used to validate the lock key (not the emergency lock key, see
-                  the documentation for **lock** API). If the lock key is a string that matches 
+                  the documentation for :ref:`method_lock` API). If the lock key is a string that matches 
                   the key used to lock RE Manager, then the request succeeds. If no lock key is passed
                   with the request, the lock key is *None* or RE Manager is not locked, then no validation 
                   is performed and the request always succeeds. The request fails if RE Manager is 
@@ -1807,7 +1889,7 @@ Returns       **success**: *boolean*
 
               **lock_info**: *dict*
                   Dictionary containing the information on the status of the lock. See the documentation
-                  on **lock** API for the detailed description.
+                  on :ref:`method_lock` API for the detailed description.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================
@@ -1822,11 +1904,11 @@ Execution     Immediate: no follow-up requests are required.
 Method        **'unlock'**
 ------------  -----------------------------------------------------------------------------------------
 Description   Unlock RE Manager with the lock key used to lock the manager or the emergency lock
-              key. See the documentation for **lock** API for more details. 
+              key. See the documentation for :ref:`method_lock` API for more details. 
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **lock_key**: *str*
-                  The lock key must match the key used to lock RE Manager (with **lock** API) or
-                  the emergency lock key.
+                  The lock key must match the key used to lock RE Manager (with :ref:`method_lock` API) 
+                  or the emergency lock key.
 ------------  -----------------------------------------------------------------------------------------
 Returns       **success**: *boolean*
                   indicates if the request was processed successfully.
@@ -1836,7 +1918,8 @@ Returns       **success**: *boolean*
 
               **lock_info**: *dict*
                   Dictionary containing the updated information on the lock status after the request 
-                  is processed. See the documentation on **lock** API for the detailed description.
+                  is processed. See the documentation on :ref:`method_lock` API for the detailed 
+                  description.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -1754,6 +1754,112 @@ Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================
 
 
+.. _method_lock_info:
+
+**'lock_info'**
+^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'lock_info'**
+------------  -----------------------------------------------------------------------------------------
+Description   Lock RE Manager with the provided lock key to prevent other clients from modifying
+------------  -----------------------------------------------------------------------------------------
+Parameters    **lock_key**: *str*
+                  The lock key is an arbitrary non-empty string. Users/clients are expected to keep
+                  the key used to lock RE Manager and use it to unlock the manager or make API requests.
+                  If the lock key is lost by accident, then RE Manager may be unlocked using the
+                  emergency lock key.
+
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+
+              **lock_info**: *dict*
+                  Dictionary containing the information on the status of the lock. The dictionary
+                  is also returned by **lock_info** API and includes the following fields:
+
+                  - **'environment'** (*boolean*) - indicates if the RE Worker environment is locked.
+
+                  - **'queue'** (*boolean*) - indicates if the queue is locked.
+
+                  - **'user'** (*str* or *None*) - the name of the user who locked RE Manager,
+                    *None* if the lock is not set.
+
+                  - **'note'** (*str* or *None*) - the text note left by the user who locked RE Manager,
+                    *None* if the lock is not set.
+
+                  - **'time'** (*float* or *None*) - timestamp (time when RE Manager was locked),
+                    *None* if the lock is not set.
+
+                  - **'time_str'** (*str*) - human-readable representation of the timestamp,
+                    empty string if the lock is not set.
+
+                  - **'emergency_lock_key_is_set'** (*boolean*) - indicates if the optional emergency
+                    lock key is set.
+
+                  - **'uid'** (*str*) - *lock_info* UID (also returned in RE Manager status).
+
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
+============  =========================================================================================
+
+
+.. _method_unlock:
+
+**'unlock'**
+^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'unlock'**
+------------  -----------------------------------------------------------------------------------------
+Description   Lock RE Manager with the provided lock key to prevent other clients from modifying
+------------  -----------------------------------------------------------------------------------------
+Parameters    **lock_key**: *str*
+                  The lock key is an arbitrary non-empty string. Users/clients are expected to keep
+                  the key used to lock RE Manager and use it to unlock the manager or make API requests.
+                  If the lock key is lost by accident, then RE Manager may be unlocked using the
+                  emergency lock key.
+
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+
+              **lock_info**: *dict*
+                  Dictionary containing the information on the status of the lock. The dictionary
+                  is also returned by **lock_info** API and includes the following fields:
+
+                  - **'environment'** (*boolean*) - indicates if the RE Worker environment is locked.
+
+                  - **'queue'** (*boolean*) - indicates if the queue is locked.
+
+                  - **'user'** (*str* or *None*) - the name of the user who locked RE Manager,
+                    *None* if the lock is not set.
+
+                  - **'note'** (*str* or *None*) - the text note left by the user who locked RE Manager,
+                    *None* if the lock is not set.
+
+                  - **'time'** (*float* or *None*) - timestamp (time when RE Manager was locked),
+                    *None* if the lock is not set.
+
+                  - **'time_str'** (*str*) - human-readable representation of the timestamp,
+                    empty string if the lock is not set.
+
+                  - **'emergency_lock_key_is_set'** (*boolean*) - indicates if the optional emergency
+                    lock key is set.
+
+                  - **'uid'** (*str*) - *lock_info* UID (also returned in RE Manager status).
+
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
+============  =========================================================================================
+
+
 
 .. _method_manager_stop:
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -920,6 +920,11 @@ Alternatively, ``qserver-list-plans-devices`` may be started from the ``~/qs_sta
   $ cd ~/qs_startup
   $ qserver-list-plans-devices --startup-dir .
 
+.. _locking_re_manager_tutorial:
+
+Locking RE Manager
+------------------
+
 .. _remote_monitoring_tutorial:
 
 Remote Monitoring of RE Manager Console Output

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1004,6 +1004,43 @@ To unlock the manager run ``qserver unlock`` with the valid lock key::
   'msg': '',
   'success': True}
 
+The lock status is stored in Redis and persists between sessions, i.e. restarting RE Manager
+does not clear the lock. If the key is lost, then the manager can be unlocked using
+an optional emergency lock key::
+
+  # Start RE Manager with the emergency lock key
+  QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER=emlockkey start-re-manager
+
+  # Lock the environment
+  $ qserver --lock-key key-to-forget lock environment
+
+  # Assume that the key is lost. Unlock the manager with the emergency key.
+  $ qserver --lock-key emlockkey unlock
+
+  # Check lock status. The manager should be unlocked.
+  $ qserver lock info
+
+If the emergency key is not set, then the lock can be
+cleared by running :ref:`qserver_clear_lock_cli` CLI tool and then restarting RE Manager
+service or application. The tool requires access to Redis server used by RE Manager.
+The following steps illustrate the procedure::
+
+  # Start RE Manager.
+
+  # Lock the environment
+  $ qserver --lock-key key-to-forget lock environment
+
+  # Check lock status
+  $ qserver lock info
+
+  # Assume that the key is lost. Clear the lock in Redis. Pass '--redis-addr' if needed.
+  qserver-clear-lock
+
+  # Stop and restart RE Manager application.
+
+  # Check lock status. The manager should be unlocked.
+  $ qserver lock info
+
 API used in this tutorial: :ref:`method_lock`, :ref:`method_lock_info`, :ref:`method_unlock`,
 :ref:`method_status`, :ref:`method_environment_open`, :ref:`method_environment_close`.
 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
             "qserver-list-plans-devices = bluesky_queueserver.manager."
             "profile_ops:gen_list_of_plans_and_devices_cli",
             "qserver-zmq-keys = bluesky_queueserver.manager.qserver_cli:qserver_zmq_keys",
+            "qserver-clear-lock = bluesky_queueserver.manager.qserver_cli:qserver_clear_lock",
             "qserver-console-monitor = bluesky_queueserver.manager.output_streaming:qserver_console_monitor_cli",
         ],
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Implementation of the new API: 

- `lock` - locks RE Manager (the worker environment and/or the queue) with user-provided lock key;
- `unlock` - unlocks RE Manager;
- `lock_info` - loads lock status and optionally validates the lock key. 

The description of implemented functionality:
The detailed description of the API:
Tutorial:


## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New `lock`, `unlock` and `lock_info` API. The API are accessible from CLI using `qserver lock` and `qserver unlock` commands.
- `qserver-clear-lock` CLI tool for unlocking RE Manager if the lock key is lost and the emergency lock key is not set or unknown.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Comprehensive unit tests are implemented.

<!--
## Screenshots (if appropriate):
-->
