### PR TITLE
Implementation of 'ignore_failures' queue mode

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -666,7 +666,10 @@ class RunEngineManager(Process):
                 msg_display,
             )
 
-            if plan_state in ("completed", "unknown"):
+            ignore_failures = self._plan_queue.plan_queue_mode["ignore_failures"]
+            continue_failed = (plan_state == "failed") and ignore_failures
+
+            if plan_state in ("completed", "unknown") or continue_failed:
                 # Check if the plan was running in the 'immediate_execution' mode.
                 item = await self._plan_queue.get_running_item_info()
                 immediate_execution = item.get("properties", {}).get("immediate_execution", False)

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -120,9 +120,11 @@ qserver queue start        # Start execution of the queue
 qserver queue stop         # Request execition of the queue to stop after current plan
 qserver queue stop cancel  # Cancel request to stop execution of the queue
 
-# Queue can operate in LOOP mode, which is disabled by default. To enable or disable the LOOP mode use
+# Change the queue mode. Enable/disable LOOP and IGNORE_FAILURES modes:
 qserver queue mode set loop True
 qserver queue mode set loop False
+qserver queue mode set ignore_failures True
+qserver queue mode set ignore_failures False
 
 # The following requests are forwarded to the Run Engine:
 qserver re pause           # Request to PAUSE currently executed plan at the next checkpoint

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -574,6 +574,14 @@ def test_qserver_queue_mode_set_1(re_manager):  # noqa F811
     status = get_queue_state()
     assert status["plan_queue_mode"]["loop"] is False
 
+    assert subprocess.call(["qserver", "queue", "mode", "set", "ignore_failures", "True"]) == SUCCESS
+    status = get_queue_state()
+    assert status["plan_queue_mode"]["ignore_failures"] is True
+
+    assert subprocess.call(["qserver", "queue", "mode", "set", "ignore_failures", "False"]) == SUCCESS
+    status = get_queue_state()
+    assert status["plan_queue_mode"]["ignore_failures"] is False
+
 
 # fmt: off
 @pytest.mark.parametrize("plist, exit_code", [
@@ -584,6 +592,8 @@ def test_qserver_queue_mode_set_1(re_manager):  # noqa F811
     (("set", "unknown_param", "True"), REQ_FAILED),  # Unsupported parameter name
     (("set", "loop", "true"), REQ_FAILED),  # Invalid parameter value
     (("set", "loop", "10"), REQ_FAILED),  # Invalid parameter value
+    (("set", "ignore_failures", "true"), REQ_FAILED),  # Invalid parameter value
+    (("set", "ignore_failures", "10"), REQ_FAILED),  # Invalid parameter value
 ])
 # fmt: on
 def test_qserver_queue_mode_set_2_fail(re_manager, plist, exit_code):  # noqa F811

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -370,17 +370,18 @@ periodically requests and displays the status of Queue Server.
 
 .. code-block::
 
-    $ qserver -h
+    qserver -h
     usage: qserver [-h] [--zmq-control-addr ZMQ_CONTROL_ADDR] [--address ADDRESS]
+                  [--lock-key LOCK_KEY]
                   command [command ...]
 
     Command-line tool for communicating with RE Monitor.
-    bluesky-queueserver version 0.0.16
+    bluesky-queueserver version 0.0.19.
 
     positional arguments:
       command           a sequence of keywords and parameters that define the command
 
-    optional arguments:
+    options:
       -h, --help        show this help message and exit
       --zmq-control-addr ZMQ_CONTROL_ADDR, -a ZMQ_CONTROL_ADDR
                         Address of the control socket of RE Manager. The parameter overrides
@@ -391,6 +392,10 @@ periodically requests and displays the status of Queue Server.
       --address ADDRESS
                         The parameter is deprecated and will be removed. Use --zmq-control-
                         addr instead.
+      --lock-key LOCK_KEY, -k LOCK_KEY
+                        Lock key. The key is an arbitrary string is used to lock and unlock RE
+                        Manager ('lock' and 'unlock' API) and control the manager when the
+                        environment or the queue is locked.
 
     If RE Manager is configured to use encrypted ZeroMQ communication channel,
     the encryption must also be enabled before running 'qserver' CLI tool by setting
@@ -477,9 +482,11 @@ periodically requests and displays the status of Queue Server.
     qserver queue stop         # Request execition of the queue to stop after current plan
     qserver queue stop cancel  # Cancel request to stop execution of the queue
 
-    # Queue can operate in LOOP mode, which is disabled by default. To enable or disable the LOOP mode use
+    # Change the queue mode. Enable/disable LOOP and IGNORE_FAILURES modes:
     qserver queue mode set loop True
     qserver queue mode set loop False
+    qserver queue mode set ignore_failures True
+    qserver queue mode set ignore_failures False
 
     # The following requests are forwarded to the Run Engine:
     qserver re pause           # Request to PAUSE currently executed plan at the next checkpoint
