### PR TITLE
ENH: Auto-start queue as non-default option 

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -2123,6 +2123,8 @@ class RunEngineManager(Process):
             # If empty queue but queue auto-start; may catch an exception, and update success
             if self._manager_state == MState.AUTO_START:
                 success_, msg_ = await self._start_plan()
+            else:
+                success_, msg_ = True, ""
             success = success and success_
             if msg_:
                 msg = f"{msg} / {msg_}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This extends the enum for `MState`,  adds an attribute to the `REManager`, and some methods for interfacing with that attribute via ZMQ. It provides the user an option for an empty queue, that is otherwise uninterrupted, to remain "hot" and auto-start when new items are added. This retains the default behavior of the `REManager`, but creates a new type of 'idle' state beyond `MState.IDLE`. All other interruptions (i.e. stopping the queue, an error in a plan, etc.) will stop the queue in an `IDLE` state, that will require user intervention to restart the queue. This will for example, allow a user to ask for a stop to the queue during the final running plan, and not have any new added plans automatically run. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Beamline scientists have been begging for this. It reflects the behavior that they are accustomed to with the RunEngine (prompt execution of plans), and enables remote agents to drive an experiment starting from an empty queue. While there is already functionality for prompt execution of plans, this would enable the addition of a plan or set of plans from multiple sources, with automatic processing from the queue. I broadly agree that this should not be the default behavior, but should be an option. 

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->
Adds an optional autostart state to `REManager`, so that an empty queue can begin processing plans automatically as they are added. 

<!--- Group the changes in the following sections: -->

### Fixed
- Adjusts the `_start_plan_task` to first check for a queue stop, then check if there are pending plans. This ordering wasn't an issue when both no pending plans and a queue stop triggered similar behavior. 

### Added
- Additional state to `MState`
- Activate and deactivate functions for autostart, with handlers

### Changed
- Caveat to some checks for `IDLE` to optionally change to `AUTOSTART` instead. 
- 
### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Written unit tests following the same syntactical approach in `test_scenarios.py` and `test_zmq_api.py`.


<!--
## Screenshots (if appropriate):
-->
