### PR TITLE
FIX: generate the new list of plans and devices to fix unit test

### DIFF
--- a/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
+++ b/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
@@ -931,20 +931,20 @@ existing_devices:
       real1:
         classname: SoftPositioner
         is_flyable: false
-        is_movable: false
-        is_readable: false
+        is_movable: true
+        is_readable: true
         module: ophyd.positioner
       real2:
         classname: SoftPositioner
         is_flyable: false
-        is_movable: false
-        is_readable: false
+        is_movable: true
+        is_readable: true
         module: ophyd.positioner
       real3:
         classname: SoftPositioner
         is_flyable: false
-        is_movable: false
-        is_readable: false
+        is_movable: true
+        is_readable: true
         module: ophyd.positioner
     is_flyable: false
     is_movable: true
@@ -1013,20 +1013,20 @@ existing_devices:
       real1:
         classname: SoftPositioner
         is_flyable: false
-        is_movable: false
-        is_readable: false
+        is_movable: true
+        is_readable: true
         module: ophyd.positioner
       real2:
         classname: SoftPositioner
         is_flyable: false
-        is_movable: false
-        is_readable: false
+        is_movable: true
+        is_readable: true
         module: ophyd.positioner
       real3:
         classname: SoftPositioner
         is_flyable: false
-        is_movable: false
-        is_readable: false
+        is_movable: true
+        is_readable: true
         module: ophyd.positioner
       sig:
         classname: Signal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Generate the updated list of plans and devices for the built-in profile collection so that the resp unit tests `test_verify_default_profile_collection` worked with updated Bluesky/Ophyd.