@@ -507,6 +514,8 @@ periodically requests and displays the status of Queue Server.
     qserver script upload <path-to-file>              # Upload a script to RE Worker environment
     qserver script upload <path-to-file> background   # ... in the background
     qserver script upload <path-to-file> update-re    # ... allow 'RE' and 'db' to be updated
+    qserver script upload <path-to-file> keep-lists   # ... leave lists of allowed and existing plans and devices
+                                                      #   unchanged (saves processing time)
 
     qserver task result <task-uid>  # Load status or result of a task with the given UID
     qserver task status <task-uid>  # Check status of a task with the given UID

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -276,7 +276,8 @@ Returns       **msg**: *str*
               **plan_queue_mode**: *dict*
                   the dictionary of parameters that determine queue execution mode. The key/value pairs
                   in the dictionary represent parameter names and values. Supported parameters:
-                  *'loop'* (*boolean*) - indicates if the LOOP mode is enabled.
+                  *'loop'* (*boolean*) - indicates if the LOOP mode is enabled, *'ignore_failures'*
+                  (*boolean*) - indicates if IGNORE_FAILURES mode is enabled.
 
               **queue_stop_pending**: *boolean*
                   indicates if the request to stop the queue after completion of the current plan is
@@ -716,11 +717,13 @@ Description   Sets parameters that define the mode of plan queue execution. The 
               built-in default values, set *mode="default"*. The request fails if the *'mode'* parameter
               is not a dictionary or the *'default'* string, the dictionary contains unsupported keys
               (mode parameters) or key values are of unsupported type. Supported mode parameters
-              (dictionary keys): *'loop'* (*True/False*) - enables/disables loop mode.
+              (dictionary keys): *'loop'* (*True/False*) - enables/disables loop mode; *'ignore_failures'*
+              (*True/False*) - enables/disables the option to continue execution of the queue after
+              a plan fails.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **mode**: *dict* or *str*
                   the dictionary of queue mode parameters or *'default'* string. Supported keys of
-                  the dictionary: *'loop'* (*boolean*).
+                  the dictionary: *'loop'* (*boolean*), *'ignore_failures'* (*boolean*).
 
               **lock_key**: *str* (optional)
                   Lock key. The API fails if **the queue** is locked and no valid key is submitted

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -244,11 +244,13 @@ The queue can operate with enabled/disabled *LOOP* mode (see :ref:`method_queue_
 is disabled (normal mode), the items are popped from the front of the queue and executed by in the Worker
 (plans) or the manager (instructions). The successfully completed plans (including stopped plans) are
 permanently removed from the queue and added to plan history upon completion. If a plan fails, is aborted
-and or halted, it is pushed to the front of the queue and  added to the history along with execution results
-(error message and traceback) and the queue execution is automatically stopped. The operation is slightly
-different if the *LOOP* mode is enabled: successfully executed (or stopped) plans and instructions are
-added to the back of the queue, allowing client to infinitely repeate a sequence of plans. The stopped plans
-are treated as successful in both modes, except that stopping a plan also stops execution of the queue.
+and or halted, it is pushed to the front of the queue and added to the history along with execution results
+(error message and traceback) and the queue execution is automatically stopped. This behavior may be changed
+by enabling *IGNORE_FAILURES* mode, in which the server proceeds with execution of the next plan in the queue
+even after the current plan fails. The operation is slightly different if the *LOOP* mode is enabled:
+successfully executed (or stopped) plans and instructions are added to the back of the queue, allowing
+client to infinitely repeate a sequence of plans. The stopped plans are treated as successful in both modes.
+Stopping a plan also stops execution of the queue.
 
 See the tutorials :ref:`tutorial_starting_stopping_queue` and :ref:`tutorial_iteracting_with_run_engine`.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The PR implements a new `ignore_failures` mode of the queue.

## Description
<!--- Describe your changes in detail -->

Normal behavior of the manager in case the currently running plan fails is to stop execution of the queue and push the current plan to the beginning of the queue so that it could be restarted after the problem is fixed. In the `ignore_failures` mode, the manager continues with execution of the next plan even if the current plan fails. The queue is still stopped if the current plan is stopped/aborted/halted. The mode may be useful in the system running independent plans and controlled by an autonomous agent, which is responsible for processing execution results.

The queue is still stopped if the manager fails to submit the request to start a plan to the worker, but this is not expected to occur during normal operation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Requested feature.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Added

- RE Manager status returns the new `plan_queue_mode/ignore_failures` boolean parameter, which indicates if the mode is enabled.
- `queue_mode_set` API now accepts a value for `ignore_failures` mode.
- The `ignore_failures` mode may be enabled/disabled using `qserver` CLI tool:
  ```
  qserver queue mode set ignore_failures True
  qserver queue mode set ignore_failures False
  ```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests are added.

<!--
## Screenshots (if appropriate):
-->
