### PR TITLE
Implementation of Queue Autostart Mode

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -911,7 +911,7 @@ class RunEngineManager(Process):
 
         return success, err_msg, item, qsize
 
-    async def _start_plan_task(self, stop_queue=False, single_item=None):
+    async def _start_plan_task(self, stop_queue=False, autostart_disable=False, single_item=None):
         """
         Upload the plan to the worker process for execution.
         Plan in the queue is represented as a dictionary with the keys "name" (plan name),
@@ -933,7 +933,7 @@ class RunEngineManager(Process):
                 logger.info("No items are left in the queue.")
 
             if self.queue_stop_pending or stop_queue:
-                autostart_disable = self.queue_stop_pending
+                autostart_disable = self.queue_stop_pending or autostart_disable
                 self._loop.create_task(self._set_manager_state(MState.IDLE, autostart_disable=autostart_disable))
                 success, err_msg = False, "Queue is stopped."
                 logger.info(err_msg)
@@ -1011,7 +1011,7 @@ class RunEngineManager(Process):
                 if next_item["name"] == "queue_stop":
                     await self._plan_queue.process_next_item(item=single_item)
                     self._manager_state = MState.EXECUTING_QUEUE
-                    asyncio.ensure_future(self._start_plan_task(stop_queue=True))
+                    asyncio.ensure_future(self._start_plan_task(stop_queue=True, autostart_disable=True))
                     success, err_msg = True, ""
                 else:
                     success = False

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -2846,19 +2846,20 @@ class RunEngineManager(Process):
         """
         Turn the autostart mode on or off.
         """
+        logger.info("Enabling/disabling autostart mode ...")
         try:
-            enable = request.get("enable", None)
-            if enable is None:
-                raise ValueError("Required 'enable' parameter is missing in 'queue_autostart' API call.")
-            if not isinstance(enable, bool):
-                raise TypeError(f"Required 'enable' parameter must be boolean: type(enable)={type(enable)}.")
-
-            logger.info("Request to %s autostart ...", "enable" if enable else "disable")
-
             supported_param_names = ["enable", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
 
             self._validate_lock_key(request.get("lock_key", None), check_environment=True)
+
+            if "enable" not in request:
+                raise ValueError("Required 'enable' parameter is missing in 'queue_autostart' API call.")
+
+            enable = request.get("enable", None)
+
+            if not isinstance(enable, bool):
+                raise TypeError(f"Required 'enable' parameter must be boolean: type(enable)={type(enable)}.")
 
             if enable:
                 success, msg = await self._autostart_enable()

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -427,6 +427,10 @@ class RunEngineManager(Process):
             success, err_msg = False, f"Failed to start_Worker {str(ex)}"
 
         self._manager_state = MState.IDLE
+
+        if success:
+            self._autostart_push()
+
         return success, err_msg
 
     async def _stop_re_worker(self):

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -893,15 +893,15 @@ class RunEngineManager(Process):
             else:
                 logger.info("No items are left in the queue.")
 
-            if not n_pending_plans:
-                self._loop.create_task(self._set_manager_state(MState.IDLE))
-                success, err_msg = False, "Queue is empty."
-                logger.info(err_msg)
-
-            elif self._queue_stop_pending or stop_queue:
+            if self._queue_stop_pending or stop_queue:
                 autostart_disable = self._queue_stop_pending
                 self._loop.create_task(self._set_manager_state(MState.IDLE, autostart_disable=autostart_disable))
                 success, err_msg = False, "Queue is stopped."
+                logger.info(err_msg)
+
+            elif not n_pending_plans:
+                self._loop.create_task(self._set_manager_state(MState.IDLE))
+                success, err_msg = False, "Queue is empty."
                 logger.info(err_msg)
 
             elif self._re_pause_pending:

--- a/bluesky_queueserver/manager/plan_monitoring.py
+++ b/bluesky_queueserver/manager/plan_monitoring.py
@@ -143,6 +143,18 @@ class RunList:
                 self._list_changed = False
             return run_list_copy
 
+    def get_uids(self):
+        """
+        Return the list of run UIDs
+        """
+        return [_["uid"] for _ in self._run_list]
+
+    def get_scan_ids(self):
+        """
+        Return the list of scan IDs
+        """
+        return [_["scan_id"] for _ in self._run_list]
+
 
 class CallbackRegisterRun(CallbackBase):
     """

--- a/bluesky_queueserver/manager/plan_monitoring.py
+++ b/bluesky_queueserver/manager/plan_monitoring.py
@@ -80,7 +80,7 @@ class RunList:
             self._run_list.clear()
             self._list_changed = True
 
-    def add_run(self, *, uid):
+    def add_run(self, *, uid, scan_id):
         """
         Add run to the end of the list. The run is labeled as 'open' (``is_open`` is set ``True``).
 
@@ -93,7 +93,7 @@ class RunList:
             return
 
         with self._lock:
-            self._run_list.append({"uid": uid, "is_open": True, "exit_status": None})
+            self._run_list.append({"uid": uid, "scan_id": scan_id, "is_open": True, "exit_status": None})
             self._list_changed = True
 
     def set_run_closed(self, *, uid, exit_status):
@@ -167,7 +167,14 @@ class CallbackRegisterRun(CallbackBase):
         """
         try:
             uid = doc["uid"]
-            self._run_list.add_run(uid=uid)
+            scan_id = doc.get("scan_id", None)
+            if scan_id is not None:
+                try:
+                    scan_id = int(scan_id)
+                except Exception:
+                    scan_id = None
+
+            self._run_list.add_run(uid=uid, scan_id=scan_id)
 
             logger.info("New run was open: %r", uid)
             logger.debug("Run list: %s", self._run_list.get_run_list())

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -80,6 +80,7 @@ class PlanQueueOperations:
         #   not used by other functions of the class.
         self._name_user_group_permissions = "user_group_permissions"
         self._name_lock_info = "lock_info"
+        self._name_autostart_mode_info = "autostart_mode_info"
 
         # The list of allowed item parameters used for parameter filtering. Filtering operation
         #   involves removing all parameters that are not in the list.
