### PR TITLE
Passing parameters using config file (YML)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,7 +11,9 @@ recursive-include docs *.rst conf.py Makefile make.bat
 
 include versioneer.py
 include bluesky_queueserver/_version.py
+include bluesky_queueserver/manager/config_schemas/*.yml
 recursive-include bluesky_queueserver/profile_collection_sim *
+
 
 # If including data files in the package, add them like:
 # include path/to/data_file

--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -388,7 +388,7 @@ class Settings:
     def __str__(self):
         cfg = {
             "zmq_control_addr": self.zmq_control_addr,
-            "zmq_private_key": None if self.zmq_private_key is None else "...",
+            "zmq_private_key": None if (self.zmq_private_key is None) else "...",
             "zmq_info_addr": self.zmq_info_addr,
             "zmq_publish_console": self.zmq_publish_console,
             "redis_addr": self.redis_addr,

--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -5,12 +5,19 @@ See profiles.py for client configuration.
 """
 import builtins
 from collections.abc import Mapping
+from importlib.util import find_spec
 import os
 from pathlib import Path
 import jsonschema
 import logging
+import sys
 
+from .output_streaming import default_zmq_info_address_for_server
 from .config_schemas.loading import load_schema_from_yml, ConfigError
+from .profile_ops import get_default_startup_dir
+from .comms import validate_zmq_key, default_zmq_control_address_for_server
+
+logger = logging.getLogger(__name__)
 
 
 SERVICE_CONFIGURATION_FILE_NAME = "config_schema.yml"
@@ -152,80 +159,541 @@ def parse_configs(config_path):
     return merged_config
 
 
-_supported_keys = [
-    "network/zmq_control_addr",
-    "network/zmq_private_key",
-    "network/zmq_info_addr",
-    "network/zmq_publish_console",
-    "network/redis_addr",
-    "startup/keep_re",
-    "startup/existing_plans_and_devices_path",
-    "startup/user_group_permissions_path",
-    "startup/startup_dir",
-    "startup/startup_profile",
-    "startup/startup_module",
-    "startup/startup_script",
-    "operation/print_console_output",
-    "operation/console_output_level",
-    "operation/existing_plans_and_devices_update",
-    "operation/user_group_permissions_reload",
-    "run_engine/user_persistent_metadata",
-    "run_engine/kafka_server",
-    "run_engine/kafka_topic",
-    "run_engine/databroker_config",
-]
+_key_mapping = {
+    "zmq_control_addr": "network/zmq_control_addr",
+    "zmq_private_key": "network/zmq_private_key",
+    "zmq_info_addr": "network/zmq_info_addr",
+    "zmq_publish_console": "network/zmq_publish_console",
+    "redis_addr": "network/redis_addr",
+    "keep_re": "startup/keep_re",
+    "existing_plans_and_devices_path": "startup/existing_plans_and_devices_path",
+    "user_group_permissions_path": "startup/user_group_permissions_path",
+    "startup_dir": "startup/startup_dir",
+    "startup_profile": "startup/startup_profile",
+    "startup_module": "startup/startup_module",
+    "startup_script": "startup/startup_script",
+    "print_console_output": "operation/print_console_output",
+    "console_logging_level": "operation/console_logging_level",
+    "update_existing_plans_devices": "operation/update_existing_plans_and_devices",
+    "user_group_permissions_reload": "operation/user_group_permissions_reload",
+    "emergency_lock_key": "operation/emergency_lock_key",
+    "use_persistent_metadata": "run_engine/use_persistent_metadata",
+    "kafka_server": "run_engine/kafka_server",
+    "kafka_topic": "run_engine/kafka_topic",
+    "zmq_data_proxy_addr": "run_engine/zmq_data_proxy_addr",
+    "databroker_config": "run_engine/databroker_config",
+}
 
 
-def get_value_from_config(config, key, default=None):
+class _ArgsExisting:
     """
-    Returns value from config dictionary. The keys is a sequence of keys separated with ``/``,
-    e.g. ``"startup/keep_re"``. If the key is not in config, then the default value is returned.
-    If the key is an empty string or does not exist, the ``ConfigError`` is raised.
+    The object should be used together with ``ArugmentParser``. The call method
+    returns the parameter value if the parameter was actually passed in the command
+    line and the default values.
+
+    Parameters
+    ----------
+    parser: ArgumentParser
+        The parser object used for parsing the list of CLI parameters
+    args
+        Namespace returned by ``parser.parse_args()``. If ``None``, then
+        the constructor call ``parse_args()`` to parse current parameters.
     """
-    if not key or key not in _supported_keys:
-        raise ConfigError(f"The key {key!r} is not supported.")
 
-    keys = key.split("/")
+    def __init__(self, *, parser, args=None):
+        self._parser = parser
+        self._args = args or parser.parse_args()
+        self._existing_params = self._get_existing_cli_params()
 
-    try:
-        value = config
-        for k in keys:
-            value = value[k]
-    except KeyError:
-        value = default
+    def _get_existing_cli_params(self):
+        """
+        Returns mapping: parameter_name -> True/False (exist in command line, or
+        default value is used).
+        """
+        key_mapping = {_.dest: _.option_strings for _ in self._parser._actions}
+        key_specified = {}
+        for k, v in key_mapping.items():
+            key_specified[k] = any([_ in sys.argv[1:] for _ in v])
+        return key_specified
 
-    return value
+    def __call__(self, param_name, *, default=None):
+        """
+        Parameters
+        ----------
+        param_name: str
+            Parameter name. If the parameter name is non-existing, then ``KeyErrror`` is raised.
+        default: object
+            The default value, which is returned if the parameter is not set in the CLI parameters.
+        """
+        if param_name not in self._existing_params:
+            raise KeyError(f"CLI parameter {param_name!r} does not exist")
+        if self._existing_params[param_name] is False:
+            return default
+        else:
+            return getattr(self._args, param_name)
 
 
-def get_log_level_from_config(config, cli_verbose, cli_quiet, cli_silent):
+def to_boolean(value):
     """
-    Select logging level based on config and CLI parameters. It is assumed that
-    only one of cli parameters is true (not checked here). CLI parameters have
-    precedence over config parameters.
+    Returns ``True`` or ``False`` if ``value`` is found in one of the lists of supported values.
+    Otherwise returns ``None`` (typicall means that the value is not set).
     """
-    value = None
-    if cli_verbose:
-        value = "VERBOSE"
-    elif cli_quiet:
-        value = "QUIET"
-    elif cli_silent:
-        value = "SILENT"
+    v = value.lower() if isinstance(value, str) else value
+    if v in (True, "y", "yes", "t", "true", "on", "1"):
+        return True
+    elif v in (False, "", "n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        return None
 
-    # If 'value' is still None, then there is no CLI parameters. Use settings from config.
-    value = get_value_from_config(config, "startup/keep_re", default=value)
 
-    # If 'value' is still None, then use the default value.
-    if value is None:
-        value = "NORMAL"
+def _profile_name_to_startup_dir(profile_name):
+    """
+    Finds and returns full path to startup directory based on the profile name.
+    """
+    if find_spec("IPython"):
+        import IPython
 
-    levels = {
-        "VERBOSE": logging.DEBUG,
-        "NORMAL": logging.INFO,
-        "QUIET": logging.WARNING,
-        "SILENT": logging.CRITICAL + 1,
-    }
+        path_to_ipython = IPython.paths.get_ipython_dir()
+    else:
+        raise ConfigError("IPython is not installed. Specify directory using CLI parameters or in config file.")
+        return 1
+    ipython_dir = os.path.abspath(path_to_ipython)
+    profile_name_full = f"profile_{profile_name}"
+    return os.path.join(ipython_dir, profile_name_full, "startup")
 
-    if value not in levels:
-        raise ConfigError(f"Unknown level: {value}. Supported levels: {list(levels.keys())}")
 
-    return levels[value]
+class Settings:
+    def __init__(self, *, parser, args):
+        self._parser = parser
+        self._args = args
+        self._args_existing = _ArgsExisting(parser=parser, args=args)
+
+        config_path = args.config_path
+        config_path = config_path or os.environ.get("QSERVER_CONFIG", None)
+        self._config = parse_configs(config_path) if config_path else {}
+
+        self._zmq_control_addr = self._get_zmq_control_addr()
+        self._zmq_private_key = self._get_zmq_private_key()
+
+        self._zmq_info_addr = self._get_param(
+            value_default=default_zmq_info_address_for_server,
+            value_ev=os.environ.get("QSERVER_ZMQ_INFO_ADDRESS_FOR_SERVER", None),
+            value_config=self._get_value_from_config("zmq_info_addr"),
+            value_cli=self._args_existing("zmq_info_addr") or self._args_existing("zmq_publish_console_addr"),
+        )
+
+        self._zmq_publish_console = self._get_param_boolean(
+            value_default=args.zmq_publish_console,
+            value_config=self._get_value_from_config("zmq_publish_console"),
+            value_cli=self._args_existing("zmq_publish_console"),
+        )
+
+        self._redis_addr = self._get_param(
+            value_default=self._args.redis_addr,
+            value_config=self._get_value_from_config("redis_addr"),
+            value_cli=self._args_existing("redis_addr"),
+        )
+        if self._redis_addr.count(":") > 1:
+            raise ConfigError(f"Redis address is incorrectly formatted: {self._redis_addr}")
+
+        self._keep_re = self._get_param_boolean(
+            value_default=args.keep_re,
+            value_config=self._get_value_from_config("keep_re"),
+            value_cli=self._args_existing("keep_re"),
+        )
+
+        self._existing_plans_and_devices_path = self._get_param(
+            value_default=args.existing_plans_and_devices_path,
+            value_config=self._get_value_from_config("existing_plans_and_devices_path"),
+            value_cli=self._args_existing("existing_plans_and_devices_path"),
+        )
+        if isinstance(self._existing_plans_and_devices_path, str):
+            self._existing_plans_and_devices_path = os.path.expanduser(self._existing_plans_and_devices_path)
+
+        self._user_group_permissions_path = self._get_param(
+            value_default=args.user_group_permissions_path,
+            value_config=self._get_value_from_config("user_group_permissions_path"),
+            value_cli=self._args_existing("user_group_permissions_path"),
+        )
+        if isinstance(self._user_group_permissions_path, str):
+            self._user_group_permissions_path = os.path.expanduser(self._user_group_permissions_path)
+
+        self._startup_dir, self._startup_module, self._startup_script = self._get_startup_options()
+
+        self._print_console_output = self._get_param_boolean(
+            value_default=args.console_output,
+            value_config=self._get_value_from_config("print_console_output"),
+            value_cli=self._args_existing("console_output"),
+        )
+
+        self._console_logging_level = self._get_console_logging_level()
+
+        self._update_existing_plans_devices = self._get_param(
+            value_default=args.update_existing_plans_devices,
+            value_config=self._get_value_from_config("update_existing_plans_devices"),
+            value_cli=self._args_existing("update_existing_plans_devices"),
+        )
+
+        self._user_group_permissions_reload = self._get_param(
+            value_default=args.user_group_permissions_reload,
+            value_config=self._get_value_from_config("user_group_permissions_reload"),
+            value_cli=self._args_existing("user_group_permissions_reload"),
+        )
+
+        self._emergency_lock_key = self._get_param(
+            value_ev=os.environ.get("QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER", None),
+            value_config=self._get_value_from_config("emergency_lock_key"),
+        )
+
+        self._use_persistent_metadata = self._get_param_boolean(
+            value_default=args.use_persistent_metadata,
+            value_config=self._get_value_from_config("use_persistent_metadata"),
+            value_cli=self._args_existing("use_persistent_metadata"),
+        )
+
+        self._kafka_server = self._get_param(
+            value_default=args.kafka_server,
+            value_config=self._get_value_from_config("kafka_server"),
+            value_cli=self._args_existing("kafka_server"),
+        )
+
+        self._kafka_topic = self._get_param(
+            value_default=args.kafka_topic,
+            value_config=self._get_value_from_config("kafka_topic"),
+            value_cli=self._args_existing("kafka_topic"),
+        )
+
+        self._zmq_data_proxy_addr = self._get_param(
+            value_default=args.zmq_data_proxy_addr,
+            value_config=self._get_value_from_config("zmq_data_proxy_addr"),
+            value_cli=self._args_existing("zmq_data_proxy_addr"),
+        )
+
+        self._databroker_config = self._get_param(
+            value_default=args.databroker_config,
+            value_config=self._get_value_from_config("databroker_config"),
+            value_cli=self._args_existing("databroker_config"),
+        )
+
+    @property
+    def zmq_control_addr(self):
+        """
+        Returns a string representing 0MQ control address.
+        """
+        return self._zmq_control_addr
+
+    @property
+    def zmq_private_key(self):
+        """
+        Returns a string representing 0MQ private key or ``None``.
+        """
+        return self._zmq_private_key
+
+    @property
+    def zmq_info_addr(self):
+        """
+        Returns a string representing 0MQ info address.
+        """
+        return self._zmq_info_addr
+
+    @property
+    def zmq_publish_console(self):
+        """
+        True/False
+        """
+        return self._zmq_publish_console
+
+    @property
+    def redis_addr(self):
+        """
+        Redis address (string).
+        """
+        return self._redis_addr
+
+    @property
+    def keep_re(self):
+        """
+        True/False
+        """
+        return self._keep_re
+
+    @property
+    def existing_plans_and_devices_path(self):
+        """
+        Returns absolute or relative path to the file containing lists of existing plans and devices
+        or ``None`` if the path is not set.
+        """
+        return self._existing_plans_and_devices_path
+
+    @property
+    def user_group_permissions_path(self):
+        """
+        Returns absolute or relative path to the file containing user group permissions
+        or ``None`` if the path is not set.
+        """
+        return self._user_group_permissions_path
+
+    @property
+    def startup_dir(self):
+        """
+        Full path to the directory containing the startup script or ``None``.
+        """
+        return self._startup_dir
+
+    @property
+    def startup_module(self):
+        """
+        Name of a Python module containing startup code or ``None``.
+        """
+        return self._startup_module
+
+    @property
+    def startup_script(self):
+        """
+        Full path to the Python startup script or ``None``.
+        """
+        return self._startup_script
+
+    @property
+    def print_console_output(self):
+        """
+        True/False
+        """
+        return self._print_console_output
+
+    @property
+    def update_existing_plans_devices(self):
+        """
+        Returns the selected option as a string.
+        """
+        return self._update_existing_plans_devices
+
+    def user_group_permissions_reload(self):
+        """
+        Returns the selected option as a string.
+        """
+        return self._user_group_permissions_reload
+
+    def emergency_lock_key(self):
+        """
+        Returns the emergency lock key (string) or ``None``.
+        """
+        return self._emergency_lock_key
+
+    @property
+    def console_logging_level(self):
+        """
+        The returned log level can be passed to the functions from ``logging`` package.
+        """
+        return self._console_logging_level
+
+    @property
+    def use_persistent_metadata(self):
+        """
+        True/False.
+        """
+        return self._use_persistent_metadata
+
+    @property
+    def kafka_server(self):
+        """
+        Returns a string representing kafka server address.
+        """
+        return self._kafka_server
+
+    @property
+    def kafka_topic(self):
+        """
+        Returns a string representing kafka topic.
+        """
+        return self._kafka_topic
+
+    @property
+    def zmq_data_proxy_addr(self):
+        """
+        Returns a string representing the address of 0MQ data proxy.
+        """
+        return self._zmq_data_proxy_addr
+
+    @property
+    def databroker_config(self):
+        """
+        Returns a string databroker configuration name or ``None`` if the configuration name is not set.
+        """
+        return self._databroker_config
+
+    def _get_value_from_config(self, key, default=None):
+        """
+        Returns value from config dictionary. The keys must be one of the keys defined in
+        ``_key_mapping``. If the value not found in config, then the ``default`` value is returned.
+        If the key is an empty string or does not exist, the ``ConfigError`` is raised.
+        """
+        if not key or key not in _key_mapping:
+            raise ConfigError(f"The key {key!r} is not supported.")
+
+        keys = _key_mapping[key].split("/")
+
+        try:
+            value = self._config
+            for k in keys:
+                value = value[k]
+        except KeyError:
+            value = default
+
+        return value
+
+    def _get_param(self, *, value_default=None, value_ev=None, value_config=None, value_cli=None):
+        """
+        ``None`` - the value is not set
+        """
+        v = value_ev if (value_ev is not None) else value_default
+        v = value_config if (value_config is not None) else v
+        return value_cli if (value_cli is not None) else v
+
+    def _get_param_boolean(self, *, value_default=None, value_ev=None, value_config=None, value_cli=None):
+        """
+        Returns ``True/False/None`` based on the input values. ``None`` - the value is not set.
+        """
+        value_default = to_boolean(value_default)
+        value_ev = to_boolean(value_ev)
+        value_config = to_boolean(value_config)
+        value_cli = to_boolean(value_cli)
+
+        return self._get_param(
+            value_default=value_default, value_ev=value_ev, value_config=value_config, value_cli=value_cli
+        )
+
+    def _get_console_logging_level(self):
+        """
+        Select logging level based on config and CLI parameters. It is assumed that
+        only one of cli parameters is true (not checked here). CLI parameters have
+        precedence over config parameters.
+        """
+
+        def get_cli_log_level():
+            cli_verbose = self._args_existing("logger_verbose")
+            cli_quiet = self._args_existing("logger_quiet")
+            cli_silent = self._args_existing("logger_silent")
+
+            # Value from CLI parameters
+            v = None
+            if cli_verbose:
+                v = "VERBOSE"
+            elif cli_quiet:
+                v = "QUIET"
+            elif cli_silent:
+                v = "SILENT"
+
+            return v
+
+        value_default = "NORMAL"
+        value_config = self._get_value_from_config("console_logging_level")
+        value_cli = get_cli_log_level()
+        value = self._get_param(value_default=value_default, value_config=value_config, value_cli=value_cli)
+
+        levels = {
+            "VERBOSE": logging.DEBUG,
+            "NORMAL": logging.INFO,
+            "QUIET": logging.WARNING,
+            "SILENT": logging.CRITICAL + 1,
+        }
+
+        if value not in levels:
+            raise ConfigError(f"Unknown level: {value}. Supported levels: {list(levels.keys())}")
+
+        return levels[value]
+
+    def _get_startup_options(self):
+        """
+        Returns names of startup_dir, startup_module or startup_script. Only one of the name can be not None.
+        """
+
+        # Default: startup scripts with simulated plans and devices
+        startup_dir, startup_module, startup_script = get_default_startup_dir(), None, None
+
+        # Process config parameters
+        cfg_dir, cfg_module, cfg_script = None, None, None
+        if self._get_value_from_config("startup_profile"):
+            cfg_dir = _profile_name_to_startup_dir(self._get_value_from_config("startup_profile"))
+        elif self._get_value_from_config("startup_dir"):
+            cfg_dir = self._get_value_from_config("startup_dir")
+            cfg_dir = os.path.abspath(os.path.expanduser(cfg_dir))
+        elif self._get_value_from_config("startup_module"):
+            cfg_module = self._get_value_from_config("startup_module")
+        elif self._get_value_from_config("startup_script"):
+            cfg_script = os.path.abspath(os.path.expanduser(self._get_value_from_config("startup_script")))
+
+        if any([cfg_dir, cfg_module, cfg_script]):
+            startup_dir, startup_module, startup_script = cfg_dir, cfg_module, cfg_script
+
+        # Process CLI parameters
+        cli_dir, cli_module, cli_script = None, None, None
+        if self._args_existing("profile_name"):
+            cli_dir = _profile_name_to_startup_dir(self._args_existing("profile_name"))
+        elif self._args_existing("startup_dir"):
+            cli_dir = self._args_existing("startup_dir")
+            cli_dir = os.path.abspath(os.path.expanduser(cli_dir))
+        elif self._args_existing("startup_module_name"):
+            cli_module = self._args_existing("startup_module_name")
+        elif self._args_existing("startup_script_path"):
+            cli_script = os.path.abspath(os.path.expanduser(self._args_existing("startup_script_path")))
+
+        if any([cli_dir, cli_module, cli_script]):
+            startup_dir, startup_module, startup_script = cli_dir, cli_module, cli_script
+
+        # Check that only one source is defined (just in case)
+        if sum([_ is not None for _ in [startup_dir, startup_module, startup_script]]) != 1:
+            raise ConfigError(
+                f"Multiple or no startup code sources were specified: startup_dir={startup_dir!r} "
+                f"startup_module={startup_module!r} startup_script={startup_script!r}"
+            )
+
+        return startup_dir, startup_module, startup_script
+
+    def _get_zmq_control_addr(self):
+        """
+        Returns 0MQ control address (string).
+        """
+        zmq_control_addr_cli = self._args.zmq_control_addr
+        if self._args.zmq_addr is not None:
+            logger.warning(
+                "Parameter --zmq-addr is deprecated and will be removed in future releases. "
+                "Use --zmq-control-addr instead."
+            )
+        zmq_control_addr_cli = zmq_control_addr_cli or self._args.zmq_addr
+
+        zmq_control_addr = self._get_param(
+            value_default=default_zmq_control_address_for_server,
+            value_ev=os.environ.get("QSERVER_ZMQ_CONTROL_ADDRESS_FOR_SERVER"),
+            value_config=self._get_value_from_config("zmq_control_addr"),
+            value_cli=zmq_control_addr_cli,
+        )
+
+        return zmq_control_addr
+
+    def _get_zmq_private_key(self):
+        """
+        Returns 0MQ private key (string) or None.
+        """
+        # Read private key from the environment variable, then check if the CLI parameter exists
+        zmq_private_key_ev = os.environ.get("QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER", None)
+        if (zmq_private_key_ev is None) and ("QSERVER_ZMQ_PRIVATE_KEY" in os.environ):
+            logger.warning(
+                "Environment variable QSERVER_ZMQ_PRIVATE_KEY is deprecated and will be removed "
+                "in future releases. Use QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER instead"
+            )
+        zmq_private_key_ev = zmq_private_key_ev or os.environ.get("QSERVER_ZMQ_PRIVATE_KEY", None)
+        zmq_private_key_ev = zmq_private_key_ev or None  # Case of key==""
+
+        zmq_private_key = self._get_param(
+            value_ev=zmq_private_key_ev, value_config=self._get_value_from_config("zmq_private_key")
+        )
+
+        if zmq_private_key is not None:
+            try:
+                validate_zmq_key(zmq_private_key)
+            except Exception as ex:
+                raise ConfigError("ZMQ private key is improperly formatted: %s", ex) from ex
+
+        return zmq_private_key

--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -404,7 +404,7 @@ class Settings:
         settings_str = ""
         for k, v in self._settings.items():
             if k == "zmq_private_key":
-                v = None if (self.zmq_private_key is None) else "..."
+                v = None if (self.zmq_private_key is None) else "*******"
             settings_str += f"    {k}: {v!r}\n"
         return settings_str
 

--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -197,17 +197,24 @@ def get_value_from_config(config, key, default=None):
     return value
 
 
-def get_log_level_from_config(config, param_verbose, param_quiet, param_silent):
+def get_log_level_from_config(config, cli_verbose, cli_quiet, cli_silent):
+    """
+    Select logging level based on config and CLI parameters. It is assumed that
+    only one of cli parameters is true (not checked here). CLI parameters have
+    precedence over config parameters.
+    """
     value = None
-    if param_verbose:
+    if cli_verbose:
         value = "VERBOSE"
-    elif param_quiet:
+    elif cli_quiet:
         value = "QUIET"
-    elif param_silent:
+    elif cli_silent:
         value = "SILENT"
 
+    # If 'value' is still None, then there is no CLI parameters. Use settings from config.
     value = get_value_from_config(config, "startup/keep_re", default=value)
 
+    # If 'value' is still None, then use the default value.
     if value is None:
         value = "NORMAL"
 

--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -385,7 +385,7 @@ class Settings:
             value_cli=self._args_existing("databroker_config"),
         )
 
-    def __str__(self):
+    def to_dict(self):
         cfg = {
             "zmq_control_addr": self.zmq_control_addr,
             "zmq_private_key": None if (self.zmq_private_key is None) else "...",
@@ -409,6 +409,10 @@ class Settings:
             "zmq_data_proxy_addr": self.zmq_data_proxy_addr,
             "databroker_config": self.databroker_config,
         }
+        return cfg
+
+    def __str__(self):
+        cfg = self.to_dict()
 
         if version.parse(python_version()) < version.parse("3.8"):
             # TODO: delete this after support for 3.7 is dropped

--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -1,0 +1,152 @@
+"""
+This module handles server configuration.
+
+See profiles.py for client configuration.
+"""
+import builtins
+from collections.abc import Mapping
+import os
+from pathlib import Path
+
+import jsonschema
+
+from .config_schemas.loading import load_schema_from_yml, ConfigError
+
+
+SERVICE_CONFIGURATION_FILE_NAME = "config_schema.yml"
+
+
+def expand_environment_variables(config):
+    """Expand environment variables in a nested config dictionary
+
+    VENDORED FROM dask.config.
+
+    This function will recursively search through any nested dictionaries
+    and/or lists.
+
+    Parameters
+    ----------
+    config : dict, iterable, or str
+        Input object to search for environment variables
+
+    Returns
+    -------
+    config : same type as input
+
+    Examples
+    --------
+    >>> expand_environment_variables({'x': [1, 2, '$USER']})  # doctest: +SKIP
+    {'x': [1, 2, 'my-username']}
+    """
+    if isinstance(config, Mapping):
+        return {k: expand_environment_variables(v) for k, v in config.items()}
+    elif isinstance(config, str):
+        return os.path.expandvars(config)
+    elif isinstance(config, (list, tuple, builtins.set)):
+        return type(config)([expand_environment_variables(v) for v in config])
+    else:
+        return config
+
+
+def parse(file):
+    """
+    Given a config file, parse it.
+
+    This wraps YAML parsing and environment variable expansion.
+    """
+    import yaml
+
+    content = yaml.safe_load(file.read())
+    return expand_environment_variables(content)
+
+
+def merge(configs):
+    merged = {}
+
+    # These variables are used to produce error messages that point
+    # to the relevant config file(s).
+    network_source = None
+    startup_source = None
+    operation_source = None
+    run_engine_source = None
+
+    for filepath, config in configs.items():
+        if "network" in config:
+            if "network" in merged:
+                raise ConfigError(
+                    "'network' can only be specified in one file. "
+                    f"It was found in both {network_source} and "
+                    f"{filepath}"
+                )
+            network_source = filepath
+            merged["network"] = config["network"]
+        if "startup" in config:
+            if "startup" in merged:
+                raise ConfigError(
+                    "'startup' can only be specified in one file. "
+                    f"It was found in both {startup_source} and "
+                    f"{filepath}"
+                )
+            startup_source = filepath
+            merged["startup"] = config["startup"]
+        if "operation" in config:
+            if "operation" in merged:
+                raise ConfigError(
+                    "'operation' can only be specified in one file. "
+                    f"It was found in both {operation_source} and "
+                    f"{filepath}"
+                )
+            operation_source = filepath
+            merged["operation"] = config["operation"]
+        if "run_engine" in config:
+            if "run_engine" in merged:
+                raise ConfigError(
+                    "'run_engine' can only be specified in one file. "
+                    f"It was found in both {run_engine_source} and "
+                    f"{filepath}"
+                )
+            run_engine_source = filepath
+            merged["run_engine"] = config["run_engine"]
+    return merged
+
+
+def parse_configs(config_path):
+    """
+    Parse configuration file or directory of configuration files.
+
+    If a directory is given it is expected to contain only valid
+    configuration files, except for the following which are ignored:
+
+    * Hidden files or directories (starting with .)
+    * Python scripts (ending in .py)
+    * The __pycache__ directory
+    """
+    if isinstance(config_path, str):
+        config_path = Path(config_path)
+    if config_path.is_file():
+        filepaths = [config_path]
+    elif config_path.is_dir():
+        filepaths = list(config_path.iterdir())
+    elif not config_path.exists():
+        raise ConfigError(f"The config path '{config_path!s}' doesn't exist.")
+    else:
+        assert False, "It should be impossible to reach this line."
+
+    parsed_configs = {}
+    # The sorting here is just to make the order of the results deterministic.
+    # There is *not* any sorting-based precedence applied.
+    for filepath in sorted(filepaths):
+        # Ignore hidden files and .py files.
+        if filepath.parts[-1].startswith(".") or filepath.suffix == ".py" or filepath.parts[-1] == "__pycache__":
+            continue
+        with open(filepath) as file:
+            config = parse(file)
+            try:
+                jsonschema.validate(instance=config, schema=load_schema_from_yml(SERVICE_CONFIGURATION_FILE_NAME))
+            except jsonschema.ValidationError as err:
+                msg = err.args[0]
+                raise ConfigError(f"ValidationError while parsing configuration file {filepath}: {msg}") from err
+            parsed_configs[filepath] = config
+
+    merged_config = merge(parsed_configs)
+    return merged_config

--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -469,12 +469,14 @@ class Settings:
         """
         return self._update_existing_plans_devices
 
+    @property
     def user_group_permissions_reload(self):
         """
         Returns the selected option as a string.
         """
         return self._user_group_permissions_reload
 
+    @property
     def emergency_lock_key(self):
         """
         Returns the emergency lock key (string) or ``None``.

--- a/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -22,24 +22,46 @@ properties:
       redis_addr:
         type: string
   startup:
-    type: object
-    additionalProperties: false
-    properties:
-      keep_re: 
-        type: boolean
-      oneOf:
-        - startup_dir:
+    oneOf:
+      - type: object
+        additionalProperties: false
+        properties:
+          keep_re:
+            type: boolean
+          existing_plans_and_devices_path:
             type: string
-        - startup_profile:
+          user_group_permissions_path:
             type: string
-        - startup_module:
+      - type: object
+        additionalProperties: false
+        properties:
+          keep_re:
+            type: boolean
+          startup_dir:
             type: string
-        - startup_script:
+          startup_profile:
             type: string
-      existing_plans_and_devices_path:
-        type: string
-      user_group_permissions_path:
-        type: string
+          startup_module:
+            type: string
+          startup_script:
+            type: string
+          existing_plans_and_devices_path:
+            type: string
+          user_group_permissions_path:
+            type: string
+        oneOf:
+          - type: object
+            required:
+              - startup_dir
+          - type: object
+            required:
+              - startup_profile
+          - type: object
+            required:
+              - startup_module
+          - type: object
+            required:
+              - startup_script
   operation:
     type: object
     additionalProperties: false
@@ -54,7 +76,7 @@ properties:
         pattern: "^(NEVER)|(ENVIRONMENT_OPEN)|(ALWAYS)$"
       user_group_permissions_reload:
         type: string
-        pattern: "^(NEVER)|("ON_REQUEST")|("ON_STARTUP")
+        pattern: "^(NEVER)|(ON_REQUEST)|(ON_STARTUP)"
   run_engine:
     type: object
     additional_properties: false

--- a/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -68,24 +68,28 @@ properties:
     properties:
       print_console_output:
         type: boolean
-      console_output_level:
+      console_logging_level:
         type: string
         pattern: "^(VERBOSE)|(NORMAL)|(QUIET)|(SILENT)$"
-      existing_plans_and_devices_update:
+      update_existing_plans_and_devices:
         type: string
         pattern: "^(NEVER)|(ENVIRONMENT_OPEN)|(ALWAYS)$"
       user_group_permissions_reload:
         type: string
         pattern: "^(NEVER)|(ON_REQUEST)|(ON_STARTUP)"
+      emergency_lock_key:
+        type: string
   run_engine:
     type: object
     additional_properties: false
     properties:
-      user_persistent_metadata:
+      use_persistent_metadata:
         type: boolean
       kafka_server:
         type: string
       kafka_topic:
+        type: string
+      zmq_data_proxy_addr:
         type: string
       databroker_config:
         type: string

--- a/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -1,0 +1,69 @@
+# This schema (a jsonschema in YAML format) is used
+# for validating configuration.
+#
+# ref: https://json-schema.org/learn/getting-started-step-by-step.html
+#
+$schema": http://json-schema.org/draft-07/schema#
+type: object
+additionalProperties: false
+properties:
+  network:
+    type: object
+    additionalProperties: false
+    properties:
+      zmq_control_addr:
+        type: string
+      zmq_private_key:
+        type: string
+      zmq_info_addr:
+        type: string
+      zmq_publish_console:
+        type: boolean
+      redis_addr:
+        type: string
+  startup:
+    type: object
+    additionalProperties: false
+    properties:
+      keep_re: 
+        type: boolean
+      oneOf:
+        - startup_dir:
+            type: string
+        - startup_profile:
+            type: string
+        - startup_module:
+            type: string
+        - startup_script:
+            type: string
+      existing_plans_and_devices_path:
+        type: string
+      user_group_permissions_path:
+        type: string
+  operation:
+    type: object
+    additionalProperties: false
+    properties:
+      print_console_output:
+        type: boolean
+      console_output_level:
+        type: string
+        pattern: "^(VERBOSE)|(NORMAL)|(QUIET)|(SILENT)$"
+      existing_plans_and_devices_update:
+        type: string
+        pattern: "^(NEVER)|(ENVIRONMENT_OPEN)|(ALWAYS)$"
+      user_group_permissions_reload:
+        type: string
+        pattern: "^(NEVER)|("ON_REQUEST")|("ON_STARTUP")
+  run_engine:
+    type: object
+    additional_properties: false
+    properties:
+      user_persistent_metadata:
+        type: boolean
+      kafka_server:
+        type: string
+      kafka_topic:
+        type: string
+      databroker_config:
+        type: string

--- a/bluesky_queueserver/manager/config_schemas/loading.py
+++ b/bluesky_queueserver/manager/config_schemas/loading.py
@@ -1,0 +1,16 @@
+import os
+from pathlib import Path
+
+
+class ConfigError(ValueError):
+    pass
+
+
+def load_schema_from_yml(file_name):
+    "Load the schema."
+    import yaml
+
+    here = Path(__file__).parent.absolute()
+    schema_path = os.path.join(here, file_name)
+    with open(schema_path, "r") as file:
+        return yaml.safe_load(file)

--- a/bluesky_queueserver/manager/logging_setup.py
+++ b/bluesky_queueserver/manager/logging_setup.py
@@ -144,7 +144,7 @@ class PPrintForLogging:
                     queue.extend(qe)
 
         if version.parse(python_version()) < version.parse("3.8"):
-            # NOTE: delete this after support for 3.7 is dropped
+            # TODO: delete this after support for 3.7 is dropped
             pprint.sorted = lambda x, key=None: x
             msg_out = pprint.pformat(msg_reduced)
             delattr(pprint, "sorted")

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -167,7 +167,6 @@ class WatchdogProcess:
 
         logging.basicConfig(level=max(logging.WARNING, self._log_level))
         setup_loggers(log_level=self._log_level)
-
         # Requests
         self._comm_to_manager.add_method(self._start_re_worker_handler, "start_re_worker")
         self._comm_to_manager.add_method(self._join_re_worker_handler, "join_re_worker")
@@ -180,6 +179,7 @@ class WatchdogProcess:
         self._comm_to_manager.start()
 
         self._start_re_manager()
+
         while True:
             # Primitive implementation of the loop that restarts the process.
             self._re_manager.join(0.1)  # Small timeout
@@ -510,7 +510,7 @@ def start_manager():
 
     startup_dir = settings.startup_dir
     startup_module_name = settings.startup_module
-    startup_script_path = settings.startup_script_path
+    startup_script_path = settings.startup_script
 
     # Primitive error processing: make sure that all essential data exists.
     if startup_dir is not None:
@@ -618,3 +618,5 @@ def start_manager():
         wp.run()
     except KeyboardInterrupt:
         logger.info("The program was manually stopped")
+    except Exception as ex:
+        logger.exception(ex)

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -479,9 +479,9 @@ def start_manager():
 
     log_level = get_log_level_from_config(
         config_from_file,
-        param_verbose=args.logger_verbose,
-        param_quiet=args.logger_quiet,
-        param_silent=args.logger_silent,
+        cli_verbose=args.logger_verbose,
+        cli_quiet=args.logger_quiet,
+        cli_silent=args.logger_silent,
     )
 
     console_output_on = args.console_output == "ON"

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -3,7 +3,6 @@ from multiprocessing import Pipe, Queue
 import threading
 import time as ttime
 import os
-import yaml
 
 from .worker import RunEngineWorker
 from .manager import RunEngineManager
@@ -14,7 +13,7 @@ from .output_streaming import (
     default_zmq_info_address_for_server,
 )
 from .logging_setup import setup_loggers
-from .config import Settings
+from .config import Settings, save_settings_to_file
 
 from .. import __version__
 
@@ -486,16 +485,8 @@ def start_manager():
     logging.basicConfig(level=max(logging.WARNING, log_level))
     setup_loggers(log_level=log_level)
 
-    # Save current settings to file. This feature is mostly for testing.
-    save_config_path = os.environ.get("QSERVER_SETTINGS_SAVE_TO_FILE", None)
-    if save_config_path and isinstance(save_config_path, str):
-        try:
-            save_config_path = os.path.abspath(os.path.expanduser(save_config_path))
-            with open(save_config_path, "w") as f:
-                yaml.dump(settings.to_dict(), f)
-            logger.info("Current config is saved to file '%s'", save_config_path)
-        except Exception as ex:
-            logger.error("Failed to save current config to file '%s': %s", save_config_path, ex)
+    # Optionally save settings to a YAML file (used for testing)
+    save_settings_to_file(settings)
 
     stream_publisher = PublishConsoleOutput(
         msg_queue=msg_queue,

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -3,6 +3,7 @@ from multiprocessing import Pipe, Queue
 import threading
 import time as ttime
 import os
+import yaml
 
 from .worker import RunEngineWorker
 from .manager import RunEngineManager
@@ -484,6 +485,17 @@ def start_manager():
     log_level = settings.console_logging_level
     logging.basicConfig(level=max(logging.WARNING, log_level))
     setup_loggers(log_level=log_level)
+
+    # Save current settings to file. This feature is mostly for testing.
+    save_config_path = os.environ.get("QSERVER_SETTINGS_SAVE_TO_FILE", None)
+    if save_config_path and isinstance(save_config_path, str):
+        try:
+            save_config_path = os.path.abspath(os.path.expanduser(save_config_path))
+            with open(save_config_path, "w") as f:
+                yaml.dump(settings.to_dict(), f)
+            logger.info("Current config is saved to file '%s'", save_config_path)
+        except Exception as ex:
+            logger.error("Failed to save current config to file '%s': %s", save_config_path, ex)
 
     stream_publisher = PublishConsoleOutput(
         msg_queue=msg_queue,

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -3,19 +3,17 @@ from multiprocessing import Pipe, Queue
 import threading
 import time as ttime
 import os
-from importlib.util import find_spec
 
 from .worker import RunEngineWorker
 from .manager import RunEngineManager
-from .comms import PipeJsonRpcReceive, validate_zmq_key, default_zmq_control_address_for_server
-from .profile_ops import get_default_startup_dir
+from .comms import PipeJsonRpcReceive, default_zmq_control_address_for_server
 from .output_streaming import (
     PublishConsoleOutput,
     setup_console_output_redirection,
     default_zmq_info_address_for_server,
 )
 from .logging_setup import setup_loggers
-from .config import parse_configs, get_log_level_from_config
+from .config import Settings
 
 from .. import __version__
 
@@ -472,45 +470,29 @@ def start_manager():
 
     args = parser.parse_args()
 
-    # Load configuration from file
-    config_path = args.config_path
-    config_path = config_path or os.environ.get("QSERVER_CONFIG", None)
-    config_from_file = parse_configs(config_path) if config_path else {}
+    settings = Settings(parser=parser, args=args)
 
-    log_level = get_log_level_from_config(
-        config_from_file,
-        cli_verbose=args.logger_verbose,
-        cli_quiet=args.logger_quiet,
-        cli_silent=args.logger_silent,
-    )
-
-    console_output_on = args.console_output == "ON"
-    zmq_publish_console_on = args.zmq_publish_console == "ON"
-
-    zmq_info_addr = args.zmq_info_addr
     if args.zmq_publish_console_addr is not None:
         logger.warning(
             "Parameter --zmq-publish-console-addr is deprecated and will be removed in future releases. "
             "Use --zmq-info-addr instead."
         )
-    zmq_info_addr = zmq_info_addr or args.zmq_publish_console_addr
-    zmq_info_addr = zmq_info_addr or os.environ.get("QSERVER_ZMQ_INFO_ADDRESS_FOR_SERVER", None)
-    zmq_info_addr = zmq_info_addr or default_zmq_info_address_for_server
 
     msg_queue = Queue()
     setup_console_output_redirection(msg_queue)
 
+    log_level = settings.console_logging_level
     logging.basicConfig(level=max(logging.WARNING, log_level))
     setup_loggers(log_level=log_level)
 
     stream_publisher = PublishConsoleOutput(
         msg_queue=msg_queue,
-        console_output_on=console_output_on,
-        zmq_publish_on=zmq_publish_console_on,
-        zmq_publish_addr=zmq_info_addr,
+        console_output_on=settings.print_console_output,
+        zmq_publish_on=settings.zmq_publish_console,
+        zmq_publish_addr=settings.zmq_info_addr,
     )
 
-    if zmq_publish_console_on:
+    if settings.zmq_publish_console:
         # Wait for a short period to allow monitoring applications to connect.
         ttime.sleep(1)
 
@@ -518,46 +500,17 @@ def start_manager():
 
     config_worker = {}
     config_manager = {}
-    if args.kafka_topic is not None:
+    if settings.kafka_topic is not None:
         config_worker["kafka"] = {}
-        config_worker["kafka"]["topic"] = args.kafka_topic
-        config_worker["kafka"]["bootstrap"] = args.kafka_server
+        config_worker["kafka"]["topic"] = settings.kafka_topic
+        config_worker["kafka"]["bootstrap"] = settings.kafka_server
 
-    if args.zmq_data_proxy_addr is not None:
-        config_worker["zmq_data_proxy_addr"] = args.zmq_data_proxy_addr
+    if settings.zmq_data_proxy_addr is not None:
+        config_worker["zmq_data_proxy_addr"] = settings.zmq_data_proxy_addr
 
-    startup_dir, startup_module_name, startup_script_path = None, None, None
-
-    # Find startup directory
-    if args.profile_name:
-        profile_name = args.profile_name
-        if find_spec("IPython"):
-            import IPython
-
-            path_to_ipython = IPython.paths.get_ipython_dir()
-        else:
-            logger.error(
-                "IPython is not installed. Specify directory to startup file by using '--startup-dir' option."
-            )
-            return 1
-        ipython_dir = os.path.abspath(path_to_ipython)
-        profile_name_full = f"profile_{profile_name}"
-        startup_dir = os.path.join(ipython_dir, profile_name_full, "startup")
-    elif args.startup_dir:
-        startup_dir = args.startup_dir
-        startup_dir = os.path.abspath(os.path.expanduser(startup_dir))
-    elif args.startup_module_name:
-        startup_module_name = args.startup_module_name
-    elif args.startup_script_path:
-        startup_script_path = os.path.abspath(os.path.expanduser(args.startup_script_path))
-    else:
-        # The default collection is the collection of simulated Ophyd devices
-        #   and built-in Bluesky plans.
-        startup_dir = get_default_startup_dir()
-
-    if sum([_ is not None for _ in [startup_dir, startup_module_name, startup_script_path]]) != 1:
-        logger.error("Multiple or no startup code sources were specified.")
-        return 1
+    startup_dir = settings.startup_dir
+    startup_module_name = settings.startup_module
+    startup_script_path = settings.startup_script_path
 
     # Primitive error processing: make sure that all essential data exists.
     if startup_dir is not None:
@@ -571,13 +524,13 @@ def start_manager():
         # startup_module_name or startup_script_path is set. This option requires
         #   the paths to existing plans and devices and user group permissions to be set.
         #   (The default directory can not be used in this case).
-        if not args.existing_plans_and_devices_path:
+        if not settings.existing_plans_and_devices_path:
             logger.error(
                 "The path to the list of existing plans and devices (--existing-plans-and-devices) "
                 "is not specified."
             )
             return 1
-        if not args.user_group_permissions_path:
+        if not settings.user_group_permissions_path:
             logger.error(
                 "The path to the file containing user group permissions (--user-group-permissions) "
                 "is not specified."
@@ -589,20 +542,20 @@ def start_manager():
                 logger.error("The script '%s' is not found.", startup_script_path)
                 return 1
 
-    config_worker["keep_re"] = args.keep_re
-    config_worker["use_persistent_metadata"] = args.use_persistent_metadata
+    config_worker["keep_re"] = settings.keep_re
+    config_worker["use_persistent_metadata"] = settings.use_persistent_metadata
 
     config_worker["databroker"] = {}
-    if args.databroker_config:
-        config_worker["databroker"]["config"] = args.databroker_config
+    if settings.databroker_config:
+        config_worker["databroker"]["config"] = settings.databroker_config
 
     config_worker["startup_dir"] = startup_dir
     config_worker["startup_module_name"] = startup_module_name
     config_worker["startup_script_path"] = startup_script_path
 
     default_existing_pd_fln = "existing_plans_and_devices.yaml"
-    if args.existing_plans_and_devices_path:
-        existing_pd_path = os.path.expanduser(args.existing_plans_and_devices_path)
+    if settings.existing_plans_and_devices_path:
+        existing_pd_path = os.path.expanduser(settings.existing_plans_and_devices_path)
         if not os.path.isabs(existing_pd_path) and startup_dir:
             existing_pd_path = os.path.join(startup_dir, existing_pd_path)
         if not existing_pd_path.endswith(".yaml"):
@@ -627,8 +580,8 @@ def start_manager():
         )
 
     default_user_group_pd_fln = "user_group_permissions.yaml"
-    if args.user_group_permissions_path:
-        user_group_pd_path = os.path.expanduser(args.user_group_permissions_path)
+    if settings.user_group_permissions_path:
+        user_group_pd_path = os.path.expanduser(settings.user_group_permissions_path)
         if not os.path.isabs(user_group_pd_path) and startup_dir:
             user_group_pd_path = os.path.join(startup_dir, user_group_pd_path)
         if not user_group_pd_path.endswith(".yaml"):
@@ -648,46 +601,15 @@ def start_manager():
     config_manager["existing_plans_and_devices_path"] = existing_pd_path
     config_manager["user_group_permissions_path"] = user_group_pd_path
 
-    config_worker["update_existing_plans_devices"] = args.update_existing_plans_devices
+    config_worker["update_existing_plans_devices"] = settings.update_existing_plans_devices
+    config_manager["user_group_permissions_reload"] = settings.user_group_permissions_reload
 
-    config_manager["user_group_permissions_reload"] = args.user_group_permissions_reload
+    config_manager["zmq_addr"] = settings.zmq_control_addr
+    config_manager["zmq_private_key"] = settings.zmq_private_key
 
-    # Read private key from the environment variable, then check if the CLI parameter exists
-    zmq_private_key = os.environ.get("QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER", None)
-    if (zmq_private_key is None) and ("QSERVER_ZMQ_PRIVATE_KEY" in os.environ):
-        logger.warning(
-            "Environment variable QSERVER_ZMQ_PRIVATE_KEY is deprecated and will be removed "
-            "in future releases. Use QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER instead"
-        )
-    zmq_private_key = zmq_private_key or os.environ.get("QSERVER_ZMQ_PRIVATE_KEY", None)
-    zmq_private_key = zmq_private_key or None  # Case of key==""
-    if zmq_private_key is not None:
-        try:
-            validate_zmq_key(zmq_private_key)
-        except Exception as ex:
-            logger.error("ZMQ private key is improperly formatted: %s", ex)
-            return 1
+    config_manager["redis_addr"] = settings.redis_addr
 
-    zmq_control_addr = args.zmq_control_addr
-    if args.zmq_addr is not None:
-        logger.warning(
-            "Parameter --zmq-addr is deprecated and will be removed in future releases. "
-            "Use --zmq-control-addr instead."
-        )
-    zmq_control_addr = zmq_control_addr or args.zmq_addr
-    zmq_control_addr = zmq_control_addr or os.environ.get("QSERVER_ZMQ_CONTROL_ADDRESS_FOR_SERVER")
-    zmq_control_addr = zmq_control_addr or default_zmq_control_address_for_server
-    config_manager["zmq_addr"] = zmq_control_addr
-    config_manager["zmq_private_key"] = zmq_private_key
-
-    redis_addr = args.redis_addr
-    if redis_addr.count(":") > 1:
-        logger.error("Redis address is incorrectly formatted: '%s'", redis_addr)
-        return 1
-    config_manager["redis_addr"] = redis_addr
-
-    lock_key_emergency = os.environ.get("QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER", None)
-    config_manager["lock_key_emergency"] = lock_key_emergency
+    config_manager["lock_key_emergency"] = settings.emergency_lock_key
 
     wp = WatchdogProcess(
         config_worker=config_worker, config_manager=config_manager, msg_queue=msg_queue, log_level=log_level

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -498,6 +498,8 @@ def start_manager():
 
     stream_publisher.start()
 
+    logger.info("RE Manager configuration:\n%s", settings)
+
     config_worker = {}
     config_manager = {}
     if settings.kafka_topic is not None:

--- a/bluesky_queueserver/manager/tests/test_config.py
+++ b/bluesky_queueserver/manager/tests/test_config.py
@@ -1,0 +1,182 @@
+import os
+import pytest
+
+from ..config import parse_configs, ConfigError
+
+fln_config_schema = "config_schema.yml"
+
+config_01_success = """
+network:
+  zmq_control_addr: tcp://*:60615
+  zmq_private_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  zmq_info_addr: tcp://*:60625
+  zmq_publish_console: true
+  redis_addr: localhost:6379
+startup:
+  keep_re: true
+  startup_dir: ~/.ipython/profile_collection/startup
+  existing_plans_and_devices_path: ~/.ipython/profile_collection/startup
+  user_group_permissions_path: ~/.ipython/profile_collection/startup
+operation:
+  print_console_output: true
+  console_output_level: NORMAL
+  existing_plans_and_devices_update: ENVIRONMENT_OPEN
+  user_group_permissions_reload: ON_REQUEST
+run_engine:
+  user_persistent_metadata: true
+  kafka_server: 127.0.0.1:9092
+  kafka_topic: topic_name
+  databroker_config: TST
+"""
+
+config_01a_success = """
+network:
+  zmq_control_addr: tcp://*:60615
+  zmq_private_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  zmq_info_addr: tcp://*:60625
+  zmq_publish_console: true
+  redis_addr: localhost:6379
+"""
+
+config_01b_success = """
+startup:
+  keep_re: true
+  startup_dir: ~/.ipython/profile_collection/startup
+  existing_plans_and_devices_path: ~/.ipython/profile_collection/startup
+  user_group_permissions_path: ~/.ipython/profile_collection/startup
+"""
+
+config_01c_success = """
+operation:
+  print_console_output: true
+  console_output_level: NORMAL
+  existing_plans_and_devices_update: ENVIRONMENT_OPEN
+  user_group_permissions_reload: ON_REQUEST
+"""
+
+config_01d_success = """
+run_engine:
+  user_persistent_metadata: true
+  kafka_server: 127.0.0.1:9092
+  kafka_topic: topic_name
+  databroker_config: TST
+"""
+
+config_01_dict = {
+    "network": {
+        "zmq_control_addr": "tcp://*:60615",
+        "zmq_private_key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "zmq_info_addr": "tcp://*:60625",
+        "zmq_publish_console": True,
+        "redis_addr": "localhost:6379",
+    },
+    "startup": {
+        "keep_re": True,
+        "startup_dir": "~/.ipython/profile_collection/startup",
+        "existing_plans_and_devices_path": "~/.ipython/profile_collection/startup",
+        "user_group_permissions_path": "~/.ipython/profile_collection/startup",
+    },
+    "operation": {
+        "print_console_output": True,
+        "console_output_level": "NORMAL",
+        "existing_plans_and_devices_update": "ENVIRONMENT_OPEN",
+        "user_group_permissions_reload": "ON_REQUEST",
+    },
+    "run_engine": {
+        "user_persistent_metadata": True,
+        "kafka_server": "127.0.0.1:9092",
+        "kafka_topic": "topic_name",
+        "databroker_config": "TST",
+    },
+}
+
+config_02_success = """
+startup:
+  keep_re: true
+"""
+
+config_02_dict = {"startup": {"keep_re": True}}
+
+# 'startup_dir' and 'startup_script' are mutually exclusive
+config_03_fail = """
+startup:
+  startup_dir: ~/.ipython/profile_collection/startup
+  startup_script: ~/.ipython/profile_collection/startup/startup.py
+"""
+
+config_04_fail = """
+startup:
+  console_output_level: INVALID
+"""
+
+config_05_fail = """
+startup:
+  existing_plans_and_devices_update: INVALID
+"""
+
+config_06_fail = """
+startup:
+  user_group_permissions_reload: INVALID
+"""
+
+
+# fmt: off
+@pytest.mark.parametrize("config_str, config_dict, success", [
+    ([config_01_success], config_01_dict, True),
+    ([config_02_success], config_02_dict, True),
+    ([config_03_fail], None, False),
+    ([config_04_fail], None, False),
+    ([config_05_fail], None, False),
+    ([config_06_fail], None, False),
+    ([config_01a_success, config_01b_success, config_01c_success, config_01d_success],
+     config_01_dict, True),
+    ([config_01a_success, config_01a_success], None, False),
+])
+# fmt: on
+def test_config_schema_01(tmpdir, config_str, config_dict, success):
+    """
+    parse_configs(): basic test
+    """
+    for n, s in enumerate(config_str):
+        fln_path = os.path.join(tmpdir, f"config{n + 1}.yml")
+        with open(fln_path, "w") as f:
+            f.writelines(s)
+
+    if len(config_str) > 1:
+        config_path = str(tmpdir)
+    else:
+        config_path = os.path.join(tmpdir, "config1.yml")
+
+    if success:
+        config = parse_configs(config_path)
+        assert config == config_dict
+    else:
+        with pytest.raises(ConfigError):
+            parse_configs(config_path)
+
+
+# fmt: off
+@pytest.mark.parametrize("option", ["file", "empty_dir", "non_existing_dir"])
+# fmt: on
+def test_config_schema_02(tmpdir, option):
+    """
+    parse_configs(): test the cases of missing file, missing directory and empty
+    directory. If the path is missing, the exception is raised. Empty directory
+    results in empty dictionary.
+    """
+    if option == "empty_dir":
+        config_path = str(tmpdir)
+    elif option == "non_existing_dir":
+        config_path = os.path.join(tmpdir, "some_dir")
+    elif option == "file":
+        config_path = os.path.join(tmpdir, "config1.yml")
+    else:
+        assert False, f"Unsupported option {option!r}"
+
+    if option in ("non_existing_dir", "file"):
+        errmsg = f"The config path '{config_path!s}' doesn't exist"
+        with pytest.raises(ConfigError, match=errmsg):
+            parse_configs(config_path)
+    else:
+        config = parse_configs(config_path)
+        assert config == {}

--- a/bluesky_queueserver/manager/tests/test_config.py
+++ b/bluesky_queueserver/manager/tests/test_config.py
@@ -1,7 +1,8 @@
+import copy
 import os
 import pytest
 
-from ..config import parse_configs, ConfigError
+from ..config import parse_configs, ConfigError, get_value_from_config
 
 fln_config_schema = "config_schema.yml"
 
@@ -180,3 +181,22 @@ def test_config_schema_02(tmpdir, option):
     else:
         config = parse_configs(config_path)
         assert config == {}
+
+
+def test_get_value_from_config_01():
+    config = config_01_dict
+    assert get_value_from_config(config, key="startup/keep_re") is True
+    assert get_value_from_config(config, key="startup/keep_re", default=False) is True
+
+    config2 = copy.deepcopy(config)
+    del config2["startup"]["keep_re"]
+    assert get_value_from_config(config2, key="startup/keep_re", default=False) is False
+
+    with pytest.raises(ConfigError, match="is not supported"):
+        get_value_from_config(config, key="", default=False)
+
+    with pytest.raises(ConfigError, match="is not supported"):
+        get_value_from_config(config, key="some_key", default=False)
+
+    with pytest.raises(ConfigError, match="is not supported"):
+        get_value_from_config(config, key="some/key", default=False)

--- a/bluesky_queueserver/manager/tests/test_config.py
+++ b/bluesky_queueserver/manager/tests/test_config.py
@@ -1,8 +1,7 @@
-import copy
 import os
 import pytest
 
-from ..config import parse_configs, ConfigError, get_value_from_config
+from ..config import parse_configs, ConfigError
 
 fln_config_schema = "config_schema.yml"
 
@@ -187,22 +186,3 @@ def test_config_schema_02(tmpdir, option):
     else:
         config = parse_configs(config_path)
         assert config == {}
-
-
-def test_get_value_from_config_01():
-    config = config_01_dict
-    assert get_value_from_config(config, key="startup/keep_re") is True
-    assert get_value_from_config(config, key="startup/keep_re", default=False) is True
-
-    config2 = copy.deepcopy(config)
-    del config2["startup"]["keep_re"]
-    assert get_value_from_config(config2, key="startup/keep_re", default=False) is False
-
-    with pytest.raises(ConfigError, match="is not supported"):
-        get_value_from_config(config, key="", default=False)
-
-    with pytest.raises(ConfigError, match="is not supported"):
-        get_value_from_config(config, key="some_key", default=False)
-
-    with pytest.raises(ConfigError, match="is not supported"):
-        get_value_from_config(config, key="some/key", default=False)

--- a/bluesky_queueserver/manager/tests/test_config.py
+++ b/bluesky_queueserver/manager/tests/test_config.py
@@ -20,13 +20,15 @@ startup:
   user_group_permissions_path: ~/.ipython/profile_collection/startup
 operation:
   print_console_output: true
-  console_output_level: NORMAL
-  existing_plans_and_devices_update: ENVIRONMENT_OPEN
+  console_logging_level: NORMAL
+  update_existing_plans_and_devices: ENVIRONMENT_OPEN
   user_group_permissions_reload: ON_REQUEST
+  emergency_lock_key: some_lock_key
 run_engine:
-  user_persistent_metadata: true
+  use_persistent_metadata: true
   kafka_server: 127.0.0.1:9092
   kafka_topic: topic_name
+  zmq_data_proxy_addr: localhost:5567
   databroker_config: TST
 """
 
@@ -50,16 +52,18 @@ startup:
 config_01c_success = """
 operation:
   print_console_output: true
-  console_output_level: NORMAL
-  existing_plans_and_devices_update: ENVIRONMENT_OPEN
+  console_logging_level: NORMAL
+  update_existing_plans_and_devices: ENVIRONMENT_OPEN
   user_group_permissions_reload: ON_REQUEST
+  emergency_lock_key: some_lock_key
 """
 
 config_01d_success = """
 run_engine:
-  user_persistent_metadata: true
+  use_persistent_metadata: true
   kafka_server: 127.0.0.1:9092
   kafka_topic: topic_name
+  zmq_data_proxy_addr: localhost:5567
   databroker_config: TST
 """
 
@@ -79,14 +83,16 @@ config_01_dict = {
     },
     "operation": {
         "print_console_output": True,
-        "console_output_level": "NORMAL",
-        "existing_plans_and_devices_update": "ENVIRONMENT_OPEN",
+        "console_logging_level": "NORMAL",
+        "update_existing_plans_and_devices": "ENVIRONMENT_OPEN",
         "user_group_permissions_reload": "ON_REQUEST",
+        "emergency_lock_key": "some_lock_key",
     },
     "run_engine": {
-        "user_persistent_metadata": True,
+        "use_persistent_metadata": True,
         "kafka_server": "127.0.0.1:9092",
         "kafka_topic": "topic_name",
+        "zmq_data_proxy_addr": "localhost:5567",
         "databroker_config": "TST",
     },
 }
@@ -107,12 +113,12 @@ startup:
 
 config_04_fail = """
 startup:
-  console_output_level: INVALID
+  console_logging_level: INVALID
 """
 
 config_05_fail = """
 startup:
-  existing_plans_and_devices_update: INVALID
+  update_existing_plans_and_devices: INVALID
 """
 
 config_06_fail = """

--- a/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -585,9 +585,13 @@ def _get_empty_params_1(tmpdir):
 
 # fmt: off
 @pytest.mark.parametrize("pass_config, file_dir, get_cli_params, get_expected_settings", [
+    # Starting RE Manager using default parameters (--verbose CLI parameter is always set)
     (None, None, _get_empty_params_1, _get_expected_settings_default_1),
+    # Pass config file (use EV to pass the path)
     ("name_as_ev", _dir_2, _get_empty_params_1, _get_expected_settings_config_2),
+    # Pass config file (use --config CLI parameter to pass the path)
     ("name_as_param", _dir_2, _get_empty_params_1, _get_expected_settings_config_2),
+    # Pass the config file and a set of CLI parameters that override the config parameters
     ("name_as_param", _dir_3, _get_cli_params_3, _get_expected_settings_params_3),
 ])
 # fmt: on
@@ -632,7 +636,7 @@ def test_manager_with_config_file_01(
     with open(save_settings_path, "r") as f:
         current_settings = yaml.load(f, Loader=yaml.FullLoader)
 
-    print(pprint.pformat(current_settings))
+    print(pprint.pformat(current_settings))  # Useful in case of failure
 
     # Remove 'startup_dir' from the settings dictionaries and compare them
     #   separately. This is needed because the default startup directory

--- a/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -480,7 +480,7 @@ def test_manager_with_config_file_01(
     re_manager_cmd(params_server)
 
     with open(save_settings_path, "r") as f:
-        current_settings = yaml.load(f)
+        current_settings = yaml.load(f, Loader=yaml.FullLoader)
 
     print(pprint.pformat(current_settings))
     assert current_settings == loaded_settings

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -24,6 +24,15 @@ the location of beamline startup scripts.
 
 .. _location_of_startup_code:
 
+Using a Configuration Files
++++++++++++++++++++++++++++
+
+RM Manager can be customized using a config file (YML). Combining the parameters
+in a single config file may be more convenient in production deployments. The path
+to config file is passed to the manager using environment variable ``QSERVER_CONFIG``
+or using CLI parameter ``--config``. CLI parameters passed to ``start-re-manager``
+override the parameters set in config file or passed using environment variables.
+
 Location of Startup Code
 ++++++++++++++++++++++++
 
@@ -177,10 +186,10 @@ Other Configuration Parameters
 .. code-block::
 
     $ start-re-manager -h
-    usage: start-re-manager [-h] [--zmq-control-addr ZMQ_CONTROL_ADDR] [--zmq-addr ZMQ_ADDR]
+    usage: start-re-manager [-h] [--config CONFIG_PATH] [--zmq-control-addr ZMQ_CONTROL_ADDR]
+                            [--zmq-addr ZMQ_ADDR]
                             [--startup-dir STARTUP_DIR | --startup-profile PROFILE_NAME |
-                             --startup-module STARTUP_MODULE_NAME |
-                             --startup-script STARTUP_SCRIPT_PATH]
+                             --startup-module STARTUP_MODULE_NAME | --startup-script STARTUP_SCRIPT_PATH]
                             [--existing-plans-devices EXISTING_PLANS_AND_DEVICES_PATH]
                             [--update-existing-plans-devices {NEVER,ENVIRONMENT_OPEN,ALWAYS}]
                             [--user-group-permissions USER_GROUP_PERMISSIONS_PATH]
@@ -196,7 +205,7 @@ Other Configuration Parameters
                             [--verbose | --quiet | --silent]
 
     Start Run Engine (RE) Manager
-    bluesky-queueserver version 0.0.15
+    bluesky-queueserver version 0.0.17.post32.dev0+ga4ba9d1
 
     Encryption for ZeroMQ communication server may be enabled by setting the value of
     'QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER' environment variable to a valid private key
@@ -210,6 +219,12 @@ Other Configuration Parameters
 
     optional arguments:
       -h, --help        show this help message and exit
+      --config CONFIG_PATH
+                        Path to a YML config file or a directory containing multiple config
+                        files. The path passed as a parameter overrides the path set using
+                        QSERVER_CONFIG environment variable. The config path must point to an
+                        existing file or directory (may be empty), otherwise the manager can
+                        not be started.
       --zmq-control-addr ZMQ_CONTROL_ADDR
                         The address of ZMQ server (control connection). The parameter
                         overrides the address defined by the environment variable

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ Bluesky-QueueServer Documentation
    item_validation
    plan_annotation
    cli_tools
+   manager_config
    qserver_quick_ref
 
 .. toctree::

--- a/docs/source/manager_config.rst
+++ b/docs/source/manager_config.rst
@@ -1,0 +1,204 @@
+.. _manager_configuration:
+
+========================
+RE Manager Configuration
+========================
+
+Introduction
+------------
+
+The default settings of RE Manager are optimized for running basic tutorials and
+simple demos using built-in startup scripts with simulated plans and devices,
+and are not sufficient for development and production deployments. The parameter
+values may be passed to RE Manager using environment variables, config file(s)
+and CLI parameters. Parameters passed using config file(s) override the parameters
+passed using environment variables. Parameters passed using CLI override all other
+parameters.
+
+CLI Parameters
+--------------
+
+Comprehensive list of CLI parameters of RE Manager may be found in the documentation
+for :ref:`start_re_manager_cli`. Note, that not setting parameters such as ``--keep-re``
+or ``--use-persistent-metadata`` does not disable the respective features if
+they are enabled in the config file.
+
+Environment Variables
+---------------------
+
+Several parameters can be passed to RE Manager using environment variables:
+
+  - ``QSERVER_CONFIG`` - a path to a single config file or a directory containing multiple
+    config files. The path can be also passed using ``--config`` CLI parameter.
+
+  - ``QSERVER_ZMQ_CONTROL_ADDRESS_FOR_SERVER`` - address of the 0MQ REQ-REP socket used
+    for control communication channel. The address may also be set in the config file or
+    passed using ``--zmq-control-addr`` CLI parameter.
+
+  - ``QSERVER_ZMQ_INFO_ADDRESS_FOR_SERVER`` - address of the 0MQ PUB-SUB socked used to
+    publish console output. The address may also be set in the config file or passed using
+    ``--zmq-info-addr`` CLI parameter.
+
+  - ``QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER`` - emergency lock key used to unlock RE Manager
+    if the lock key set by a user is lost. The key may also be set in the config file.
+
+  - ``QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER`` - private key used to decrypt control messages sent
+    by clients. **Using environment variables may be preferred way of setting the public key.**
+    Alternatively, the private key may be set in the config file by referencing a different
+    environment variable. Explicitly listing security keys in the config file is not recommended.
+
+Configuration Files
+-------------------
+
+The example of a configuration file (e.g. ``qserver_config.yml``) that contains all supported
+parameters:
+
+.. code-block::
+
+    network:
+      zmq_control_addr: tcp://*:60615
+      zmq_private_key: ${CUSTOM_EV_FOR_PRIVATE_KEY}
+      zmq_info_addr: tcp://*:60625
+      zmq_publish_console: true
+      redis_addr: localhost:6379
+    startup:
+      keep_re: true
+      startup_dir: ~/.ipython/profile_collection/startup
+      existing_plans_and_devices_path: ~/.ipython/profile_collection/startup
+      user_group_permissions_path: ~/.ipython/profile_collection/startup
+    operation:
+      print_console_output: true
+      console_logging_level: NORMAL
+      update_existing_plans_and_devices: ENVIRONMENT_OPEN
+      user_group_permissions_reload: ON_REQUEST
+      emergency_lock_key: custom_lock_key
+    run_engine:
+      use_persistent_metadata: true
+      kafka_server: 127.0.0.1:9092
+      kafka_topic: custom_topic_name
+      zmq_data_proxy_addr: localhost:5567
+      databroker_config: TST
+
+All the parameters are optional. The default values or values passed using environment
+variables are used for missing parameters. The configuration may be split into multiple YML
+files and the path to the directory containing the files passed to RE Manager.
+
+Assuming the configuration is saved in ``~/.config/qserver/qserver_config.yml``,
+RE Manager can be started as ::
+
+    $ start-re-manager --config=~/.config/qserver/qserver_config.yml
+
+or ::
+
+    $ QSERVER_CONFIG=~/.config/qserver/qserver_config.yml start-re-manager
+
+Additional CLI parameters override the respective configuration or default parameters.
+
+network
++++++++
+
+Parameters that define for network settings used by RE Manager:
+
+- ``zmq_control_addr`` - address of the 0MQ REQ-REP socket used  for control communication channel.
+  The address may also be set using environment variable ``QSERVER_ZMQ_CONTROL_ADDRESS_FOR_SERVER``
+  or passed using ``--zmq-control-addr`` CLI parameter. Address format: ``tcp://*:60615``.
+
+- ``zmq_private_key`` - private key used to decrypt control messages sent by clients (40 characters).
+  The value should be a string referencing an environment variable (e.g. ``${CUSTOM_EV_NAME}``)
+  or a string containing a public key (not recommended). The private key may also be set
+  using environment variable ``QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER``.
+
+- ``zmq_info_addr`` - address of the 0MQ PUB-SUB socked used to publish console output. The address
+  may also be passed using environment variable QSERVER_ZMQ_INFO_ADDRESS_FOR_SERVER or
+  ``--zmq-info-addr`` CLI parameter. Address format: ``tcp://*:60625``.
+
+- ``zmq_publish_console`` - enable or disable publishing console output to the socket set using
+  ``zmq_info_addr``. Accepted values are ``true`` and ``false``. The value can also passed using
+  ``--zmq-publish-console`` CLI parameter.
+
+- ``redis_addr`` - the address of Redis server, e.g. ``localhost``, ``127.0.0.1``, ``localhost:6379``.
+  The value may also be passed using ``--redis-addr`` CLI parameter.
+
+startup
++++++++
+
+  Parameters that control opening the worker environment and handling of startup files:
+
+  - ``keep_re`` - keep and use the instance of the Run Engine created in startup scripts (``true``)
+    or delete the instance of the Run Engine created in startup scripts and create a new instance
+    based on settings in :ref:`config_file_run_engine` (``false``). The built-in configuration
+    options for Run Engine are very limited and it is assumed that Run Engine is created in startup
+    scripts in production deployments.
+
+  - ``startup_dir``, ``startup_profile``, ``startup_module`` and ``startup_script`` are mutually
+    exclusive parameters that specify a path to startup directory, name of the startup IPython
+    profile, name of installed Python module containing startup code or a path to startup script.
+    The values may be passed using ``--startup-dir``, ``--startup-profile``, ``--startup-module``
+    or ``--startup-script`` CLI parameters.
+
+  - ``existing_plans_and_devices_path`` - path to file that contains the list of existing plans
+    and devices. The path may be a relative path to the directory containing startup files.
+    If the path is directory, then the default file name 'existing_plans_and_devices.yaml' is used.
+    The value may also be passed using ``--existing-plans-devices`` CLI parameter.
+
+  - ``user_group_permissions_path`` - path to a file that contains lists of plans and devices
+    available to users. The path may be a relative path to the profile collection directory.
+    If the path is a directory, then the default file name 'user_group_permissions.yaml' is used.
+    The value may also be passed using ``--user-group-permissions`` CLI parameter.
+
+
+operation
++++++++++
+
+The parameters that define run-time behavior of RE Manager:
+
+- ``print_console_output`` - enables (``true``) or disables (``false``) printing of console
+  output in the terminal. The value may also be set using ``--console-output`` CLI parameter.
+
+- ``console_logging_level`` - sets logging level used by RE Manager. The accepted values are
+  ``'SILENT'``, ``'QUIET'`` ``'NORMAL'`` (default) and ``'VERBOSE'``. The non-default value
+  may also be selected using ``--silent``, ``--quiet`` and ``--verbose`` CLI parameters.
+
+- ``update_existing_plans_and_devices`` - select when the list of existing plans and devices
+  stored on disk should be updated. The available choices are not to update the stored
+  lists (``'NEVER'``), update the lists when the environment is opened
+  (``'ENVIRONMENT_OPEN'``, default) or update the lists each the lists are changed (``'ALWAYS'``).
+  The value may be set using ``--update-existing-plans-devices`` parameter.
+
+- ``user_group_permissions_reload`` - select when user group permissions are reloaded from disk.
+  Options: ``'NEVER'`` - RE Manager never attempts to load permissions from disk file.
+  If permissions fail to load from Redis, they are loaded from disk at the first startup
+  of RE Manager or on request. ``'ON_REQUEST'`` - permissions are loaded from disk file when
+  requested by 'permission_reload' API call. ``'ON_STARTUP'`` (default) - permissions are loaded
+  from disk each time RE Manager is started or when 'permission_reload' API request is received.
+  The value may be set using ``--user-group-permissions-reload`` CLI parameter.
+
+- ``emergency_lock_key`` - emergency lock key used to unlock RE Manager if the lock key set by
+  a user is lost. The key may also be set using environment variable
+  ``QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER``.
+
+.. _config_file_run_engine:
+
+run_engine
+++++++++++
+
+The parameters that define configuration of Run Engine created by RE Manager and some basic
+subscriptions for the Run Engine. The configuration options are very limited and primarily
+intended for use in quick demos. It is assumed that in production systems, Run Engine and
+its subscriptions are fully defined in startup scripts and this section is skipped completely.
+
+- ``use_persistent_metadata`` - use msgpack-based persistent storage for scan metadata
+  (``true/false``). The option can also be enabled using ``--use-persistent-metadata`` CLI
+  parameter.
+
+- ``kafka_server`` - bootstrap server to for Kafka Run Engine callback, e.g. ``127.0.0.1:9092``.
+  The value can be set using ``--kafka-server`` CLI parameter.
+
+- ``kafka_topic`` - kafka topic of Kafka Run Engine callback. The value can also be set using
+  ``--kafka-topic`` CLI parameter.
+
+- ``zmq_data_proxy_addr`` - address of ZMQ proxy used to publish data by ZMQ Run Engine callback.
+  The value can also be set using ``--zmq-data-proxy-addr`` CLI parameter.
+
+- ``databroker_config`` -  databroker configuration (e.g. ``'srx'``) used by Databroker
+  callback. The value can also be set using ``--databroker-config`` CLI parameter.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ codecov
 coverage
 flake8
 happi>=1.14.0
-pytest
+pytest<7.2.0
 pytest-xprocess
 sphinx
 # These are dependencies of various sphinx extensions for documentation.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,8 +5,9 @@ codecov
 coverage
 flake8
 happi>=1.14.0
-pytest<7.2.0
+pytest
 pytest-xprocess
+py
 sphinx
 # These are dependencies of various sphinx extensions for documentation.
 ipython


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Implemented functionality that allows passing parameters to RE Manager as a configuration file. The path may be passed using `--config` CLI parameter or `QSERVER_CONFIG` environment variable. See `RE Manager Configuration` section in the documentation for more details.

RE Manager is not attempting to load configuration unless the path is passed as EV or `--config` parameter and CLI parameters override parameters passed in configuration file, so the changes are not expect to affect existing deployments.

The config files have similar format as config files used for Databroker/Tiled and Bluesky HTTP Server. Example config file (e.g. `config.yml`):

```
network:
  zmq_control_addr: tcp://*:60615
  zmq_private_key: ${CUSTOM_EV_FOR_PRIVATE_KEY}
  zmq_info_addr: tcp://*:60625
  zmq_publish_console: true
  redis_addr: localhost:6379
startup:
  keep_re: true
  startup_dir: ~/.ipython/profile_collection/startup
  existing_plans_and_devices_path: ~/.ipython/profile_collection/startup
  user_group_permissions_path: ~/.ipython/profile_collection/startup
operation:
  print_console_output: true
  console_logging_level: NORMAL
  update_existing_plans_and_devices: ENVIRONMENT_OPEN
  user_group_permissions_reload: ON_REQUEST
  emergency_lock_key: custom_lock_key
run_engine:
  use_persistent_metadata: true
  kafka_server: 127.0.0.1:9092
  kafka_topic: custom_topic_name
  zmq_data_proxy_addr: localhost:5567
  databroker_config: TST
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Managing parameters using configuration files may be more convenient in production deployments.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Support for managing parameters to RE Manager using configuration YML files.

- New CLI parameter `--config` and environment variable `QSERVER_CONFIG` for passing the path to config file to RE Manager.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
