### PR TITLE
`timeout` parameter for 0MQ API

### DIFF
--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -208,11 +208,11 @@ class PipeJsonRpcReceive:
                     # There is a major malfunction with the worker if you are here ...
                     logger.warning(
                         "The buffer is full. Message is discarded: %s. Report the bug to the development team",
-                        str(msg),
+                        msg,
                     )
                 except Exception as ex:
                     logger.exception(
-                        "Exception occurred while waiting for a message or receiving a message: %s", str(ex)
+                        "Exception occurred while waiting for a message or receiving a message: %s", ex
                     )
                     break
             if not self._thread_running:  # Exit thread
@@ -230,7 +230,7 @@ class PipeJsonRpcReceive:
             except queue.Empty:
                 pass
             except Exception as ex:
-                logger.exception("Exception occurred while processing the message %s: %s", str(msg), str(ex))
+                logger.exception("Exception occurred while processing the message %s: %s", msg, ex)
             if not self._thread_running:  # Exit thread
                 break
 
@@ -469,7 +469,7 @@ class PipeJsonRpcSendAsync:
                     # Messages should be handled in the event loop
                     self._loop.call_soon_threadsafe(self._conn_received, msg)
                 except Exception as ex:
-                    logger.exception("Exception occurred while waiting for packet: %s", str(ex))
+                    logger.exception("Exception occurred while waiting for packet: %s", ex)
                     break
             if not self._thread_running:  # Exit thread
                 break
@@ -569,7 +569,7 @@ class ZMQCommSendThreads:
             msg = zmq_comm.send_message(method="some_method", params={"some_value": n})
             # Code that uses msg
         except CommTimeoutError as ex:
-            logger.exception("Exception occurred: %s", str(ex)
+            logger.exception("Exception occurred: %s", ex)
 
         # Non-blocking call (trivial example)
         msg_received, msg_err_received = [], []
@@ -662,7 +662,7 @@ class ZMQCommSendThreads:
                         self._cb(msg, msg_err)
                     except Exception as ex:
                         # Operation should continue even if there are problems with callback
-                        logger.exception("Exception occurred in ZMQ communication callback: %s", str(ex))
+                        logger.exception("Exception occurred in ZMQ communication callback: %s", ex)
 
                 self._event_wait_for_msg.clear()
                 if self._blocking_call:
@@ -797,7 +797,7 @@ class ZMQCommSendThreads:
         # Successful connection does not mean that the socket exists
         self._zmq_socket.connect(self._zmq_server_address)
 
-        logger.info("Connected to ZeroMQ server '%s'" % str(self._zmq_server_address))
+        logger.info("Connected to ZeroMQ server '%s'", self._zmq_server_address)
         logger.info("ZMQ encryption: %s", "disabled" if self._server_public_key is None else "enabled")
 
     def _zmq_socket_restart(self):
@@ -983,7 +983,7 @@ class ZMQCommSendAsync:
                 raise Exception("timeout occurred")
         except Exception as ex:
             # Timeout occurred. Socket needs to be reset.
-            logger.exception("ZeroMQ communication failed: %s" % str(ex))
+            logger.exception("ZeroMQ communication failed: %s", ex)
             raise
         return msg
 
@@ -1012,7 +1012,7 @@ class ZMQCommSendAsync:
         # Successful connection does not mean that the socket exists
         self._zmq_socket.connect(self._zmq_server_address)
 
-        logger.info("Connected to ZeroMQ server '%s'" % str(self._zmq_server_address))
+        logger.info("Connected to ZeroMQ server '%s'", self._zmq_server_address)
         logger.info("ZMQ encryption: %s", "disabled" if self._server_public_key is None else "enabled")
 
     def _zmq_socket_restart(self):
@@ -1138,6 +1138,6 @@ def zmq_single_request(method, params=None, *, zmq_server_address=None, server_p
         msg_err = str(ex)
 
     if msg_err:
-        logger.warning("Communication with RE Manager failed: %s", str(msg_err))
+        logger.warning("Communication with RE Manager failed: %s", msg_err)
 
     return msg, msg_err

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -401,7 +401,6 @@ class PipeJsonRpcSendAsync:
 
         async with self._lock_comm:
             msg = format_jsonrpc_msg(method, params, notification=notification)
-            import time as ttime  ##
 
             try:
 

--- a/bluesky_queueserver/manager/comms.py
+++ b/bluesky_queueserver/manager/comms.py
@@ -401,6 +401,8 @@ class PipeJsonRpcSendAsync:
 
         async with self._lock_comm:
             msg = format_jsonrpc_msg(method, params, notification=notification)
+            import time as ttime  ##
+
             try:
 
                 # 'fut_send' sent along with the message. If the thread is still sending the previous
@@ -486,7 +488,8 @@ class PipeJsonRpcSendAsync:
         asyncio.create_task(self._response_received(response))
 
     async def _response_sent(self, response, fut_send):
-        fut_send.set_result(True)
+        if not fut_send.done():
+            fut_send.set_result(True)  # The result value is not used
 
     def _conn_sent(self, response, fut_send):
         asyncio.create_task(self._response_sent(response, fut_send))

--- a/bluesky_queueserver/manager/conversions.py
+++ b/bluesky_queueserver/manager/conversions.py
@@ -132,7 +132,7 @@ def simplify_plan_descriptions(plans_source):
                         p["default"] = default
                         p["is_optional"] = True
                     except Exception:
-                        logger.error(f"Failed to reconstruct the default value {param['default']} from string")
+                        logger.error("Failed to reconstruct the default value %s from string", param["default"])
                 p["is_optional"] = "default" in p
 
                 # Copy 'min', 'max' and 'step' values if any
@@ -140,17 +140,17 @@ def simplify_plan_descriptions(plans_source):
                     try:
                         p["min"] = _convert_str_to_number(param["min"])
                     except Exception as ex:
-                        logger.error(f"Failed to reconstruct 'min' value from string: {ex}")
+                        logger.error("Failed to reconstruct 'min' value from string: %s", ex)
                 if "max" in param:
                     try:
                         p["max"] = _convert_str_to_number(param["max"])
                     except Exception as ex:
-                        logger.error(f"Failed to reconstruct 'max' value from string: {ex}")
+                        logger.error("Failed to reconstruct 'max' value from string: %s", ex)
                 if "step" in param:
                     try:
                         p["step"] = _convert_str_to_number(param["step"])
                     except Exception as ex:
-                        logger.error(f"Failed to reconstruct 'step' value from string: {ex}")
+                        logger.error("Failed to reconstruct 'step' value from string: %s", ex)
 
                 plan["parameters"].append(p)
 
@@ -349,7 +349,7 @@ def spreadsheet_to_plan_list(*, spreadsheet_file, file_name, **kwargs):  # noqa:
             plan_list.append(plan)
 
         except Exception as ex:
-            logger.exception(f"{ex}")
+            logger.exception("Exception: %s", ex)
             raise ValueError(
                 f"Error occurred while interpreting plan parameters in row {nr + 1} ({_format_row(df, nr)}): {ex}"
             )

--- a/bluesky_queueserver/manager/logging_setup.py
+++ b/bluesky_queueserver/manager/logging_setup.py
@@ -1,5 +1,8 @@
+import copy
 import logging
 import sys
+import pprint
+from collections.abc import Iterable, Mapping
 
 
 def setup_loggers(*, log_level, name="bluesky_queueserver"):
@@ -29,3 +32,77 @@ def setup_loggers(*, log_level, name="bluesky_queueserver"):
     logging.getLogger(name).addHandler(log_stream_handler)
     logging.getLogger(name).setLevel(log_level)
     logging.getLogger(name).propagate = False
+
+
+class PPrintForLogging:
+    """
+    Applies ``pprint.pformat`` to logging messages::
+
+      logger.debug("Received message: %s", PPrintForLogging(msg))
+
+    The ``pprint.pformat`` is called only if the debug output is required, which reduces overhead.
+
+    Parameters
+    ----------
+    msg: object
+        A message to be printed
+    max_list_size: int (optional)
+        Maximum number of displayed elements of a lists (iterable)
+    max_dict_size: int (optional)
+        Maximum number of displayed elements of a dictionary (mapping). The number
+        should be large enought to fully display 'status'.
+
+    Returns
+    -------
+    str
+        Formatted object ``msg``.
+    """
+
+    def __init__(self, msg, *, max_list_size=10, max_dict_size=25):
+        self._msg = msg
+        self._max_list_size = max_list_size
+        self._max_dict_size = max_dict_size
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+
+        large_dict_keys = ("plans_allowed", "plans_existing", "devices_allowed", "devices_existing")
+
+        def convert_large_dicts(msg_in):
+            """
+            Some large dictionaries need to be treated in a special way.
+            """
+            if not isinstance(msg_in, Mapping):
+                return reduce_msg(msg_in)
+            else:
+                msg_out = copy.deepcopy(msg_in)
+                for k in msg_out.keys():
+                    msg_out[k] = "{...}"
+                return msg_out
+
+        def reduce_msg(msg_in):
+            if isinstance(msg_in, Mapping):
+                msg_out = {}
+                for n, k in enumerate(msg_in):
+                    if n < self._max_dict_size:
+                        if k in large_dict_keys:
+                            msg_out[k] = convert_large_dicts(msg_in[k])
+                        else:
+                            msg_out[k] = reduce_msg(msg_in[k])
+                    else:
+                        msg_out["..."] = "..."
+                        break
+            elif isinstance(msg_in, Iterable) and not isinstance(msg_in, str):
+                msg_out = list(msg_in[: self._max_list_size + 1])
+                n_pts = min(len(msg_out), self._max_list_size)
+                for n in range(n_pts):
+                    msg_out[n] = reduce_msg(msg_out[n])
+                if len(msg_out) > self._max_list_size:
+                    msg_out[-1] = "..."
+            else:
+                msg_out = msg_in
+            return msg_out
+
+        return pprint.pformat(reduce_msg(self._msg), sort_dicts=False)

--- a/bluesky_queueserver/manager/logging_setup.py
+++ b/bluesky_queueserver/manager/logging_setup.py
@@ -51,7 +51,15 @@ class PPrintForLogging:
         Maximum number of displayed elements of a lists (iterable)
     max_dict_size: int (optional)
         Maximum number of displayed elements of a dictionary (mapping). The number
-        should be large enought to fully display 'status'.
+        should be large enought to fully display 'status'. The dictionary values for
+        the keys ``plans_allowed``, ``plans_existing``, ``devices_allowed`` and
+        ``devices_existing``, which are dictionaries themselves are treated differently:
+        all the keys (names of plans or devices) are kept, but all values are replaced with
+        ``"{ ... }"`` (string).
+    max_chars_in_str: int (optional)
+        Strings longer then specified number of characters are truncated. Only the first
+        and the last ``max_chars_in_str / 2`` are printed. If the string is the value
+        of a ``traceback`` key of a dictionary, then it is not truncated.
 
     Returns
     -------

--- a/bluesky_queueserver/manager/logging_setup.py
+++ b/bluesky_queueserver/manager/logging_setup.py
@@ -101,7 +101,6 @@ class PPrintForLogging:
 
             return msg_out, new_entries
 
-
         msg_reduced, queue = process_entry(self._msg)
 
         while queue:

--- a/bluesky_queueserver/manager/logging_setup.py
+++ b/bluesky_queueserver/manager/logging_setup.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import sys
 import pprint
@@ -79,8 +78,8 @@ class PPrintForLogging:
             if not isinstance(msg_in, Mapping):
                 return reduce_msg(msg_in)
             else:
-                msg_out = copy.deepcopy(msg_in)
-                for k in msg_out.keys():
+                msg_out = {}
+                for k in msg_in.keys():
                     msg_out[k] = "{...}"
                 return msg_out
 
@@ -109,10 +108,9 @@ class PPrintForLogging:
 
         if version.parse(python_version()) < version.parse("3.8"):
             # NOTE: delete this after support for 3.7 is dropped
-            f_sorted = pprint._sorted
-            pprint._sorted = lambda x: x
+            pprint.sorted = lambda x, key=None: x
             msg_out = pprint.pformat(reduce_msg(self._msg))
-            pprint._sorted = f_sorted
+            delattr(pprint, "sorted")
         else:
             msg_out = pprint.pformat(reduce_msg(self._msg), sort_dicts=False)
 

--- a/bluesky_queueserver/manager/logging_setup.py
+++ b/bluesky_queueserver/manager/logging_setup.py
@@ -3,6 +3,8 @@ import logging
 import sys
 import pprint
 from collections.abc import Iterable, Mapping
+from platform import python_version
+from packaging import version
 
 
 def setup_loggers(*, log_level, name="bluesky_queueserver"):
@@ -105,4 +107,13 @@ class PPrintForLogging:
                 msg_out = msg_in
             return msg_out
 
-        return pprint.pformat(reduce_msg(self._msg), sort_dicts=False)
+        if version.parse(python_version()) < version.parse("3.8"):
+            # NOTE: delete this after support for 3.7 is dropped
+            f_sorted = pprint._sorted
+            pprint._sorted = lambda x: x
+            msg_out = pprint.pformat(reduce_msg(self._msg))
+            pprint._sorted = f_sorted
+        else:
+            msg_out = pprint.pformat(reduce_msg(self._msg), sort_dicts=False)
+
+        return msg_out

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -308,6 +308,8 @@ class RunEngineManager(Process):
             try:
                 await asyncio.sleep(t_period)
                 await self._watchdog_send_heartbeat()
+            except asyncio.CancelledError:
+                break
             except Exception as ex:
                 logger.warning(f"Exception occurred while sending heartbeat: {ex}")
 
@@ -3337,6 +3339,7 @@ class RunEngineManager(Process):
                     await self._kill_re_worker_task()
 
                 await self._watchdog_manager_stopping()
+                self._heartbeat_generator_task.cancel()
                 self._comm_to_watchdog.stop()
                 self._comm_to_worker.stop()
                 self._zmq_socket.close()

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -3289,26 +3289,8 @@ class RunEngineManager(Process):
 
             msg_out = await self._zmq_execute(msg_in)
 
-            def gen_log_msg(msg_out):
-                """
-                Avoid printing large dictionaries (allowed devices or allowed plans) in the log.
-                Replace values with "..." for better visualization.
-                """
-                log_msg_out = copy.copy(msg_out)
-                # Do not print large dicts in the log: replace values with "..."
-                large_dicts = ("plans_allowed", "plans_existing", "devices_allowed", "devices_existing")
-                for dict_name in large_dicts:
-                    if dict_name in log_msg_out:
-                        d = copy.deepcopy(log_msg_out[dict_name])
-                        for k in d.keys():
-                            d[k] = "{...}"
-                return log_msg_out
-
-            if logger.level <= logging.DEBUG:
-                msg_out_reduced = gen_log_msg(msg_out)
-                logger.debug("ZeroMQ server sending response: %s", ppfl(msg_out_reduced))
-
             #  Send reply back to client
+            logger.debug("ZeroMQ server sending response: %s", ppfl(msg_out))
             await self._zmq_send(msg_out)
 
             if self._manager_stopping:

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -2518,27 +2518,22 @@ class RunEngineManager(Process):
 
             self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
-            logger.info("function_execute: getting data from request")  ##
             item, item_type, _success, _msg = self._get_item_from_request(
                 request=request, supported_item_types=("function",)
             )
             if not _success:
                 raise Exception(_msg)
-            logger.info("function_execute: checking user and user group")  ##
 
             user, user_group = self._get_user_info_from_request(request=request)
             run_in_background = bool(request.get("run_in_background", False))
 
-            logger.info("function_execute: preparing item")  ##
             item, _ = self._prepare_item(
                 item=item, item_type=item_type, user=user, user_group=user_group, generate_new_uid=True
             )
 
-            logger.info("function_execute: calling '_environment_function_execute'")  ##
             success, msg, item, task_uid = await self._environment_function_execute(
                 item=item, run_in_background=run_in_background
             )
-            logger.info("function_execute: completed")  ##
             if not success:
                 raise RuntimeError(msg)
 
@@ -3107,7 +3102,6 @@ class RunEngineManager(Process):
         }
 
         try:
-            logger.info("starting the handler")  ##
             if isinstance(msg, str):
                 raise Exception(f"Failed to decode the request: {msg}")
             if not isinstance(msg, dict):
@@ -3123,7 +3117,6 @@ class RunEngineManager(Process):
             method = msg["method"]  # Required
             params = msg.get("params", {})  # Optional
 
-            logger.info(f"handling message: method={method}")  ##
             handler_name = handler_dict[method]
             handler = getattr(self, handler_name)
             result = await handler(params)
@@ -3144,7 +3137,6 @@ class RunEngineManager(Process):
     async def _zmq_receive(self):
         try:
             msg_in = await self._zmq_socket.recv_json()
-            logger.info("zmq message received")  ##
         except Exception as ex:
             msg_in = f"JSON decode error: {ex}"
         return msg_in
@@ -3284,9 +3276,7 @@ class RunEngineManager(Process):
         while True:
             #  Wait for next request from client
             msg_in = await self._zmq_receive()
-            logger.info("Received request")  ##
             logger.debug("ZeroMQ server received request: %s", ppfl(msg_in))
-            logger.info("Following with execute")  ##
 
             msg_out = await self._zmq_execute(msg_in)
 

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -306,9 +306,7 @@ class RunEngineManager(Process):
         t_period = 0.5
         while True:
             try:
-                logger.debug("Waiting for the next heartbeat: %s", str(ttime.time()))  ##
                 await asyncio.sleep(t_period)
-                logger.debug("Requesting to send heartbeat: %s", str(ttime.time()))  ##
                 await self._watchdog_send_heartbeat()
             except Exception as ex:
                 logger.warning(f"Exception occurred while sending heartbeat: {ex}")
@@ -1400,7 +1398,6 @@ class RunEngineManager(Process):
         """
         Send (periodic) heartbeat signal to Watchdog.
         """
-        logger.debug("Sending heartbeat: %s", str(ttime.time()))  ##
         await self._comm_to_watchdog.send_msg("heartbeat", {"value": "alive"}, notification=True)
 
     # =========================================================================
@@ -1849,7 +1846,6 @@ class RunEngineManager(Process):
             allowed_plans = self._allowed_plans[user_group] if self._allowed_plans else self._allowed_plans
             allowed_devices = self._allowed_devices[user_group] if self._allowed_devices else self._allowed_devices
             success, msg = validate_plan(item, allowed_plans=allowed_plans, allowed_devices=allowed_devices)
-            ## success, msg = True, ""  ##
         elif item_type == "instruction":
             # At this point we support only one instruction ('queue_stop'), so validation is trivial.
             if ("name" in item) and (item["name"] == "queue_stop"):
@@ -2003,19 +1999,9 @@ class RunEngineManager(Process):
 
         logger.debug("Starting validation of item batch ...")
 
-        t0 = ttime.time()  ##
-        t1 = t0  ##
-
         success, items_prepared, results = True, [], []
-        for n, item_info in enumerate(items):
-            # if n > 10:
-            #     break
+        for item_info in items:
             item, item_type = None, None
-            if not (n % 200):  ##
-                t2 = ttime.time()  ##
-                dt = t2 - t1  ##
-                t1 = t2  ##
-                logger.debug("n=%s time=%s dt=%s", n, t2 - t0, dt)  ##
 
             try:
                 item, item_type, _success, _msg = self._get_item_from_request(item=item_info)
@@ -2027,11 +2013,6 @@ class RunEngineManager(Process):
                     item=item, item_type=item_type, user=user, user_group=user_group, generate_new_uid=True
                 )
 