@@ -1866,4 +1867,36 @@ class PlanQueueOperations:
             Returns dictionary with saved lock info or ``None`` if no lock info is saved.
         """
         lock_info_json = await self._r_pool.get(self._name_lock_info)
+        return json.loads(lock_info_json) if lock_info_json else None
+
+    # =============================================================================================
+    #         Methods for saving and retrieving 'autostart' mode.
+
+    async def autostart_mode_clear(self):
+        """
+        Clear 'autostart' mode info info saved in Redis.
+        """
+        await self._r_pool.delete(self._name_autostart_mode_info)
+
+    async def autostart_mode_save(self, lock_info):
+        """
+        Save 'autostart' mode info to Redis.
+
+        Parameters
+        ----------
+        lock_info: dict
+            A dictionary containing lock info.
+        """
+        await self._r_pool.set(self._name_autostart_mode_info, json.dumps(lock_info))
+
+    async def autostart_mode_retrieve(self):
+        """
+        Retreive saved 'autostart' mode info.
+
+        Returns
+        -------
+        dict or None
+            Returns dictionary with saved lock info or ``None`` if no lock info is saved.
+        """
+        lock_info_json = await self._r_pool.get(self._name_autostart_mode_info)
         return json.loads(lock_info_json) if lock_info_json else None

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -1667,7 +1667,7 @@ class PlanQueueOperations:
         async with self._lock:
             return await self._set_next_item_as_running(item=item)
 
-    async def _set_processed_item_as_completed(self, *, exit_status, run_uids, err_msg, err_tb):
+    async def _set_processed_item_as_completed(self, *, exit_status, run_uids, scan_ids, err_msg, err_tb):
         """
         See ``self.set_processed_item_as_completed`` method.
         """
@@ -1689,6 +1689,7 @@ class PlanQueueOperations:
             item_cleaned.setdefault("result", {})
             item_cleaned["result"]["exit_status"] = exit_status
             item_cleaned["result"]["run_uids"] = run_uids
+            item_cleaned["result"]["scan_ids"] = scan_ids
             item_cleaned["result"]["time_start"] = item_time_start
             item_cleaned["result"]["time_stop"] = ttime.time()
             item_cleaned["result"]["msg"] = err_msg
@@ -1702,7 +1703,7 @@ class PlanQueueOperations:
             item_cleaned = {}
         return item_cleaned
 
-    async def set_processed_item_as_completed(self, *, exit_status, run_uids, err_msg, err_tb):
+    async def set_processed_item_as_completed(self, *, exit_status, run_uids, scan_ids, err_msg, err_tb):
         """
         Moves currently executed item (plan) to history and sets ``exit_status`` key.
         UID is removed from ``self._uid_dict``, so a copy of the item with
@@ -1718,6 +1719,8 @@ class PlanQueueOperations:
             Completion status of the plan.
         run_uids: list(str)
             A list of uids of completed runs.
+        scan_ids: list(int)
+            A list of scan IDs for the completed runs.
         err_msg: str
             Error message in case of failure.
         err_tb: str
@@ -1731,10 +1734,10 @@ class PlanQueueOperations:
         """
         async with self._lock:
             return await self._set_processed_item_as_completed(
-                exit_status=exit_status, run_uids=run_uids, err_msg=err_msg, err_tb=err_tb
+                exit_status=exit_status, run_uids=run_uids, scan_ids=scan_ids, err_msg=err_msg, err_tb=err_tb
             )
 
-    async def _set_processed_item_as_stopped(self, *, exit_status, run_uids, err_msg, err_tb):
+    async def _set_processed_item_as_stopped(self, *, exit_status, run_uids, scan_ids, err_msg, err_tb):
         """
         See ``self.set_processed_item_as_stopped()`` method.
         """
@@ -1743,7 +1746,7 @@ class PlanQueueOperations:
             # Stopped item is considered successful, so it is not pushed back to the beginning
             #   of the queue, and it is added to the back of the queue in LOOP mode.
             item_cleaned = await self._set_processed_item_as_completed(
-                exit_status=exit_status, run_uids=run_uids, err_msg=err_msg, err_tb=err_tb
+                exit_status=exit_status, run_uids=run_uids, scan_ids=scan_ids, err_msg=err_msg, err_tb=err_tb
             )
         elif await self._is_item_running():
             item = await self._get_running_item_info()
@@ -1754,6 +1757,7 @@ class PlanQueueOperations:
             item_cleaned.setdefault("result", {})
             item_cleaned["result"]["exit_status"] = exit_status
             item_cleaned["result"]["run_uids"] = run_uids
+            item_cleaned["result"]["scan_ids"] = scan_ids
             item_cleaned["result"]["time_start"] = item_time_start
             item_cleaned["result"]["time_stop"] = ttime.time()
             item_cleaned["result"]["msg"] = err_msg
@@ -1774,7 +1778,7 @@ class PlanQueueOperations:
             item_cleaned = {}
         return item_cleaned
 
-    async def set_processed_item_as_stopped(self, *, exit_status, run_uids, err_msg, err_tb):
+    async def set_processed_item_as_stopped(self, *, exit_status, run_uids, scan_ids, err_msg, err_tb):
         """
         A stopped plan is considered successfully completed (if ``exit_status=="stopped"``) or
         failed (otherwise). All items are added to history with respective ``exit_status``.
@@ -1789,6 +1793,8 @@ class PlanQueueOperations:
             Completion status of the plan.
         run_uids: list(str)
             A list of uids of completed runs.
+        scan_ids: list(int)
+            A list of scan IDs for the completed runs.
         err_msg: str
             Error message in case of failure.
         err_tb: str
@@ -1803,7 +1809,7 @@ class PlanQueueOperations:
         """
         async with self._lock:
             return await self._set_processed_item_as_stopped(
-                exit_status=exit_status, run_uids=run_uids, err_msg=err_msg, err_tb=err_tb
+                exit_status=exit_status, run_uids=run_uids, scan_ids=scan_ids, err_msg=err_msg, err_tb=err_tb
             )
 
     # =============================================================================================

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -81,6 +81,7 @@ class PlanQueueOperations:
         self._name_user_group_permissions = "user_group_permissions"
         self._name_lock_info = "lock_info"
         self._name_autostart_mode_info = "autostart_mode_info"
+        self._name_stop_pending_info = "stop_pending_info"
 
         # The list of allowed item parameters used for parameter filtering. Filtering operation
         #   involves removing all parameters that are not in the list.
@@ -1868,6 +1869,38 @@ class PlanQueueOperations:
         """
         lock_info_json = await self._r_pool.get(self._name_lock_info)
         return json.loads(lock_info_json) if lock_info_json else None
+
+    # =============================================================================================
+    #         Methods for saving and retrieving 'queue_stop_pending'.
+
+    async def stop_pending_clear(self):
+        """
+        Clear 'stop_pending' mode info info saved in Redis.
+        """
+        await self._r_pool.delete(self._name_stop_pending_info)
+
+    async def stop_pending_save(self, stop_pending):
+        """
+        Save 'stop_pending' mode info to Redis.
+
+        Parameters
+        ----------
+        lock_info: dict
+            A dictionary containing lock info.
+        """
+        await self._r_pool.set(self._name_stop_pending_info, json.dumps(stop_pending))
+
+    async def stop_pending_retrieve(self):
+        """
+        Retreive saved 'stop_pending' mode info.
+
+        Returns
+        -------
+        dict or None
+            Returns dictionary with saved 'stop_pending' or ``None`` if no 'stop_pending' is saved.
+        """
+        stop_pending_json = await self._r_pool.get(self._name_stop_pending_info)
+        return json.loads(stop_pending_json) if stop_pending_json else None
 
     # =============================================================================================
     #         Methods for saving and retrieving 'autostart' mode.

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -274,7 +274,7 @@ def condition_manager_paused(msg):
 
 
 def condition_environment_created(msg):
-    return msg["worker_environment_exists"] and (msg["manager_state"] == "idle")
+    return msg["worker_environment_exists"] and (msg["manager_state"] in ("idle", "executing_queue"))
 
 
 def condition_environment_closed(msg):

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -342,6 +342,7 @@ def clear_redis_pool():
         await pq.user_group_permissions_clear()
         await pq.lock_info_clear()
         await pq.autostart_mode_clear()
+        await pq.stop_pending_clear()
 
     asyncio.run(run())
 

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -341,6 +341,7 @@ def clear_redis_pool():
         await pq.delete_pool_entries()
         await pq.user_group_permissions_clear()
         await pq.lock_info_clear()
+        await pq.autostart_mode_clear()
 
     asyncio.run(run())
 

--- a/bluesky_queueserver/manager/tests/test_plan_monitoring.py
+++ b/bluesky_queueserver/manager/tests/test_plan_monitoring.py
@@ -53,6 +53,9 @@ def test_RunList_1():
         run_list.set_run_closed(uid="non-existing-uid", exit_status="success")
     assert run_list.is_changed() is False
 
+    assert run_list.get_uids() == uids
+    assert run_list.get_scan_ids() == scan_ids
+
     run_list.clear()
     assert run_list.is_changed() is True
     assert run_list.get_run_list(clear_state=True) == []
@@ -105,6 +108,9 @@ def test_RunList_2():
     run_list.set_run_closed(uid=uids[1], exit_status="success")
     assert run_list.is_changed() is False
     assert run_list.nruns == 1
+
+    assert run_list.get_uids() == uids[:1]
+    assert run_list.get_scan_ids() == scan_ids[:1]
 
     # The disabled list can be cleared
     run_list.clear()

--- a/bluesky_queueserver/manager/tests/test_plan_monitoring.py
+++ b/bluesky_queueserver/manager/tests/test_plan_monitoring.py
@@ -10,10 +10,12 @@ def test_RunList_1():
     Full functionality test: ``RunList`` class.
     """
     uids = [str(uuid.uuid4()) for _ in range(3)]
+    scan_ids = list(range(1, 4))
     is_open = [True] * 3
     exit_code = [None] * 3
     expected_run_list = [
-        {"uid": _[0], "is_open": _[1], "exit_status": _[2]} for _ in zip(uids, is_open, exit_code)
+        {"uid": _[0], "scan_id": _[1], "is_open": _[2], "exit_status": _[3]}
+        for _ in zip(uids, scan_ids, is_open, exit_code)
     ]
 
     # Create run list
@@ -24,7 +26,7 @@ def test_RunList_1():
     run_list.enable()
 
     # Add one object
-    run_list.add_run(uid=uids[0])
+    run_list.add_run(uid=uids[0], scan_id=scan_ids[0])
     assert run_list.is_changed() is True
     assert run_list.get_run_list() == expected_run_list[0:1]
     assert run_list.is_changed() is True
@@ -32,8 +34,8 @@ def test_RunList_1():
     assert run_list.is_changed() is False
 
     # Add two more objects
-    run_list.add_run(uid=uids[1])
-    run_list.add_run(uid=uids[2])
+    run_list.add_run(uid=uids[1], scan_id=scan_ids[1])
+    run_list.add_run(uid=uids[2], scan_id=scan_ids[2])
     assert run_list.is_changed() is True
     assert run_list.get_run_list(clear_state=True) == expected_run_list
     assert run_list.is_changed() is False
@@ -63,6 +65,7 @@ def test_RunList_2():
     """
 
     uids = [str(uuid.uuid4()) for _ in range(2)]
+    scan_ids = list(range(1, 3))
 
     # Create run list
     run_list = RunList()
@@ -74,7 +77,7 @@ def test_RunList_2():
     assert run_list.is_enabled() is True
 
     # List is enabled, add one run
-    run_list.add_run(uid=uids[0])
+    run_list.add_run(uid=uids[0], scan_id=scan_ids[0])
     assert run_list.is_changed() is True
     assert run_list.nruns == 1
     run_list.get_run_list(clear_state=True)
@@ -94,7 +97,7 @@ def test_RunList_2():
     assert run_list.is_changed() is False
 
     # But no plans can be added to the list
-    run_list.add_run(uid=uids[1])
+    run_list.add_run(uid=uids[1], scan_id=scan_ids[1])
     assert run_list.is_changed() is False
     assert run_list.nruns == 1
     run_list.get_run_list(clear_state=True)
@@ -108,7 +111,10 @@ def test_RunList_2():
     assert run_list.nruns == 0
 
 
-def test_CallbackRegisterRun_1():
+# fmt: off
+@pytest.mark.parametrize("scan_id", [101, None, []])
+# fmt: on
+def test_CallbackRegisterRun_1(scan_id):
     """
     Basic test: ``CallbackRegisterRun`` class.
     """
@@ -117,7 +123,9 @@ def test_CallbackRegisterRun_1():
     cb = CallbackRegisterRun(run_list=run_list)
     uid = str(uuid.uuid4())
 
-    cb("start", {"uid": uid})
-    assert run_list.get_run_list() == [{"uid": uid, "is_open": True, "exit_status": None}]
+    param = {"scan_id": scan_id} if scan_id is not None else {}
+    param_expected = {"scan_id": scan_id} if isinstance(scan_id, int) else {"scan_id": None}
+    cb("start", {"uid": uid, **param})
+    assert run_list.get_run_list() == [{"uid": uid, "is_open": True, "exit_status": None, **param_expected}]
     cb("stop", {"run_start": uid, "exit_status": "success"})
-    assert run_list.get_run_list() == [{"uid": uid, "is_open": False, "exit_status": "success"}]
+    assert run_list.get_run_list() == [{"uid": uid, "is_open": False, "exit_status": "success", **param_expected}]

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -31,6 +31,7 @@ class PQ:
         await self._pq.delete_pool_entries()
         await self._pq.user_group_permissions_clear()
         await self._pq.lock_info_clear()
+        await self._pq.autostart_mode_clear()
         return self._pq
 
     async def __aexit__(self, exc_t, exc_v, exc_tb):
@@ -41,6 +42,7 @@ class PQ:
         await self._pq.delete_pool_entries()
         await self._pq.user_group_permissions_clear()
         await self._pq.lock_info_clear()
+        await self._pq.autostart_mode_clear()
 
 
 # fmt: off