-                # for n in range(2000):  ##
-                #     item_prepared, _ = self._prepare_item(  ##
-                #         item=item, item_type=item_type, user=user, user_group=user_group, generate_new_uid=True  ##
-                #     )  ##
-
                 items_prepared.append(item_prepared)
                 results.append({"success": True, "msg": ""})
 
@@ -2039,18 +2020,6 @@ class RunEngineManager(Process):
                 success = False
                 items_prepared.append(item)  # Add unchanged item or None if no item is found
                 results.append({"success": False, "msg": f"Failed to add a plan: {ex}"})
-
-        # allowed_plans = self._allowed_plans[user_group] if self._allowed_plans else self._allowed_plans  ##
-        # allowed_devices = self._allowed_devices[user_group] if self._allowed_devices else self._allowed_devices  ##
-        # for n in range(len(items)-4000):  ##
-        #     if not (n % 100):  ##
-        #         ttime.sleep(0.1)  ##
-        #     validate_plan(items[0], allowed_plans=allowed_plans, allowed_devices=allowed_devices)  ##
-
-        # start = ttime.time()
-        # i = 0
-        # while ttime.time() - start < 90:  ##
-        #     i += 1  ##
 
         logger.debug("Validation of item batch completed: success=%s.", success)
 
@@ -2105,53 +2074,9 @@ class RunEngineManager(Process):
             after_uid = request.get("after_uid", None)
 
             # First validate all the items