@@ -2373,5 +2375,30 @@ def test_lock_info_1():
 
             await pq.lock_info_clear()
             assert await pq.lock_info_retrieve() is None
+
+    asyncio.run(testing())
+
+
+# ==============================================================================================
+#                           Saving and retrieving autostart info
+def test_autostart_mode_info_1():
+    """
+    Test for saving and retrieving and clearing user group permissions, which are backed up in Redis.
+    """
+    autostart_info_1 = {"enabled": False}
+    autostart_info_2 = {"enabled": True}
+
+    async def testing():
+        async with PQ() as pq:
+            assert await pq.autostart_mode_retrieve() is None
+
+            await pq.autostart_mode_save(autostart_info_1)
+            assert await pq.autostart_mode_retrieve() == autostart_info_1
+
+            await pq.autostart_mode_save(autostart_info_2)
+            assert await pq.autostart_mode_retrieve() == autostart_info_2
+
+            await pq.autostart_mode_clear()
+            assert await pq.autostart_mode_retrieve() is None
 
     asyncio.run(testing())

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -32,6 +32,7 @@ class PQ:
         await self._pq.user_group_permissions_clear()
         await self._pq.lock_info_clear()
         await self._pq.autostart_mode_clear()
+        await self._pq.stop_pending_clear()
         return self._pq
 
     async def __aexit__(self, exc_t, exc_v, exc_tb):
@@ -43,6 +44,7 @@ class PQ:
         await self._pq.user_group_permissions_clear()
         await self._pq.lock_info_clear()
         await self._pq.autostart_mode_clear()
+        await self._pq.stop_pending_clear()
 
 
 # fmt: off
@@ -2375,6 +2377,31 @@ def test_lock_info_1():
 
             await pq.lock_info_clear()
             assert await pq.lock_info_retrieve() is None
+
+    asyncio.run(testing())
+
+
+# ==============================================================================================
+#                           Saving and retrieving 'stop pending' info
+def test_stop_pending_info_1():
+    """
+    Test for saving and retrieving and clearing user group permissions, which are backed up in Redis.
+    """
+    stop_pending_info_1 = {"enabled": False}
+    stop_pending_info_2 = {"enabled": True}
+
+    async def testing():
+        async with PQ() as pq:
+            assert await pq.stop_pending_retrieve() is None
+
+            await pq.stop_pending_save(stop_pending_info_1)
+            assert await pq.stop_pending_retrieve() == stop_pending_info_1
+
+            await pq.stop_pending_save(stop_pending_info_2)
+            assert await pq.stop_pending_retrieve() == stop_pending_info_2
+
+            await pq.stop_pending_clear()
+            assert await pq.stop_pending_retrieve() is None
 
     asyncio.run(testing())
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -1882,14 +1882,16 @@ def test_set_processed_item_as_completed_1():
         {"item_type": "plan", "item_uid": plan_uids[2], "name": "c"},
     ]
     plans_run_uids = [["abc1"], ["abc2", "abc3"], []]
+    plans_scan_ids = [[1], [100, 101], []]
 
-    def add_status_to_plans(plans, run_uids, exit_status):
+    def add_status_to_plans(plans, run_uids, scan_ids, exit_status):
         plans = copy.deepcopy(plans)
         plans_modified = []
-        for plan, run_uid in zip(plans, run_uids):
+        for plan, run_uid, scan_id in zip(plans, run_uids, scan_ids):
             plan.setdefault("result", {})
             plan["result"]["exit_status"] = exit_status
             plan["result"]["run_uids"] = run_uid
+            plan["result"]["scan_ids"] = scan_id
             plan["result"]["msg"] = ""
             plan["result"]["traceback"] = ""
             plans_modified.append(plan)
@@ -1923,7 +1925,11 @@ def test_set_processed_item_as_completed_1():
             pq_uid = pq.plan_queue_uid
             ph_uid = pq.plan_history_uid
             plan = await pq.set_processed_item_as_completed(
-                exit_status="completed", run_uids=plans_run_uids[0], err_msg="", err_tb=""
+                exit_status="completed",
+                run_uids=plans_run_uids[0],
+                scan_ids=plans_scan_ids[0],
+                err_msg="",
+                err_tb="",
             )
             assert plan == {}
             assert pq.plan_queue_uid == pq_uid
@@ -1933,7 +1939,11 @@ def test_set_processed_item_as_completed_1():
             await pq.set_next_item_as_running()
             pq_uid = pq.plan_queue_uid
             plan = await pq.set_processed_item_as_completed(
-                exit_status="completed", run_uids=plans_run_uids[0], err_msg="Test message", err_tb="Traceback"
+                exit_status="completed",
+                run_uids=plans_run_uids[0],
+                scan_ids=plans_scan_ids[0],
+                err_msg="Test message",
+                err_tb="Traceback",
             )
             assert pq.plan_queue_uid != pq_uid
             assert pq.plan_history_uid != ph_uid
@@ -1943,9 +1953,12 @@ def test_set_processed_item_as_completed_1():
             assert plan["name"] == plans[0]["name"]
             assert plan["result"]["exit_status"] == "completed"
             assert plan["result"]["run_uids"] == plans_run_uids[0]
+            assert plan["result"]["scan_ids"] == plans_scan_ids[0]
 
             plan_history, _ = await pq.get_history()
-            plan_history_expected = add_status_to_plans(plans[0:1], plans_run_uids[0:1], "completed")
+            plan_history_expected = add_status_to_plans(
+                plans[0:1], plans_run_uids[0:1], plans_scan_ids[0:1], "completed"
+            )
             plan_history_expected = add_msg_to_plan_history(
                 plan_history_expected, [plan_uids[0]], "Test message", "Traceback"
             )
@@ -1956,7 +1969,11 @@ def test_set_processed_item_as_completed_1():
             # Execute the second plan
             await pq.set_next_item_as_running()
             plan = await pq.set_processed_item_as_completed(
-                exit_status="completed", run_uids=plans_run_uids[1], err_msg="", err_tb=""
+                exit_status="completed",
+                run_uids=plans_run_uids[1],
+                scan_ids=plans_scan_ids[1],
+                err_msg="",
+                err_tb="",
             )
 
             assert await pq.get_queue_size() == 1
@@ -1964,9 +1981,12 @@ def test_set_processed_item_as_completed_1():
             assert plan["name"] == plans[1]["name"]
             assert plan["result"]["exit_status"] == "completed"
             assert plan["result"]["run_uids"] == plans_run_uids[1]
+            assert plan["result"]["scan_ids"] == plans_scan_ids[1]
 
             plan_history, _ = await pq.get_history()
-            plan_history_expected = add_status_to_plans(plans[0:2], plans_run_uids[0:2], "completed")
+            plan_history_expected = add_status_to_plans(
+                plans[0:2], plans_run_uids[0:2], plans_scan_ids[0:2], "completed"
+            )
             plan_history_expected = add_msg_to_plan_history(
                 plan_history_expected, [plan_uids[0]], "Test message", "Traceback"
             )
@@ -1988,6 +2008,7 @@ def test_set_processed_item_as_completed_2():
         {"item_type": "plan", "item_uid": plan_uids[2], "name": "c"},
     ]
     plans_run_uids = [["abc1"], ["abc2", "abc3"], []]
+    plans_scan_ids = [[1], [100, 101], []]
 
     async def testing():
         async with PQ() as pq:
@@ -2001,7 +2022,11 @@ def test_set_processed_item_as_completed_2():
             pq_uid = pq.plan_queue_uid
             ph_uid = pq.plan_history_uid
             plan = await pq.set_processed_item_as_completed(
-                exit_status="completed", run_uids=plans_run_uids[0], err_msg="", err_tb=""
+                exit_status="completed",
+                run_uids=plans_run_uids[0],
+                scan_ids=plans_scan_ids[0],
+                err_msg="",
+                err_tb="",
             )
             assert plan == {}
             assert pq.plan_queue_uid == pq_uid
@@ -2014,7 +2039,11 @@ def test_set_processed_item_as_completed_2():
             await pq.set_next_item_as_running()
             pq_uid = pq.plan_queue_uid
             plan = await pq.set_processed_item_as_completed(
-                exit_status="completed", run_uids=plans_run_uids[0], err_msg="", err_tb=""
+                exit_status="completed",
+                run_uids=plans_run_uids[0],
+                scan_ids=plans_scan_ids[0],
+                err_msg="",
+                err_tb="",
             )
             assert pq.plan_queue_uid != pq_uid
             assert pq.plan_history_uid != ph_uid
@@ -2027,6 +2056,7 @@ def test_set_processed_item_as_completed_2():
             assert plan["name"] == plans[0]["name"]
             assert plan["result"]["exit_status"] == "completed"
             assert plan["result"]["run_uids"] == plans_run_uids[0]
+            assert plan["result"]["scan_ids"] == plans_scan_ids[0]
             assert plan["result"]["msg"] == ""
             assert plan["result"]["traceback"] == ""
             assert plan["result"]["time_stop"] > plan["result"]["time_start"]
@@ -2036,6 +2066,7 @@ def test_set_processed_item_as_completed_2():
             plan = await pq.set_processed_item_as_completed(
                 exit_status="unknown",
                 run_uids=plans_run_uids[1],
+                scan_ids=plans_scan_ids[1],
                 err_msg="Unknown exit status",
                 err_tb="Some traceback",
             )
@@ -2048,6 +2079,7 @@ def test_set_processed_item_as_completed_2():
             assert plan["name"] == plans[1]["name"]
             assert plan["result"]["exit_status"] == "unknown"
             assert plan["result"]["run_uids"] == plans_run_uids[1]
+            assert plan["result"]["scan_ids"] == plans_scan_ids[1]
             assert plan["result"]["msg"] == "Unknown exit status"
             assert plan["result"]["traceback"] == "Some traceback"
             assert plan["result"]["time_stop"] > plan["result"]["time_start"]
@@ -2071,8 +2103,9 @@ def test_set_processed_item_as_stopped_1():
         {"item_type": "plan", "item_uid": plan_uids[2], "name": "c"},
     ]
     plans_run_uids = [["abc1"], ["abc2", "abc3"], []]
+    plans_scan_ids = [[1], [100, 101], []]
 
-    def add_status_to_plans(plans, run_uids, exit_status):
+    def add_status_to_plans(plans, run_uids, scan_ids, exit_status):
         plans = copy.deepcopy(plans)
 
         if isinstance(exit_status, list):
@@ -2081,10 +2114,11 @@ def test_set_processed_item_as_stopped_1():
             exit_status = [exit_status] * len(plans)
 
         plans_modified = []
-        for plan, run_uid, es in zip(plans, run_uids, exit_status):
+        for plan, run_uid, scan_id, es in zip(plans, run_uids, scan_ids, exit_status):
             plan.setdefault("result", {})
             plan["result"]["exit_status"] = es
             plan["result"]["run_uids"] = run_uid
+            plan["result"]["scan_ids"] = scan_id
             plan["result"]["msg"] = ""
             plan["result"]["traceback"] = ""
             plans_modified.append(plan)
@@ -2118,7 +2152,11 @@ def test_set_processed_item_as_stopped_1():
             pq_uid = pq.plan_queue_uid
             ph_uid = pq.plan_history_uid
             plan = await pq.set_processed_item_as_stopped(
-                exit_status="stopped", run_uids=plans_run_uids[0], err_msg="Test", err_tb=""
+                exit_status="stopped",
+                run_uids=plans_run_uids[0],
+                scan_ids=plans_scan_ids[0],
+                err_msg="Test",
+                err_tb="",
             )
             assert plan == {}
             assert pq.plan_queue_uid == pq_uid
@@ -2129,7 +2167,11 @@ def test_set_processed_item_as_stopped_1():
             running_uid1 = (await pq.get_running_item_info())["item_uid"]
             pq_uid = pq.plan_queue_uid
             plan = await pq.set_processed_item_as_stopped(
-                exit_status="failed", run_uids=plans_run_uids[0], err_msg="Plan failed", err_tb="Traceback"
+                exit_status="failed",
+                run_uids=plans_run_uids[0],
+                scan_ids=plans_scan_ids[0],
+                err_msg="Plan failed",
+                err_tb="Traceback",
             )
             assert pq.plan_queue_uid != pq_uid
             assert pq.plan_history_uid != ph_uid
@@ -2139,6 +2181,7 @@ def test_set_processed_item_as_stopped_1():
             assert plan["name"] == plans[0]["name"]
             assert plan["result"]["exit_status"] == "failed"
             assert plan["result"]["run_uids"] == plans_run_uids[0]
+            assert plan["result"]["scan_ids"] == plans_scan_ids[0]
             assert plan["result"]["msg"] == "Plan failed"
             assert plan["result"]["traceback"] == "Traceback"
             assert plan["result"]["time_stop"] > plan["result"]["time_start"]
@@ -2151,7 +2194,9 @@ def test_set_processed_item_as_stopped_1():
             assert plan_modified_uid != plans[0]["item_uid"]
 
             plan_history, _ = await pq.get_history()
-            plan_history_expected = add_status_to_plans([plans[0]], [plans_run_uids[0]], "failed")
+            plan_history_expected = add_status_to_plans(
+                [plans[0]], [plans_run_uids[0]], [plans_scan_ids[0]], "failed"
+            )
             plan_history_expected = add_msg_to_plan_history(
                 plan_history_expected, [running_uid1], "Plan failed", "Traceback"
             )