-            logger.info(f"Validating items")  ##
             success, items_prepared, results = await self._loop.run_in_executor(
                 None, self.validate_item_batch, items, user, user_group
             )
-
-            # import math
-            # n_items, n_step = len(items), 500
-            # n_intervals = math.ceil(n_items/n_step)
-
-            # for n in range(n_intervals):
-            #     ## if n > 0:
-            #     ##     await asyncio.sleep(2)
-            #     logger.debug("Range %s ... %s", n * n_step, (n+1)*n_step - 1)  ##
-            #     _success, _items_prepared, _results = await self._loop.run_in_executor(
-            #         None, self.validate_item_batch, items[n * n_step: (n+1)*n_step], user, user_group
-            #     )
-            #     success = success if not success else _success
-            #     items_prepared.extend(_items_prepared)
-            #     results.extend(_results)
-
-            # success, items_prepared, results = self.validate_item_batch(items=items, user=user, user_group=user_group)
-
-            # for n, item_info in enumerate(items):
-            #     if not (n % 200):
-            #         await self._watchdog_send_heartbeat()
-            #         # await asyncio.sleep(0.05)
-            #         logger.debug("n=%s", n) ##
-            #     item, item_type = None, None
-            #     try:
-            #         item, item_type, _success, _msg = self._get_item_from_request(item=item_info)
-            #         if not _success:
-            #             raise Exception(_msg)
-
-            #         # Always generate a new UID for the added plan!!!
-            #         item_prepared, _ = self._prepare_item(
-            #             item=item, item_type=item_type, user=user, user_group=user_group, generate_new_uid=True
-            #         )
-
-            #         items_prepared.append(item_prepared)
-            #         results.append({"success": True, "msg": ""})
-
-            #     except Exception as ex:
-            #         success = False
-            #         items_prepared.append(item)  # Add unchanged item or None if no item is found
-            #         results.append({"success": False, "msg": f"Failed to add a plan: {ex}"})
-
-            logger.info(f"Validation completed")  ##
 
             if len(results) != len(items) != len(items_prepared):
                 # This error should never happen, but the message may be useful for debugging if it happens.

--- a/bluesky_queueserver/manager/output_streaming.py
+++ b/bluesky_queueserver/manager/output_streaming.py
@@ -153,7 +153,7 @@ class PublishConsoleOutput:
                 logger.error(
                     "Failed to create 0MQ socket at %s. Console output will not be published. Exception: %s",
                     self._zmq_publish_addr,
-                    str(ex),
+                    ex,
                 )
 
         if self._socket and self._zmq_publish_on:
@@ -262,8 +262,8 @@ class ReceiveConsoleOutput:
 
         zmq_subscribe_addr = zmq_subscribe_addr or default_zmq_info_address
 
-        logger.info(f"Subscribing to console output stream from 0MQ address: {zmq_subscribe_addr} ...")
-        logger.info(f"Subscribing to 0MQ topic: '{zmq_topic}' ...")
+        logger.info("Subscribing to console output stream from 0MQ address: %s ...", zmq_subscribe_addr)
+        logger.info("Subscribing to 0MQ topic: '%s' ...", zmq_topic)
         self._zmq_subscribe_addr = zmq_subscribe_addr
         self._zmq_topic = zmq_topic
 
@@ -441,8 +441,8 @@ class ReceiveConsoleOutputAsync:
         self._exit = False
         self._is_running = False
 
-        logger.info(f"Subscribing to console output stream from 0MQ address: {zmq_subscribe_addr} ...")
-        logger.info(f"Subscribing to 0MQ topic: '{zmq_topic}' ...")
+        logger.info("Subscribing to console output stream from 0MQ address: %s ...", zmq_subscribe_addr)
+        logger.info("Subscribing to 0MQ topic: '%s' ...", zmq_topic)
         self._zmq_subscribe_addr = zmq_subscribe_addr
         self._zmq_topic = zmq_topic
 
@@ -542,7 +542,9 @@ class ReceiveConsoleOutputAsync:
         except TimeoutError:
             pass
         except Exception as ex:
-            logger.exception(f"Exception occurred while while waiting for RE Manager console output message: {ex}")
+            logger.exception(
+                "Exception occurred while while waiting for RE Manager console output message: %s", ex
+            )
 
         if not self._exit:
             asyncio.ensure_future(self._recv_next_message())

--- a/bluesky_queueserver/manager/plan_monitoring.py
+++ b/bluesky_queueserver/manager/plan_monitoring.py
@@ -121,9 +121,9 @@ class CallbackRegisterRun(CallbackBase):
             self._run_list.add_run(uid=uid)
 
             logger.info("New run was open: '%s'", uid)
-            logger.debug("Run list: %s", str(self._run_list.get_run_list()))
+            logger.debug("Run list: %s", self._run_list.get_run_list())
         except Exception as ex:
-            logger.exception(f"RE Manager: Could not register new run: {ex}")
+            logger.exception("RE Manager: Could not register new run: %s", ex)
 
     def stop(self, doc):
         """
@@ -136,4 +136,4 @@ class CallbackRegisterRun(CallbackBase):
 
             print(f"Run was closed: '{uid}'")
         except Exception as ex:
-            logger.exception(f"RE Manager: Failed to label run as closed: {ex}")
+            logger.exception("RE Manager: Failed to label run as closed: %s", ex)

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -792,7 +792,7 @@ class PlanQueueOperations:
                 item, _ = await self._pop_item_from_queue(uid=uid)
                 items.append(item)
             except Exception as ex:
-                logger.debug("Failed to remove item with UID '%s' from the queue: %s", uid, str(ex))
+                logger.debug("Failed to remove item with UID '%s' from the queue: %s", uid, ex)
 
         qsize = await self._get_queue_size()
         return items, qsize
@@ -1023,7 +1023,7 @@ class PlanQueueOperations:
                     await self._pop_item_from_queue(uid=uid)
                 except Exception as ex:
                     logger.error(
-                        "Failed to remove an item with uid='%s' after failure to add a batch of plans", str(ex)
+                        "Failed to remove an item with uid='%s' after failure to add a batch of plans", ex
                     )
 
             # Also do not return 'changed' items if adding the batch failed.

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -1401,8 +1401,18 @@ class PlanQueueOperations:
         """
         See ``self.clear_queue()`` method.
         """
-        while await self._get_queue_size():
-            await self._pop_item_from_queue()
+        self._plan_queue_uid = self.new_item_uid()
+        await self._r_pool.delete(self._name_plan_queue)
+
+        # Remove all entries from 'self._uid_dict' except the running item.
+        running_item = await self._get_running_item_info()
+        if running_item:
+            uid = running_item["item_uid"]
+            item = self._uid_dict_get_item(uid)
+            self._uid_dict_clear()
+            self._uid_dict_add(item)
+        else:
+            self._uid_dict_clear()
 
     async def clear_queue(self):
         """
@@ -1480,8 +1490,7 @@ class PlanQueueOperations:
         See ``self.clear_history()`` method.
         """
         self._plan_history_uid = self.new_item_uid()
-        while await self._get_history_size():
-            await self._r_pool.rpop(self._name_plan_history)
+        await self._r_pool.delete(self._name_plan_history)
 
     async def clear_history(self):
         """

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -7,7 +7,6 @@ import pkg_resources
 import yaml
 import re
 import sys
-import pprint
 import jsonschema
 import copy
 import typing
@@ -22,6 +21,8 @@ import traceback
 
 import logging
 import bluesky_queueserver
+
+from .logging_setup import PPrintForLogging as ppfl
 
 logger = logging.getLogger(__name__)
 qserver_version = bluesky_queueserver.__version__
@@ -796,7 +797,7 @@ def prepare_plan(plan, *, plans_in_nspace, devices_in_nspace, allowed_plans, all
 
     if not success_meta:
         success = False
-        err_msg = f"Plan metadata must be a dictionary or a list of dictionaries: '{pprint.pformat(plan_meta)}'"
+        err_msg = f"Plan metadata must be a dictionary or a list of dictionaries: '{ppfl(plan_meta)}'"
 
     if not success:
         raise RuntimeError(f"Error while parsing the plan: {err_msg}")
@@ -2310,7 +2311,7 @@ def validate_plan(plan, *, allowed_plans, allowed_devices):
 
     except Exception as ex:
         success = False
-        msg = f"Plan validation failed: {str(ex)}\nPlan: {pprint.pformat(plan)}"
+        msg = f"Plan validation failed: {str(ex)}\nPlan: {ppfl(plan)}"
 
     return success, msg
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -181,7 +181,7 @@ def load_profile_collection(path, *, patch_profiles=True, keep_re=False):
         for file in file_list:
 
             try:
-                logger.info(f"Loading startup file {file!r} ...")
+                logger.info("Loading startup file '%s' ...", file)
 
                 # Set '__file__' and '__name__' variables
                 patch = f"__file__ = '{file}'; __name__ = 'startup_script'\n"
@@ -447,7 +447,7 @@ def load_script_into_existing_nspace(
 
     root_path_exists = script_root_path and os.path.isdir(script_root_path)
     if enable_local_imports and not root_path_exists:
-        logger.error(f"The path {script_root_path!r} does not exist. Local imports will not work.")
+        logger.error("The path '%s' does not exist. Local imports will not work.", script_root_path)
 
     use_local_imports = enable_local_imports and root_path_exists
 
@@ -589,7 +589,7 @@ def _get_nspace_object(object_name, *, objects_in_nspace):
                 device = getattr(device, c, None)
                 if object_found is None:
                     object_found = False
-                    logger.error("Device '%s' does not have attribute (subdevice) '%s'", str(object_name), str(c))
+                    logger.error("Device '%s' does not have attribute (subdevice) '%s'", object_name, c)
                 object_found = object_found if device else False
 
             else:
@@ -2853,7 +2853,7 @@ def _prepare_devices(devices, *, max_depth=0, ignore_all_subdevices_if_one_fails
                 except Exception as ex:
                     ignore_subdevices = ignore_all_subdevices_if_one_fails
                     logger.warning(
-                        f"Device '%s': component {comp_name!r} can not be processed: %s", device_name, ex
+                        "Device '%s': component '%s' can not be processed: %s", device_name, comp_name, ex
                     )
                 if ignore_subdevices:
                     components = {}  # Ignore all components of the subdevice
@@ -3143,7 +3143,7 @@ def load_existing_plans_and_devices(path_to_file=None):
         try:
             existing_plans_and_devices = yaml.load(stream, Loader=yaml.FullLoader)
         except Exception as ex:
-            logger.error("%s File '%s' has invalid YAML: %s", msg, path_to_file, str(ex))
+            logger.error("%s File '%s' has invalid YAML: %s", msg, path_to_file, ex)
             existing_plans_and_devices = {}
 
     if not isinstance(existing_plans_and_devices, dict):
@@ -3294,7 +3294,7 @@ def update_existing_plans_and_devices(
                 )
             except Exception as ex:
                 logger.error(
-                    "Failed to save lists of existing plans and device to file '%s': %s", path_to_file, str(ex)
+                    "Failed to save lists of existing plans and device to file '%s': %s", path_to_file, ex
                 )
 
     return changes_exist
@@ -3706,7 +3706,7 @@ def load_allowed_plans_and_devices(
             allowed_plans[group] = selected_plans
 
     except Exception as ex:
-        logger.exception("Error occurred while generating the list of allowed plans and devices: %s", str(ex))
+        logger.exception("Error occurred while generating the list of allowed plans and devices: %s", ex)
 
         # The 'default' lists in case error occurred while generating lists
         allowed_plans["root"] = existing_plans

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -1246,10 +1246,10 @@ def qserver():
             ttime.sleep(1)
 
     except CommandParameterError as ex:
-        logger.error("Invalid command or parameters: %s.", str(ex))
+        logger.error("Invalid command or parameters: %s.", ex)
         exit_code = QServerExitCodes.PARAMETER_ERROR
     except Exception as ex:
-        logger.exception("Exception occurred: %s.", str(ex))
+        logger.exception("Exception occurred: %s.", ex)
         exit_code = QServerExitCodes.EXCEPTION_OCCURRED
     except KeyboardInterrupt:
         print("\nThe program was manually stopped.")
@@ -1357,7 +1357,7 @@ def qserver_clear_lock():
                 print("No lock was detected.")
         except Exception as ex:
             exit_code = 1
-            logger.error(f"Failed to clear RE Manager lock: {ex}")
+            logger.error("Failed to clear RE Manager lock: %s", ex)
 
     asyncio.run(remove_lock())
 

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -2,7 +2,6 @@ import ast
 import copy
 import time as ttime
 from datetime import datetime
-import pprint
 import argparse
 import enum
 import os
@@ -17,7 +16,7 @@ from .comms import (
     generate_zmq_keys,
     default_zmq_control_address,
 )
-
+from .logging_setup import PPrintForLogging as ppfl
 from .plan_queue_ops import PlanQueueOperations
 
 import logging
@@ -1123,7 +1122,7 @@ def prepare_qserver_output(msg):
             d = msg[dict_name]
             for k in d.keys():
                 d[k] = "{...}"
-    return pprint.pformat(msg)
+    return ppfl(msg)
 
 
 def qserver():
@@ -1350,7 +1349,7 @@ def qserver_clear_lock():
             await pq.start()
             lock_info = await pq.lock_info_retrieve()
             if lock_info is not None:
-                print(f"Detected lock info:\n{pprint.pformat(lock_info)}")
+                print(f"Detected lock info:\n{ppfl(lock_info)}")
                 print("Clearing the lock ...")
                 await pq.lock_info_clear()
                 print("RE Manager lock was cleared. Restart RE Manager service to unlock the manager!")

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -570,7 +570,7 @@ def start_manager():
         # Check if startup script exists (if it is specified)
         if startup_script_path is not None:
             if not os.path.isfile(startup_script_path):
-                logger.error(f"The script '{startup_script_path}' is not found.")
+                logger.error("The script '%s' is not found.", startup_script_path)
                 return 1
 
     config_worker["keep_re"] = args.keep_re
@@ -649,7 +649,7 @@ def start_manager():
         try:
             validate_zmq_key(zmq_private_key)
         except Exception as ex:
-            logger.error("ZMQ private key is improperly formatted: %s", str(ex))
+            logger.error("ZMQ private key is improperly formatted: %s", ex)
             return 1
 
     zmq_control_addr = args.zmq_control_addr
@@ -666,7 +666,7 @@ def start_manager():
 
     redis_addr = args.redis_addr
     if redis_addr.count(":") > 1:
-        logger.error(f"Redis address is incorrectly formatted: '{redis_addr}'")
+        logger.error("Redis address is incorrectly formatted: '%s'", redis_addr)
         return 1
     config_manager["redis_addr"] = redis_addr
 

--- a/bluesky_queueserver/manager/tests/plan_lists.py
+++ b/bluesky_queueserver/manager/tests/plan_lists.py
@@ -109,7 +109,7 @@ def create_excel_file_from_plan_list(tmp_path, *, plan_list, ss_filename="spread
         for key in df.keys():
             for n in range(len(df[key])):
                 try:
-                    df[key][n] = str_to_number(df[key][n])
+                    df.loc[n, key] = str_to_number(df.loc[n, key])
                 except Exception:
                     pass
         return df

--- a/bluesky_queueserver/manager/tests/test_comms.py
+++ b/bluesky_queueserver/manager/tests/test_comms.py
@@ -3,6 +3,7 @@ import time as ttime
 import json
 import logging
 import multiprocessing
+import pprint
 import threading
 import asyncio
 import zmq
@@ -1133,7 +1134,48 @@ def test_ZMQCommSendThreads_4(is_blocking, raise_exception, delay_between_reads,
     thread.join()
 
 
-def test_ZMQCommSendThreads_5_fail():
+def _zmq_server_delay3(delay):
+    """
+    ZMQ server: delay of 3 seconds before the response
+    """
+    ctx = zmq.Context()
+    zmq_socket = ctx.socket(zmq.REP)
+    zmq_socket.bind("tcp://*:60615")
+    msg_in = zmq_socket.recv_json()
+    ttime.sleep(delay)  # Generate timeout at the client
+    msg_out = {"success": True, "msg_in": msg_in}
+    zmq_socket.send_json(msg_out)
+    zmq_socket.close(linger=10)
+
+
+# fmt: off
+@pytest.mark.parametrize("timeout", [None, 2000, 5000])
+# fmt: on
+def test_ZMQCommSendThreads_5(timeout):
+    """
+    ZMQCommSendThreads: Pass timeout as 'send_message' parameter.
+    """
+    delay = 3000
+    thread = threading.Thread(target=_zmq_server_delay3, kwargs={"delay": delay / 1000})
+    thread.start()
+
+    timeout_default = 2000
+    zmq_comm = ZMQCommSendThreads(timeout_recv=timeout_default)
+    method, params = "testing", {"p1": 10, "p2": "abc"}
+
+    timeout_used = timeout or timeout_default
+
+    if timeout_used < delay:
+        with pytest.raises(CommTimeoutError, match="timeout occurred"):
+            zmq_comm.send_message(method=method, params=params, timeout=timeout, raise_exceptions=True)
+    else:
+        msg_recv = zmq_comm.send_message(method=method, params=params, timeout=timeout, raise_exceptions=True)
+        assert msg_recv["success"] is True, pprint.pformat(msg_recv)
+
+    thread.join()
+
+
+def test_ZMQCommSendThreads_6_fail():
     """
     Invalid public key
     """
@@ -1302,7 +1344,39 @@ def test_ZMQCommSendAsync_4(raise_exception, delay_between_reads, encryption_ena
     thread.join()
 
 
-def test_ZMQCommSendAsync_5_fail():
+# fmt: off
+@pytest.mark.parametrize("timeout", [None, 2000, 5000])
+# fmt: on
+def test_ZMQCommSendAsync_5(timeout):
+    """
+    ZMQCommSendThreads: Pass timeout as 'send_message' parameter.
+    """
+    delay = 3000
+    thread = threading.Thread(target=_zmq_server_delay3, kwargs={"delay": delay / 1000})
+    thread.start()
+
+    async def testing():
+        timeout_default = 2000
+        zmq_comm = ZMQCommSendAsync(timeout_recv=timeout_default)
+        method, params = "testing", {"p1": 10, "p2": "abc"}
+
+        timeout_used = timeout or timeout_default
+
+        if timeout_used < delay:
+            with pytest.raises(CommTimeoutError, match="timeout occurred"):
+                await zmq_comm.send_message(method=method, params=params, timeout=timeout, raise_exceptions=True)
+        else:
+            msg_recv = await zmq_comm.send_message(
+                method=method, params=params, timeout=timeout, raise_exceptions=True
+            )
+            assert msg_recv["success"] is True, pprint.pformat(msg_recv)
+
+    asyncio.run(testing())
+
+    thread.join()
+
+
+def test_ZMQCommSendAsync_6_fail():
     """
     Invalid public key
     """

--- a/bluesky_queueserver/manager/tests/test_comms.py
+++ b/bluesky_queueserver/manager/tests/test_comms.py
@@ -298,7 +298,7 @@ def test_PipeJsonRpcReceive_5(clear_buffer):
     # Non-existing method ('Method not found' error)
     request = format_jsonrpc_msg("method3")
 
-    n_buf = pc._msg_buffer_size
+    n_buf = pc._msg_recv_buffer_size
 
     conn1.send(json.dumps(request))
     ttime.sleep(1)
@@ -464,7 +464,7 @@ def test_PipeJsonRpcSendAsync_1():
 
         pc = PipeJsonRpcSendAsync(conn=conn1, name=new_name)
         pc.start()
-        assert count_threads_with_name(new_name) == 1, "One thread is expected to exist"
+        assert count_threads_with_name(new_name) == 2, "One thread is expected to exist"
 
         pc.start()  # Expected to do nothing
 
@@ -473,7 +473,7 @@ def test_PipeJsonRpcSendAsync_1():
         assert count_threads_with_name(new_name) == 0, "No threads are expected to exist"
 
         pc.start()  # Restart
-        assert count_threads_with_name(new_name) == 1, "One thread is expected to exist"
+        assert count_threads_with_name(new_name) == 2, "One thread is expected to exist"
         pc.stop()
 
     asyncio.run(object_start_stop())
@@ -709,7 +709,7 @@ def test_PipeJsonRpcSendAsync_6(caplog):
     asyncio.run(send_messages())
     pc.stop()
 
-    txt = "Unsolicited message received"
+    txt = "Unexpected message received"
     assert txt in caplog.text
     assert caplog.text.count(txt) == 2, caplog.text
 

--- a/bluesky_queueserver/manager/tests/test_logging.py
+++ b/bluesky_queueserver/manager/tests/test_logging.py
@@ -1,0 +1,142 @@
+import copy
+import pytest
+
+from bluesky_queueserver.manager.logging_setup import PPrintForLogging as ppfl
+
+msg_in_01a = 10
+msg_out_01a = "10"
+
+msg_in_01b = "Some string"
+msg_out_01b = "'Some string'"
+
+msg_in_01c = [1, 2, 3, "ab"]
+msg_out_01c = "[1, 2, 3, 'ab']"
+
+msg_in_01d = {"ab": 10, "cd": "Some string"}
+msg_out_01d = "{'ab': 10, 'cd': 'Some string'}"
+
+# Complicated dictionary, which should be passed without change
+# fmt: off
+msg_in_02 = {
+    "short_list": [1, 2, 3, 4, 5],
+    "small_dict": {
+        "number": 50,
+        "str": "Another string",
+        "short_dict": {
+            "number": 70,
+            "short_list": ["ab", "cd", "ef", {"gh": 50, "ef": "abc"}],
+        }
+    },
+    "str": "This is some string",
+    "number": 10,
+}
+# fmt: on
+
+msg_out_02 = """{'short_list': [1, 2, 3, 4, 5],
+ 'small_dict': {'number': 50,
+                'str': 'Another string',
+                'short_dict': {'number': 70,
+                               'short_list': ['ab',
+                                              'cd',
+                                              'ef',
+                                              {'gh': 50, 'ef': 'abc'}]}},
+ 'str': 'This is some string',
+ 'number': 10}"""
+
+msg_in_03a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+msg_out_03a = "[1, 2, 3, 4, 5, '...']"
+
+# fmt: off
+msg_in_03b = {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6, "g": 7, "h": 8, "i": 9, "j": 10, "k": 11, "l": 12}
+# fmt: on
+msg_out_03b = "{'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 6, 'g': 7, '...': '...'}"
+
+
+msg_in_04a = {"b": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], "a": "Some string"}
+msg_out_04a = "{'b': [1, 2, 3, 4, 5, '...'], 'a': 'Some string'}"
+
+msg_in_04b = [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], "Some string"]
+msg_out_04b = "[[1, 2, 3, 4, 5, '...'], 'Some string']"
+
+msg_in_04c = [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]]
+msg_out_04c = "[[1, 2, 3, 4, 5, '...']]"
+
+# fmt: off
+msg_in_04d = [{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6, "g": 7, "h": 8}, "Some String"]
+# fmt: on
+msg_out_04d = """[{'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 6, 'g': 7, '...': '...'},
+ 'Some String']"""
+
+msg_in_05a = {
+    "success": True,
+    "msg": "",
+    "item": {
+        "name": "func_receive_data",
+        "args": [
+            [
+                0.9369286739807017,
+                0.34376855785565996,
+                0.42682410595184694,
+                0.07561990556676668,
+                0.99047480979217,
+                0.6645094767060512,
+                0.23949066214689685,
+                0.9506291248522921,
+                0.074846613000778,
+                0.5056064487856279,
+                0.5857598003946347,
+                0.3171865307386059,
+                0.2749306001778441,
+                0.14193313428663756,
+                0.8694254472618858,
+            ]
+        ],
+        "kwargs": {},
+    },
+}
+
+msg_out_05a = """{'success': True,
+ 'msg': '',
+ 'item': {'name': 'func_receive_data',
+          'args': [[0.9369286739807017,
+                    0.34376855785565996,
+                    0.42682410595184694,
+                    0.07561990556676668,
+                    0.99047480979217,
+                    '...']],
+          'kwargs': {}}}"""
+
+# msg: off
+msg_in_06a = {"plans_existing": {"plan1": {}, "plan2": []}, "devices_allowed": []}
+# msg: on
+msg_out_06a = "{'plans_existing': {'plan1': '{...}', 'plan2': '{...}'}, 'devices_allowed': []}"
+
+
+# fmt: on
+@pytest.mark.parametrize(
+    "msg_in, msg_out",
+    [
+        (msg_in_01a, msg_out_01a),
+        (msg_in_01b, msg_out_01b),
+        (msg_in_01c, msg_out_01c),
+        (msg_in_01d, msg_out_01d),
+        (msg_in_02, msg_out_02),
+        (msg_in_03a, msg_out_03a),
+        (msg_in_03b, msg_out_03b),
+        (msg_in_04a, msg_out_04a),
+        (msg_in_04b, msg_out_04b),
+        (msg_in_04c, msg_out_04c),
+        (msg_in_04d, msg_out_04d),
+        (msg_in_05a, msg_out_05a),
+        (msg_in_06a, msg_out_06a),
+    ],
+)
+# fmt: off
+def test_PPrintForLogging_01(msg_in, msg_out):
+    msg_in_backup = copy.deepcopy(msg_in)
+    result = str(ppfl(msg_in, max_list_size=5, max_dict_size=7))
+    print(result)
+    # Check the result
+    assert result == msg_out
+    # Check that the orinal data did not change
+    assert msg_in_backup == msg_in

--- a/bluesky_queueserver/manager/tests/test_logging.py
+++ b/bluesky_queueserver/manager/tests/test_logging.py
@@ -111,6 +111,31 @@ msg_in_06a = {"plans_existing": {"plan1": {}, "plan2": []}, "devices_allowed": [
 # msg: on
 msg_out_06a = "{'plans_existing': {'plan1': '{...}', 'plan2': '{...}'}, 'devices_allowed': []}"
 
+# Long string: 508 characters
+msg_in_07a = "The result is an aggregate list of returned values."
+msg_out_07a = "'The result is an aggregate list of returned values.'"
+
+msg_in_07b = "If all awaitables are completed successfully, the result is an aggregate list of returned values."
+msg_out_07b = "'If all awaitables are completed  ...\\n... gregate list of returned values.'"
+
+msg_in_07c = {
+    "msg": "If all awaitables are completed successfully, the result is an aggregate list of returned values.",
+    "lst": ["If all awaitables are completed successfully, the result is an aggregate list of returned values."],
+}
+
+msg_out_07c = """{'msg': 'If all awaitables are completed  ...\\n'
+        '... gregate list of returned values.',
+ 'lst': ['If all awaitables are completed  ...\\n'
+         '... gregate list of returned values.']}"""
+
+msg_in_07d = {
+    "traceback": "If all awaitables are completed successfully, "
+    "the result is an aggregate list of returned values.",
+}
+
+msg_out_07d = """{'traceback': 'If all awaitables are completed successfully, the result is an '
+              'aggregate list of returned values.'}"""
+
 
 # fmt: on
 @pytest.mark.parametrize(
@@ -129,12 +154,16 @@ msg_out_06a = "{'plans_existing': {'plan1': '{...}', 'plan2': '{...}'}, 'devices
         (msg_in_04d, msg_out_04d),
         (msg_in_05a, msg_out_05a),
         (msg_in_06a, msg_out_06a),
+        (msg_in_07a, msg_out_07a),
+        (msg_in_07b, msg_out_07b),
+        (msg_in_07c, msg_out_07c),
+        (msg_in_07d, msg_out_07d),
     ],
 )
 # fmt: off
 def test_PPrintForLogging_01(msg_in, msg_out):
     msg_in_backup = copy.deepcopy(msg_in)
-    result = str(ppfl(msg_in, max_list_size=5, max_dict_size=7))
+    result = str(ppfl(msg_in, max_list_size=5, max_dict_size=7, max_chars_in_str=64))
     print(result)
     # Check the result
     assert result == msg_out

--- a/bluesky_queueserver/manager/tests/test_scenarios.py
+++ b/bluesky_queueserver/manager/tests/test_scenarios.py
@@ -483,6 +483,7 @@ def unit_test_download_data():
     return _data
 """
 
+
 # fmt: off
 @pytest.mark.parametrize("background", [False, True])
 # fmt: on
@@ -605,13 +606,13 @@ def test_large_datasets_02(re_manager):  # noqa: F811
     assert wait_for_condition(time=timeout_env_open, condition=condition_environment_closed)
 
 
-
 # fmt: off
 _plan_move_then_count = {
     "name": "move_then_count",
     "kwargs": {"motors": ["motor1", "motor2"], "detectors": ["det1"], "positions": [1, 2]},
     "item_type": "plan",
 }
+
 
 @pytest.mark.parametrize("plan, n_plans, timeout_ms", [
     (_plan4, 10000, 60000),

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1006,6 +1006,7 @@ class RunEngineWorker(Process):
         # Reuse item UID as task UID
         task_uid = func_info.get("item_uid", None)
 
+        logger.info("======== Starting task ...")  ##
         status, err_msg, task_uid, payload = self._start_task(
             name="Execute function",
             target=self._execute_function_in_environment,
@@ -1013,7 +1014,9 @@ class RunEngineWorker(Process):
             run_in_background=run_in_background,
             task_uid=task_uid,
         )
+        logger.info("======== Starting task finished")  ##
         msg_out = {"status": status, "err_msg": err_msg, "task_uid": task_uid, "payload": payload}
+        logger.info(f"========  msg_out={msg_out}")  ##
         return msg_out
 
     # ------------------------------------------------------------

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -286,7 +286,7 @@ class RunEngineWorker(Process):
 
         except Exception as ex:
             # The exception was raised while preparing the function for execution.
-            logger.exception(f"Failed to execute task in main thread: {ex}")
+            logger.exception("Failed to execute task in main thread: %s", ex)
         else:
             logger.debug("Task execution is completed.")
 
@@ -516,7 +516,7 @@ class RunEngineWorker(Process):
 
         task_uid = task_uid or str(uuid.uuid4())
         time_start = ttime.time()
-        logger.debug(f"Starting task {name!r}. Task UID: {task_uid!r}.")
+        logger.debug("Starting task '%s'. Task UID: '%s'.", name, task_uid)
 
         try:
             # Verify that the environment is ready
@@ -567,7 +567,11 @@ class RunEngineWorker(Process):
             status, msg = "error", f"Error occurred while to starting the task {name!r}: {ex}"
 
         logger.debug(
-            f"Completing the request to start the task {name!r} ({task_uid!r}): status={status!r} msg={msg!r}."
+            "Completing the request to start the task '%s' ('%s'): status='%s' msg='%s'.",
+            name,
+            task_uid,
+            status,
+            msg,
         )
 
         # Payload contains information that may be useful for tracking the execution of the task.
@@ -703,7 +707,7 @@ class RunEngineWorker(Process):
         return_value = func_callable(*func_args, **func_kwargs)
 
         func_name = func_info.get("name", "--")
-        logger.debug(f"The execution of the function {func_name!r} was successfully completed.")
+        logger.debug("The execution of the function '%s' was successfully completed.", func_name)
 
         return return_value
 
@@ -1149,9 +1153,9 @@ class RunEngineWorker(Process):
         except Exception as ex:
             s = "Failed to start RE Worker environment. Error while loading startup code"
             if hasattr(ex, "tb"):  # ScriptLoadingError
-                logger.error("%s:\n%s\n", s, str(ex.tb))
+                logger.error("%s:\n%s\n", s, ex.tb)
             else:
-                logger.exception("%s: %s.", s, str(ex))
+                logger.exception("%s: %s.", s, ex)
             success = False
 
         if success:
@@ -1238,7 +1242,7 @@ class RunEngineWorker(Process):
 
             except BaseException as ex:
                 success = False
-                logger.exception("Error occurred while initializing the environment: %s.", str(ex))
+                logger.exception("Error occurred while initializing the environment: %s.", ex)
 
         if success:
             logger.info("RE Environment is ready")

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1006,7 +1006,6 @@ class RunEngineWorker(Process):
         # Reuse item UID as task UID
         task_uid = func_info.get("item_uid", None)
 
-        logger.info("======== Starting task ...")  ##
         status, err_msg, task_uid, payload = self._start_task(
             name="Execute function",
             target=self._execute_function_in_environment,
@@ -1014,9 +1013,7 @@ class RunEngineWorker(Process):
             run_in_background=run_in_background,
             task_uid=task_uid,
         )
-        logger.info("======== Starting task finished")  ##
         msg_out = {"status": status, "err_msg": err_msg, "task_uid": task_uid, "payload": payload}
-        logger.info(f"========  msg_out={msg_out}")  ##
         return msg_out
 
     # ------------------------------------------------------------

--- a/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -42,5 +42,6 @@ user_groups:
       - ":elements$"
       - "function_sleep"
       - "clear_buffer"
+      - ":^unit_test.*$"
     forbidden_functions:
       - ":^_"  # All functions with names starting with '_'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added new `timeout` parameter for `ZMQCommSendThreads.send_message()`, `ZMQCommSendAsync.send_message()` and `zmq_single_request()` functions. The timeout overrides the default timeout ``timeout_recv`` set during instantiation of the respective classes for the particular request. The parameter is useful for implementation of some unit tests.

Some code refactoring to improve efficiency of logging and processing of submitted plans and functions. The changes are not expected to affect functionality of RE Manager.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New `timeout` parameter for `ZMQCommSendThreads.send_message()`, `ZMQCommSendAsync.send_message()` and `zmq_single_request()` functions. The timeout overrides the default timeout ``timeout_recv`` set during instantiation of the respective classes for the particular request.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Additional unit tests are added.

<!--
## Screenshots (if appropriate):
-->