@@ -2161,7 +2206,11 @@ def test_set_processed_item_as_stopped_1():
             await pq.set_next_item_as_running()
             running_uid2 = (await pq.get_running_item_info())["item_uid"]
             plan = await pq.set_processed_item_as_stopped(
-                exit_status="stopped", run_uids=plans_run_uids[1], err_msg="Plan stopped", err_tb="Traceback 2"
+                exit_status="stopped",
+                run_uids=plans_run_uids[1],
+                scan_ids=plans_scan_ids[1],
+                err_msg="Plan stopped",
+                err_tb="Traceback 2",
             )
 
             assert await pq.get_queue_size() == 2
@@ -2169,13 +2218,17 @@ def test_set_processed_item_as_stopped_1():
             assert plan["name"] == plans[0]["name"]
             assert plan["result"]["exit_status"] == "stopped"
             assert plan["result"]["run_uids"] == plans_run_uids[1]
+            assert plan["result"]["scan_ids"] == plans_scan_ids[1]
             assert plan["result"]["msg"] == "Plan stopped"
             assert plan["result"]["traceback"] == "Traceback 2"
             assert plan["result"]["time_stop"] > plan["result"]["time_start"]
 
             plan_history, _ = await pq.get_history()
             plan_history_expected = add_status_to_plans(
-                [plans[0].copy(), plans[0].copy()], [plans_run_uids[0], plans_run_uids[1]], ["failed", "stopped"]
+                [plans[0].copy(), plans[0].copy()],
+                [plans_run_uids[0], plans_run_uids[1]],
+                [plans_scan_ids[0], plans_scan_ids[1]],
+                ["failed", "stopped"],
             )
             # Plan 0 has different UID after it was inserted in the queue during the 1st attempt
             plan_history_expected[1]["item_uid"] = plan_modified_uid
@@ -2213,6 +2266,7 @@ def test_set_processed_item_as_stopped_2(loop_mode, func, immediate_execution):
     ]
     plan4 = {"item_type": "plan", "item_uid": 3, "name": "d"}
     plan4_run_uids = ["abc2", "abc3"]
+    plan4_scan_ids = [100, 101]
 
     async def testing():
         async with PQ() as pq:
@@ -2238,11 +2292,19 @@ def test_set_processed_item_as_stopped_2(loop_mode, func, immediate_execution):
             err_msg, err_tb = f"Plan {func}", f"Traceback {func}"
             if func in ("completed", "unknown"):
                 plan = await pq.set_processed_item_as_completed(
-                    exit_status=func, run_uids=plan4_run_uids, err_msg=err_msg, err_tb=err_tb
+                    exit_status=func,
+                    run_uids=plan4_run_uids,
+                    scan_ids=plan4_scan_ids,
+                    err_msg=err_msg,
+                    err_tb=err_tb,
                 )
             elif func in ("failed", "stopped", "aborted", "halted"):
                 plan = await pq.set_processed_item_as_stopped(
-                    exit_status=func, run_uids=plan4_run_uids, err_msg=err_msg, err_tb=err_tb
+                    exit_status=func,
+                    run_uids=plan4_run_uids,
+                    scan_ids=plan4_scan_ids,
+                    err_msg=err_msg,
+                    err_tb=err_tb,
                 )
             else:
                 assert False, f"Unknown value of parameter 'func': '{func}'"
@@ -2264,6 +2326,7 @@ def test_set_processed_item_as_stopped_2(loop_mode, func, immediate_execution):
                 assert p["name"] == plan4["name"] if immediate_execution else plans[0]["name"]
                 assert p["result"]["exit_status"] == func
                 assert p["result"]["run_uids"] == plan4_run_uids
+                assert p["result"]["scan_ids"] == plan4_scan_ids
                 assert p["result"]["msg"] == err_msg
                 assert p["result"]["traceback"] == err_tb
                 assert plan["result"]["time_stop"] > plan["result"]["time_start"]
@@ -2308,11 +2371,11 @@ def test_set_processed_item_as_stopped_3(loop_mode, func):
 
             if func == "completed":
                 plan1 = await pq.set_processed_item_as_completed(
-                    exit_status="completed", run_uids=["abc"], err_msg="", err_tb=""
+                    exit_status="completed", run_uids=["abc"], scan_ids=[1], err_msg="", err_tb=""
                 )
             elif func == "stopped":
                 plan1 = await pq.set_processed_item_as_stopped(
-                    exit_status="stopped", run_uids=["abc"], err_msg="", err_tb=""
+                    exit_status="stopped", run_uids=["abc"], scan_ids=[1], err_msg="", err_tb=""
                 )
             else:
                 raise Exception(f"Unsupported parameter value func={func!r}")

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -3744,6 +3744,34 @@ def test_zmq_api_queue_mode_set_4_ignore_failures(re_manager):  # noqa: F811
 
 
 # =======================================================================================
+#                              Method 'queue_autostart'
+
+
+def test_zmq_api_queue_autostart_01(re_manager):  # noqa: F811
+    resp1, _ = zmq_single_request("queue_autostart", params={"enable": True})
+    assert resp1["success"] is True, f"resp={resp1}"
+
+    status = get_queue_state()
+    assert status["queue_autostart_enabled"] is True
+
+    resp2, _ = zmq_single_request("queue_autostart", params={"enable": False})
+    assert resp2["success"] is True, f"resp={resp2}"
+
+    status = get_queue_state()
+    assert status["queue_autostart_enabled"] is False
+
+
+def test_zmq_api_queue_autostart_02_fail(re_manager):  # noqa: F811
+    resp1, _ = zmq_single_request("queue_autostart", params={})
+    assert resp1["success"] is False, f"resp={resp1}"
+    assert "Required 'enable' parameter is missing" in resp1["msg"]
+
+    resp2, _ = zmq_single_request("queue_autostart", params={"enable": 50})
+    assert resp2["success"] is False, f"resp={resp1}"
+    assert "Required 'enable' parameter must be boolean" in resp2["msg"]
+
+
+# =======================================================================================
 #                              Method 'permissions_reload'
 
 
@@ -5110,6 +5138,12 @@ def test_zmq_api_lock_7(re_manager, lock_options, is_locked, unlock):  # noqa: F
     cond = condition_environment_created if not is_locked or unlock else condition_manager_idle
     assert wait_for_condition(20, condition=cond)
 
+    # resp4a, _ = zmq_single_request("queue_autostart", params={"enable": True, **unlock_params})
+    # check_reply(resp4a)
+
+    # resp4b, _ = zmq_single_request("queue_autostart", params={"enable": False, **unlock_params})
+    # check_reply(resp4b)
+
     for api_to_test in ("re_resume", "re_stop", "re_abort", "re_halt"):
         # Always add the plan (not part of the test, but necessary for the test to complete)
         params = {"item": _plan3, "user": _user, "user_group": _user_group, "lock_key": custom_key}
@@ -5251,6 +5285,7 @@ def test_zmq_api_unsupported_parameters(re_manager):  # noqa: F811
         "queue_start",
         "queue_stop",
         "queue_stop_cancel",
+        "queue_autostart",
         "re_pause",
         "re_resume",
         "re_stop",

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -790,6 +790,7 @@ def test_zmq_api_queue_item_add_09(db_catalog, re_manager_cmd, meta_param, meta_
     # Check if metadata was recorded in the start document.
     uid = history[-1]["result"]["run_uids"][0]
     start_doc = cat[uid].metadata["start"]
+    assert start_doc["scan_id"] == history[-1]["result"]["scan_ids"][0]
     for key in meta_saved:
         assert key in start_doc, str(start_doc)
         assert meta_saved[key] == start_doc[key], str(start_doc)
@@ -5023,6 +5024,7 @@ def test_zmq_api_re_runs_1(re_manager_pc_copy, tmp_path, test_with_manager_resta
             # Save full UID list (for all runs)
             if len(full_list) == 3:
                 full_uid_list = [_["uid"] for _ in full_list]
+                full_scan_id_list = [_["scan_id"] for _ in full_list]
 
             is_open_list = [_["is_open"] for _ in full_list]
             for n, state in enumerate(run_list_states):
@@ -5068,6 +5070,11 @@ def test_zmq_api_re_runs_1(re_manager_pc_copy, tmp_path, test_with_manager_resta
     assert len(history_run_uids) == 3, str(resp5b)
     # Make sure that the list of UID in history matches the list of UIDs in the run list
     assert history_run_uids == full_uid_list
+
+    for scan_id in full_scan_id_list:
+        assert isinstance(scan_id, int)
+    history_scan_ids = history[0]["result"]["scan_ids"]
+    assert history_scan_ids == full_scan_id_list
 
     # Close the environment
     resp6, _ = zmq_single_request("environment_close")

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -4045,6 +4045,8 @@ def test_zmq_api_queue_autostart_06(re_manager, option, autostart_on, apply_queu
     ``queue_autostart``: make sure the autostart persists thoughout restart of the manager process.
     Test the following cases: enabled/disabled autostart, queue_stop is applied before restart,
     cases of 1 and 2 plans added to queue before the restart.
+
+    This tests also verifies that 'queue_stop' persists through the restart. There is not separate test for this.
     """
 
     def add_plans(plans):

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -3856,9 +3856,8 @@ def test_zmq_api_queue_autostart_03(re_manager, open_env_first, autostart_first,
 # fmt: on
 def test_zmq_api_queue_autostart_04(re_manager, option):  # noqa: F811
     """
-    ``queue_autostart``: check that the queue is properly started in various scenarios.
-    The following scenarios are tested: start env/add plans/enable autostart in
-    any sequence. Check that the manager is in correct state and the plan is running.
+    ``queue_autostart``: check that autostart is manually and automatically disabled
+    in various scenarios.
     """
     failing_plan = {"name": "failing_plan", "item_type": "plan"}
 

--- a/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -23,6 +23,7 @@ user_groups:
       - null  # Nothing is forbidden
     allowed_functions:
       - "function_sleep"  # Explicitly listed name
+      - ":^func_for_test"  
   test_user:  # Another group used for unit tests.
     allowed_plans:
       - ":^count"  # Use regular expression patterns

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -114,6 +114,7 @@ Start and stop execution of the plan queue:
 - :ref:`method_queue_start`
 - :ref:`method_queue_stop`
 - :ref:`method_queue_stop_cancel`
+- :ref:`method_queue_autostart`
 
 Send commands to Bluesky Run Engine:
 
@@ -1386,6 +1387,63 @@ Description   Cancel the pending request to stop execution of the queue after th
               *The request always succeeds*.
 ------------  -----------------------------------------------------------------------------------------
 Parameters    **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted
+                  with the request. See documentation on :ref:`method_lock` API for more details.
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
+============  =========================================================================================
+
+
+.. _method_queue_autostart:
+
+**'queue_autostart'**
+^^^^^^^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'queue_autostart'**
+------------  -----------------------------------------------------------------------------------------
+Description   Enable/disable autostart mode. In autostart mode, the queue execution is automatically 
+              started whenever the queue contains items and the manager and the environment are
+              ready to execute plans. Client applications may check if the manager is in autostart
+              mode using *queue_autostart_enabled* parameter of RE Manager status 
+              (see :ref:`method_status`).The autostart mode is not disabled after the queue runs out of
+              items, but is automatically restarted once new items are added. The autostart mode is
+              disabled if the API is called with *enable=False*, or if the queue or the running plan 
+              is stopped due to the following events:
+
+              - **queue_stop** queue instruction was executed;
+
+              - the queue was stopped using :ref:`method_queue_stop` API (the API call itself does not
+                disable autostart, the queue remains in autostart mode if **queue_stop** was cancelled
+                before the queue was stopped);
+
+              - running plan was stopped/aborted/halted;
+
+              - running plan failed, unless the *ignore_failures* queue mode is enabled (see 
+                :ref:`method_queue_mode_set` API).
+
+              The autostart mode may be enabled/disabled at any time. If the queue contains items,
+              but queue can not be started immediately, e.g. due to environment being closed,
+              the manager periodically checks the state of the manager and the worker and will attempt to
+              start the queue once the manager and the worker are ready. If the queue runs
+              out of items, the manager returns to IDLE state and will accept requests to execute
+              foreground tasks: run a plan (:ref:`method_queue_item_execute`), a function 
+              (:ref:`method_function_execute`) or a script (:ref:`method_script_upload`). 
+              If plans are added to the queue while the manager is busy, the queue is 
+              is automatically started once the task is complete.
+
+              *The request always succeeds*.
+------------  -----------------------------------------------------------------------------------------
+Parameters    **enable**: *boolean*
+                  pass *True* to enable the 'autostart' mode and *False* to disable it.
+
+              **lock_key**: *str* (optional)
                   Lock key. The API fails if **the environment** is locked and no valid key is submitted
                   with the request. See documentation on :ref:`method_lock` API for more details.
 ------------  -----------------------------------------------------------------------------------------

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -564,7 +564,9 @@ Returns       **success**: *boolean*
                     to restart of RE Manager process, but plan information still needs to be placed in the history;
                     this is very unlikely to happen in practice);
 
-                  - **run_uids** - list of UIDs of runs executed by the plan;
+                  - **run_uids** - list of UIDs (str) of runs executed by the plan;
+
+                  - **scan_ids** - list of scan IDs (int) of runs executed by the plan;
 
                   - **time_start** and **time_stop** - time of start and completion of the plan (not runs),
                     floating point number returned by *time.time()*.
@@ -1496,8 +1498,8 @@ Returns       **success**: *boolean*
 
               **run_list**: *list(dict)*
                   the requested list of runs, list items are dictionaries with keys 'uid' (str),
-                  'is_open' (boolean) and 'exit_status' (str or None). See Bluesky documentation
-                  for 'exit_status' values.
+                  'scan_id' (int), 'is_open' (boolean) and 'exit_status' (str or None). 
+                  See Bluesky documentation for 'exit_status' values.
 
               **run_list_uid**: str
                   UID of the returned run list, identical to the RE Manager status field with

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -284,6 +284,10 @@ Returns       **msg**: *str*
                   indicates if the request to stop the queue after completion of the current plan is
                   pending.
 
+              **queue_autostart_enabled**: *boolean*
+                  indicates if the autostart queue mode is enabled, see 
+                  :ref:`method_queue_autostart` API.
+
               **pause_pending**: *boolean*
                   indicates if the request to pause the currently running plan was send to Run Engine
                   (see **re_pause** method), but the plan is not stopped yet. It may take considerable
@@ -1412,12 +1416,12 @@ Description   Enable/disable autostart mode. In autostart mode, the queue execut
               started whenever the queue contains items and the manager and the environment are
               ready to execute plans. Client applications may check if the manager is in autostart
               mode using *queue_autostart_enabled* parameter of RE Manager status 
-              (see :ref:`method_status`).The autostart mode is not disabled after the queue runs out of
+              (see :ref:`method_status` API).The autostart mode is not disabled after the queue runs out of
               items, but is automatically restarted once new items are added. The autostart mode is
               disabled if the API is called with *enable=False*, or if the queue or the running plan 
               is stopped due to the following events:
 
-              - **queue_stop** queue instruction was executed;
+              - *'queue_stop'* queue instruction was executed;
 
               - the queue was stopped using :ref:`method_queue_stop` API (the API call itself does not
                 disable autostart, the queue remains in autostart mode if **queue_stop** was cancelled
@@ -1425,7 +1429,7 @@ Description   Enable/disable autostart mode. In autostart mode, the queue execut
 
               - running plan was stopped/aborted/halted;
 
-              - running plan failed, unless the *ignore_failures* queue mode is enabled (see 
+              - running plan failed, unless the *'ignore_failures'* queue mode is enabled (see 
                 :ref:`method_queue_mode_set` API).
 
               The autostart mode may be enabled/disabled at any time. If the queue contains items,
@@ -1433,8 +1437,8 @@ Description   Enable/disable autostart mode. In autostart mode, the queue execut
               the manager periodically checks the state of the manager and the worker and will attempt to
               start the queue once the manager and the worker are ready. If the queue runs
               out of items, the manager returns to IDLE state and will accept requests to execute
-              foreground tasks: run a plan (:ref:`method_queue_item_execute`), a function 
-              (:ref:`method_function_execute`) or a script (:ref:`method_script_upload`). 
+              foreground tasks: run a plan (:ref:`method_queue_item_execute` API), a function 
+              (:ref:`method_function_execute` API) or a script (:ref:`method_script_upload` API). 
               If plans are added to the queue while the manager is busy, the queue is 
               is automatically started once the task is complete.
 

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -494,3 +494,28 @@ The operations of locking and unlocking RE Manager using CLI tool could be found
   The :ref:`method_lock` API controls access to other API, not internal operation of the server.
   For example, if the server is executing the queue, the queue will continue running after
   the manager is locked until it runs out of plans or stopped.
+
+
+.. _queue_autostart_mode:
+
+Queue Autostart Mode
+--------------------
+
+RE Manager supports queue autostart mode. In the autostart mode, the manager automatically
+starts execution of the queue whenever the queue is not empty and the manager and the worker
+are in the correct state. For example, if the autostart mode is enabled at the time when 
+the queue is empty, adding a queue item will automatically start the queue execution.
+Once the queue runs out of items, the manager is switched to IDLE state, but the queue
+is automatically restarted once more items are added to the queue. If the manager is busy
+executing another task (a script or a function) when the plan is added, the queue is 
+restarted once the current task is completed.
+
+The autostart is enabled by calling :ref:`method_queue_autostart` API with *enable=True* and
+disabled using the same API with *enable=False*. The mode can be enabled at any time,
+even when the queue can not be started (e.g. the environment is closed). The manager 
+will automatically monitor the state start the queue when possible (e.g. once the environment
+is opened). The autostart is automatically disabled once the queue is stopped by the user
+(by inserting *'queue_stop'* queue instruction or by calling :ref:`method_queue_stop` API) 
+or a plan is stopped/halted/aborted or failed (unless *ignore_failures* queue mode is enabled).
+
+See documentation on :ref:`method_queue_autostart` API for more details.

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -249,7 +249,7 @@ and or halted, it is pushed to the front of the queue and added to the history a
 by enabling *IGNORE_FAILURES* mode, in which the server proceeds with execution of the next plan in the queue
 even after the current plan fails. The operation is slightly different if the *LOOP* mode is enabled:
 successfully executed (or stopped) plans and instructions are added to the back of the queue, allowing
-client to infinitely repeate a sequence of plans. The stopped plans are treated as successful in both modes.
+client to infinitely repeate a sequence of plans. The stopped plans are treated as successful in all modes.
 Stopping a plan also stops execution of the queue.
 
 See the tutorials :ref:`tutorial_starting_stopping_queue` and :ref:`tutorial_iteracting_with_run_engine`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Implementation of 'autostart' mode, in which the queue is automatically started once plans are added to the queue or the manager becomes ready to execute plans (e.g. environment is opened). The autostart mode is enabled by calling `queue_autostart` API with the parameter `enable=True` and disabled by calling the same API with `enable=False`. The autostart mode is disabled automatically if the queue is stopped (using `queue_stop` queue instruction or `queue_stop` API) or a running plan was stopped, halted or aborted. The autostart mode is also disabled if the plan fails, unless the `ignore_failures` mode is enabled (see `queue_mode` API). 

Another new feature was implemented after multiple request from beamline staff. In addition to run UUIDs, the worker is now collecting scan ID from start documents. The scan IDs are returned in the list of runs (`re_runs` API) and included in the history returned by `history_get` API. The scan IDs may be useful in monitoring GUI widgets, since many beamlines primarily use scan IDs to identify runs.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The implemented features were requested by beamline staff.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New `queue_autostart` API (enable/disable 'autostart' mode by passing `True`/`False` with the `enable` parameter).

- New `queue_autostart_enabled` status parameter, which indicates if the queue is in the 'autostart' mode.

- Each item in the list of current runs (`re_runs` API) now contains `scan_id` (integer) of the current scan.

- The history items (`history_get` API) now contains a list of scan IDS (`scan_ids`, `list(int)`) in addition to the list of `uids'.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Detailed unit tests were implemented.

<!--
## Screenshots (if appropriate):
-->
