### PR TITLE
Implementation of 'qserver-console'

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.10]
       fail-fast: false
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
       fail-fast: false
 
     steps:

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
       fail-fast: false
 
     steps:

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.10]
       fail-fast: false
 
     steps:

--- a/bluesky_queueserver/__init__.py
+++ b/bluesky_queueserver/__init__.py
@@ -20,6 +20,10 @@ from .manager.profile_ops import register_device  # noqa: E402, F401
 from .manager.profile_ops import register_plan  # noqa: E402, F401
 from .manager.profile_ops import validate_plan  # noqa: E402, F401
 from .manager.profile_tools import is_ipython_mode  # noqa: E402, F401
-from .manager.profile_tools import clear_ipython_mode, set_ipython_mode  # noqa: E402, F401
 from .manager.profile_tools import is_re_worker_active  # noqa: E402, F401
-from .manager.profile_tools import clear_re_worker_active, set_re_worker_active  # noqa: E402, F401
+from .manager.profile_tools import (  # noqa: E402, F401
+    clear_ipython_mode,
+    clear_re_worker_active,
+    set_ipython_mode,
+    set_re_worker_active,
+)

--- a/bluesky_queueserver/__init__.py
+++ b/bluesky_queueserver/__init__.py
@@ -19,5 +19,6 @@ from .manager.profile_ops import format_text_descriptions  # noqa: E402, F401
 from .manager.profile_ops import register_device  # noqa: E402, F401
 from .manager.profile_ops import register_plan  # noqa: E402, F401
 from .manager.profile_ops import validate_plan  # noqa: E402, F401
+from .manager.profile_tools import is_ipython_mode  # noqa: E402, F401
 from .manager.profile_tools import is_re_worker_active  # noqa: E402, F401
 from .manager.profile_tools import clear_re_worker_active, set_re_worker_active  # noqa: E402, F401

--- a/bluesky_queueserver/__init__.py
+++ b/bluesky_queueserver/__init__.py
@@ -20,5 +20,6 @@ from .manager.profile_ops import register_device  # noqa: E402, F401
 from .manager.profile_ops import register_plan  # noqa: E402, F401
 from .manager.profile_ops import validate_plan  # noqa: E402, F401
 from .manager.profile_tools import is_ipython_mode  # noqa: E402, F401
+from .manager.profile_tools import clear_ipython_mode, set_ipython_mode  # noqa: E402, F401
 from .manager.profile_tools import is_re_worker_active  # noqa: E402, F401
 from .manager.profile_tools import clear_re_worker_active, set_re_worker_active  # noqa: E402, F401

--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -190,6 +190,7 @@ _key_mapping = {
     "ipython_dir": "startup/ipython_dir",
     "device_max_depth": "startup/device_max_depth",
     "use_ipython_kernel": "worker/use_ipython_kernel",
+    "ipython_kernel_ip": "worker/ipython_kernel_ip",
     "ipython_matplotlib": "worker/ipython_matplotlib",
     "print_console_output": "operation/print_console_output",
     "console_logging_level": "operation/console_logging_level",
@@ -341,6 +342,13 @@ class Settings:
             value_ev=os.environ.get("QSERVER_USE_IPYTHON_KERNEL", None),
             value_config=self._get_value_from_config("use_ipython_kernel"),
             value_cli=self._args_existing("use_ipython_kernel"),
+        )
+
+        self._settings["ipython_kernel_ip"] = self._get_param(
+            value_default=args.ipython_kernel_ip,
+            value_ev=os.environ.get("QSERVER_IPYTHON_KERNEL_IP", None),
+            value_config=self._get_value_from_config("ipython_kernel_ip"),
+            value_cli=self._args_existing("ipython_kernel_ip"),
         )
 
         self._settings["ipython_matplotlib"] = self._get_param(

--- a/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -28,7 +28,7 @@ properties:
       use_ipython_kernel:
         type: boolean
       ipython_kernel_ip:
-        type: str
+        type: string
       ipython_matplotlib:
         type: string
   startup:

--- a/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -27,6 +27,8 @@ properties:
     properties:
       use_ipython_kernel:
         type: boolean
+      ipython_kernel_ip:
+        type: str
       ipython_matplotlib:
         type: string
   startup:

--- a/bluesky_queueserver/manager/profile_tools.py
+++ b/bluesky_queueserver/manager/profile_tools.py
@@ -349,7 +349,7 @@ def is_re_worker_active():
     return os.environ.get(_env_re_worker_active, "false").lower() not in _env_values_false
 
 
-def set_ipython_mode(ipython_kernel):
+def set_ipython_mode(using_ipython):
     """
     Set the environment variable used to determine if RE Manager is using IPython-based worker.
     The variable is used by ``is_ipython_mode()`` public API, which determines if the script
@@ -357,10 +357,10 @@ def set_ipython_mode(ipython_kernel):
 
     Parameters
     ----------
-    ipython_kernel: bool
+    using_ipython: bool
         Pass ``True`` if the worker is using IPython kernel, ``False`` otherwise.
     """
-    os.environ[_env_ipython_kernel] = "1"
+    os.environ[_env_ipython_kernel] = "1" if using_ipython else "0"
 
 
 def clear_ipython_mode():

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -1441,7 +1441,11 @@ def qserver_console():
     parser = argparse.ArgumentParser(
         description="Bluesky-QServer: Start Jupyter console for IPython kernel running in the worker process.\n"
         f"bluesky-queueserver version {qserver_version}.\n\n"
-        "Requests IPython kernel connection info and starts Jupyter Console.\n",
+        "Requests IPython kernel connection info from RE Manager and starts Jupyter Console. The RE Worker\n"
+        "must be running (environment opened) and using IPython kernel. The address of 0MQ control port of\n"
+        "RE Manager can be passed as a parameter or an environment variable. If encryption of the control\n"
+        "channel is enabled, the public key can be passed by setting QSERVER_ZMQ_PUBLIC_KEY environment\n"
+        "variable.\n",
         formatter_class=formatter,
     )
 

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -1445,7 +1445,8 @@ def qserver_console():
         "must be running (environment opened) and using IPython kernel. The address of 0MQ control port of\n"
         "RE Manager can be passed as a parameter or an environment variable. If encryption of the control\n"
         "channel is enabled, the public key can be passed by setting QSERVER_ZMQ_PUBLIC_KEY environment\n"
-        "variable.\n",
+        "variable. Use 'Ctrl-D' to exit the console. Typing 'quit' or 'exit' in the console will close\n"
+        "the worker environment.\n",
         formatter_class=formatter,
     )
 

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -58,6 +58,8 @@ qserver monitor  # Start 'qserver' in monitoring mode
 qserver ping     # Send 'ping' request to RE Manager via ZMQ
 qserver status   # Request status of RE Manager
 
+qserver config   # Get RE Manager config
+
 qserver environment open         # Open RE environment
 qserver environment close        # Close RE environment
 qserver environment destroy      # Destroy RE environment (kill RE worker process)
@@ -853,6 +855,12 @@ def create_msg(params, *, lock_key):
         if len(params) != 0:
             raise CommandParameterError(f"Parameters are not allowed for '{command}' request")
         method = command
+
+    # ----------- status ------------
+    elif command == "config":
+        if len(params) != 0:
+            raise CommandParameterError(f"Parameters are not allowed for '{command}' request")
+        method = "config_get"
 
     # ----------- environment ------------
     elif command == "environment":

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -1457,16 +1457,6 @@ def qserver_console():
         f"(default: {default_zmq_control_address!r}).",
     )
 
-    parser.add_argument(
-        "--lock-key",
-        "-k",
-        dest="lock_key",
-        action="store",
-        default=None,
-        help="Lock key. The key is an arbitrary string is used to lock and unlock RE Manager "
-        "('lock' and 'unlock' API) and control the manager when the environment or the queue is locked.",
-    )
-
     args = parser.parse_args()
 
     exit_code = QServerExitCodes.SUCCESS
@@ -1477,13 +1467,6 @@ def qserver_console():
         address = address or os.environ.get("QSERVER_ZMQ_CONTROL_ADDRESS", None)
         # If the address is not specified, then use the default address
         address = address or default_zmq_control_address
-
-        lock_key = args.lock_key
-        if lock_key is not None:
-            if not isinstance(lock_key, str) or not lock_key:
-                raise CommandParameterError(
-                    f"Lock key must be a non-empty string: submitted lock key is {lock_key!r}"
-                )
 
         # Read public key from the environment variable, then check if the CLI parameter exists
         zmq_public_key = os.environ.get("QSERVER_ZMQ_PUBLIC_KEY", None)

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -435,7 +435,7 @@ class ReManager:
             params.append("--verbose")
 
         # Start the manager with IPython kernel if the
-        if ("--use-ipython-kernel" not in params) and use_ipykernel_for_tests():
+        if not any([_.startswith("--use-ipython-kernel") for _ in params]) and use_ipykernel_for_tests():
             params.append("--use-ipython-kernel=ON")
 
         if not self._p:

--- a/bluesky_queueserver/manager/tests/test_config.py
+++ b/bluesky_queueserver/manager/tests/test_config.py
@@ -280,6 +280,28 @@ startup:
   user_group_permissions_reload: INVALID
 """
 
+config07_a = """
+worker:
+  use_ipython_kernel: True
+  ipython_kernel_ip: localhost
+  ipython_matplotlib: qt5
+"""
+
+config07_a_dict = {
+    "worker": {"use_ipython_kernel": True, "ipython_kernel_ip": "localhost", "ipython_matplotlib": "qt5"}
+}
+
+config07_b = """
+worker:
+  use_ipython_kernel: false
+  ipython_kernel_ip: 127.0.0.1
+  ipython_matplotlib: agg
+"""
+
+config07_b_dict = {
+    "worker": {"use_ipython_kernel": False, "ipython_kernel_ip": "127.0.0.1", "ipython_matplotlib": "agg"}
+}
+
 
 # fmt: off
 @pytest.mark.parametrize("config_str, config_dict, success", [
@@ -309,6 +331,8 @@ startup:
     ([config_01a_success, config_01b_success, config_01c_success, config_01d_success],
      config_01_dict, True),
     ([config_01a_success, config_01a_success], None, False),
+    ([config07_a], config07_a_dict, True),
+    ([config07_b], config07_b_dict, True),
 ])
 # fmt: on
 def test_config_schema_01(tmpdir, config_str, config_dict, success):

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -1534,6 +1534,32 @@ def test_qserver_lock_01(re_manager):  # noqa: F811
     check_state(False, False)
 
 
+# fmt: off
+@pytest.mark.parametrize("env_open", [False, True])
+# fmt: on
+def test_qserver_config_01(re_manager, env_open):  # noqa: F811
+    """
+    ``qserver config``: basic test.
+    """
+    if env_open:
+        assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
+        assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    status = get_queue_state()
+    assert status["worker_environment_exists"] == env_open
+
+    assert subprocess.call(["qserver", "config"]) == SUCCESS
+    assert subprocess.call(["qserver", "config", "something"]) == PARAM_ERROR
+    assert subprocess.call(["qserver", "config"]) == SUCCESS
+
+    if env_open:
+        assert subprocess.call(["qserver", "environment", "close"]) == SUCCESS
+        assert wait_for_condition(time=timeout_env_open, condition=condition_environment_closed)
+
+    status = get_queue_state()
+    assert status["worker_environment_exists"] is False
+
+
 # ==================================================================================
 #                             qserver-clear-lock
 

--- a/bluesky_queueserver/manager/tests/test_qserver_console.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_console.py
@@ -1,0 +1,76 @@
+import subprocess
+
+import pytest
+
+from ..comms import zmq_single_request
+from ..qserver_cli import QServerExitCodes
+from .common import re_manager_cmd  # noqa: F401
+from .common import (
+    condition_environment_closed,
+    condition_environment_created,
+    use_ipykernel_for_tests,
+    wait_for_condition,
+)
+
+timeout_env_open = 10
+
+
+# fmt: off
+@pytest.mark.parametrize("ipython_kernel_ip", ['localhost', 'auto'])
+@pytest.mark.parametrize("env_open", [True, False])
+# fmt: on
+def test_cli_qserver_console_01(re_manager_cmd, ipython_kernel_ip, env_open):  # noqa: F811
+    """
+    'qserver-console' CLI tool: basic test
+
+    This test verifies if the console is properly started when the environment is opened
+    and IPython kernel is used, and fails to start with appropriate code if IPython is not used
+    or the environment is not opened.
+
+    Run the test both with and without IPython kernel.
+    """
+    using_ipython = bool(use_ipykernel_for_tests())
+
+    # Start the manager
+    params = []
+    if ipython_kernel_ip is not None:
+        params.extend([f"--ipython-kernel-ip={ipython_kernel_ip}"])
+    re_manager_cmd(params)
+
+    if env_open:
+        resp2, _ = zmq_single_request("environment_open")
+        assert resp2["success"] is True
+        assert resp2["msg"] == ""
+
+        assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    p = subprocess.Popen(
+        ["qserver-console"],
+        universal_newlines=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        p.wait(timeout=5)
+        outs, errs = p.communicate()
+    except subprocess.TimeoutExpired:
+        outs, errs = p.communicate(input="quit(keep_kernel=True)\n")
+
+    p.wait()
+    output = outs + "\n" + errs
+    return_code = p.returncode
+
+    if not using_ipython or not env_open:
+        assert return_code == QServerExitCodes.OPERATION_FAILED.value, output
+        assert "Failed to start the console" in output, output
+    else:
+        assert return_code == QServerExitCodes.SUCCESS.value, output
+        assert "Starting Jupyter Console ..." in output, output
+
+    if env_open:
+        resp9, _ = zmq_single_request("environment_close")
+        assert resp9["success"] is True
+        assert resp9["msg"] == ""
+
+        assert wait_for_condition(time=3, condition=condition_environment_closed)

--- a/bluesky_queueserver/manager/tests/test_qserver_console.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_console.py
@@ -2,14 +2,19 @@ import subprocess
 
 import pytest
 
-from ..comms import zmq_single_request
+from bluesky_queueserver import generate_zmq_keys
+from bluesky_queueserver.manager.comms import zmq_single_request
+
 from ..qserver_cli import QServerExitCodes
 from .common import re_manager_cmd  # noqa: F401
 from .common import (
     condition_environment_closed,
     condition_environment_created,
+    set_qserver_zmq_address,
+    set_qserver_zmq_public_key,
     use_ipykernel_for_tests,
     wait_for_condition,
+    zmq_secure_request,
 )
 
 timeout_env_open = 10
@@ -74,3 +79,86 @@ def test_cli_qserver_console_01(re_manager_cmd, ipython_kernel_ip, env_open):  #
         assert resp9["msg"] == ""
 
         assert wait_for_condition(time=3, condition=condition_environment_closed)
+
+
+# fmt: off
+@pytest.mark.parametrize("zmq_control_address", [False, True])
+@pytest.mark.parametrize("encryption_key", [False, True])
+@pytest.mark.parametrize("use_env_var", [False, True])
+# fmt: on
+@pytest.mark.skipif(not use_ipykernel_for_tests(), reason="Test is run only with IPython worker")
+def test_cli_qserver_console_02(
+    monkeypatch, re_manager_cmd, zmq_control_address, encryption_key, use_env_var  # noqa: F811
+):
+    """
+    'qserver-console' CLI tool: basic test
+
+    Test --zmq-control-addr parameter of 'qserver-console'. Also test that the control address
+    may be set using QSERVER_ZMQ_CONTROL_ADDRESS environment variable. Also test that
+    the encryption public key is set using QSERVER_ZMQ_PUBLIC_KEY environment variable.
+
+    Run the test only with IPython kernel.
+    """
+    using_ipython = bool(use_ipykernel_for_tests())
+    if not using_ipython:
+        assert False, "Test must be run only in IPython kernel mode"
+
+    address_server = "tcp://*:60621"
+    public_key, private_key = generate_zmq_keys()
+
+    params_console = []
+
+    params = []
+    if zmq_control_address:
+        params.append(f"--zmq-control-addr={address_server}")
+        address_client = address_server.replace("*", "localhost")
+        set_qserver_zmq_address(monkeypatch, zmq_server_address=address_client)
+
+        if use_env_var:
+            monkeypatch.setenv("QSERVER_ZMQ_CONTROL_ADDRESS", address_client)
+        else:
+            params_console.append(f"--zmq-control-addr={address_client}")
+
+    if encryption_key:
+        # # Set server public key (for 'qserver') using environment variable
+        # monkeypatch.setenv("QSERVER_ZMQ_PUBLIC_KEY", public_key)
+        # Set private key for RE manager
+        monkeypatch.setenv("QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER", private_key)
+        # Set public key used by test helper functions such as 'wait_for_condition'
+        set_qserver_zmq_public_key(monkeypatch, server_public_key=public_key)
+
+        monkeypatch.setenv("QSERVER_ZMQ_PUBLIC_KEY", public_key)
+
+    re_manager_cmd(params)
+
+    resp2, _ = zmq_secure_request("environment_open")
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    p = subprocess.Popen(
+        ["qserver-console", *params_console],
+        universal_newlines=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        p.wait(timeout=5)
+        outs, errs = p.communicate()
+    except subprocess.TimeoutExpired:
+        outs, errs = p.communicate(input="quit(keep_kernel=True)\n")
+
+    p.wait()
+    output = outs + "\n" + errs
+    return_code = p.returncode
+
+    assert return_code == QServerExitCodes.SUCCESS.value, output
+    assert "Starting Jupyter Console ..." in output, output
+
+    resp9, _ = zmq_secure_request("environment_close")
+    assert resp9["success"] is True
+    assert resp9["msg"] == ""
+
+    assert wait_for_condition(time=3, condition=condition_environment_closed)

--- a/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -469,6 +469,7 @@ def _get_expected_settings_default_1(tmpdir):
         "keep_re": False,
         "device_max_depth": 0,
         "use_ipython_kernel": use_ipython_kernel,
+        "ipython_kernel_ip": "localhost",
         "ipython_matplotlib": None,
         "print_console_output": True,
         "redis_addr": "localhost",
@@ -502,6 +503,7 @@ network:
   redis_addr: localhost:6379
 worker:
   use_ipython_kernel: true
+  ipython_kernel_ip: auto
   ipython_matplotlib: qt5
 startup:
   keep_re: false
@@ -542,6 +544,7 @@ def _get_expected_settings_config_2(tmpdir):
         "device_max_depth": 2,
         "ignore_invalid_plans": True,
         "use_ipython_kernel": True,
+        "ipython_kernel_ip": "auto",
         "ipython_matplotlib": "qt5",
         "print_console_output": True,
         "redis_addr": "localhost:6379",
@@ -580,6 +583,7 @@ def _get_cli_params_3(tmpdir):
         "--device-max-depth=5",
         "--ignore-invalid-plans=ON",
         "--use-ipython-kernel=ON",
+        "--ipython-kernel-ip=127.0.0.1",
         "--ipython-matplotlib=qt",
         "--zmq-data-proxy-addr=tcp://localhost:5571",
         "--databroker-config=NEW",
@@ -604,6 +608,7 @@ def _get_expected_settings_params_3(tmpdir):
         "device_max_depth": 5,
         "ignore_invalid_plans": True,
         "use_ipython_kernel": True,
+        "ipython_kernel_ip": "127.0.0.1",
         "ipython_matplotlib": "qt",
         "print_console_output": False,
         "redis_addr": "localhost:6379",

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -896,6 +896,15 @@ class RunEngineWorker(Process):
         }
         return msg_out
 
+    def _request_ip_connect_info(self):
+        """
+        Return IP connect info obtained from IPython kernel. Returns ``{}`` if
+        worker is using pure Python.
+        """
+        connect_info = copy.deepcopy(self._ip_connect_info)
+        connect_info["key"] = connect_info["key"].decode("utf-8")
+        return {"ip_connect_info": connect_info}
+
     def _request_plan_report_handler(self):
         """
         Returns the report on recently completed plan. Note that the report is `None` if
@@ -1267,6 +1276,7 @@ class RunEngineWorker(Process):
         self._comm_to_manager = PipeJsonRpcReceive(conn=self._conn, name="RE Worker-Manager Comm")
 
         self._comm_to_manager.add_method(self._request_state_handler, "request_state")
+        self._comm_to_manager.add_method(self._request_ip_connect_info, "request_ip_connect_info")
         self._comm_to_manager.add_method(self._request_plan_report_handler, "request_plan_report")
         self._comm_to_manager.add_method(self._request_run_list_handler, "request_run_list")
         self._comm_to_manager.add_method(

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1730,69 +1730,89 @@ class RunEngineWorker(Process):
 
                 return port
 
+            def find_kernel_ip(ip_str):
+                if ip_str == "localhost":
+                    ip = "127.0.0.1"
+                elif ip_str == "auto":
+                    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    s.connect(("8.8.8.8", 80))
+                    ip = s.getsockname()[0]
+                else:
+                    ip = ip_str
+                return ip
+
             logger.info("Generating random port numbers for IPython kernel ...")
-            self._ip_kernel_app.shell_port = generate_random_port()
-            self._ip_kernel_app.iopub_port = generate_random_port()
-            self._ip_kernel_app.stdin_port = generate_random_port()
-            self._ip_kernel_app.hb_port = generate_random_port()
-            self._ip_kernel_app.control_port = generate_random_port()
-            self._ip_connect_info = self._ip_kernel_app.get_connection_info()
-
-            def start_jupyter_client():
-                from jupyter_client import BlockingKernelClient
-
-                self._ip_kernel_client = BlockingKernelClient()
-                self._ip_kernel_client.load_connection_info(self._ip_connect_info)
-                logger.info(
-                    "Session ID for communication with IP kernel: %s", self._ip_kernel_client.session.session
-                )
-                self._ip_kernel_client.start_channels()
-
-                ip_kernel_iopub_monitor_thread = Thread(
-                    target=self._ip_kernel_iopub_monitor_thread,
-                    kwargs=dict(output_stream=out_stream, error_stream=err_stream),
-                    daemon=True,
-                )
-                ip_kernel_iopub_monitor_thread.start()
-
-            start_jupyter_client()
-
-            self._ip_kernel_monitor_always_allow_types = ["error"]
-            self._ip_kernel_monitor_collected_tracebacks = []
-
-            ttime.sleep(0.5)  # Wait unitl 0MQ monitor is connected to the kernel ports
-
-            logger.info("Initializing IPython kernel ...")
-            self._ip_kernel_app.initialize([])
-
-            ttime.sleep(0.2)  # Wait until the error message are delivered (if startup fails)
-
-            self._ip_kernel_monitor_always_allow_types = ["stream", "error", "execute_result"]
-            collected_tracebacks = self._ip_kernel_monitor_collected_tracebacks
-            self._ip_kernel_monitor_collected_tracebacks = None
-
-            self._ip_connect_file = self._ip_kernel_app.connection_file
-
-            # This is a very naive idea: if no exceptions were raised during kernel initialization
-            #   the we consider that startup code was loaded and the environment is fully functional
-            #   Otherwise we assume that loading failed and the collected tracebacks are used
-            #   to generate report (if needed). TODO: there could be some other non-obvious way to
-            #   detect if startup code was loaded. Ideas are appreciated.
-            if collected_tracebacks:
+            kernel_ip = self._config_dict["ipython_kernel_ip"]
+            try:
+                kernel_ip = find_kernel_ip(kernel_ip)
+                self._ip_kernel_app.ip = kernel_ip
+                self._ip_kernel_app.shell_port = generate_random_port(kernel_ip)
+                self._ip_kernel_app.iopub_port = generate_random_port(kernel_ip)
+                self._ip_kernel_app.stdin_port = generate_random_port(kernel_ip)
+                self._ip_kernel_app.hb_port = generate_random_port(kernel_ip)
+                self._ip_kernel_app.control_port = generate_random_port(kernel_ip)
+                self._ip_connect_info = self._ip_kernel_app.get_connection_info()
+            except Exception as ex:
                 self._success_startup = False
-                logger.error("The environment can not be opened: failed to load startup code.")
+                logger.error("Failed to generates kernel ports for IP %r: %s", kernel_ip, ex)
 
-            # Disable echoing, since startup code is already loaded
-            self._ip_kernel_app.quiet = True
-            self._ip_kernel_app.init_io()
+            if self._success_startup:
 
-            # Print connect info for the kernel (after kernel initialization)
-            cinfo = copy.deepcopy(self._ip_connect_info)
-            cinfo["key"] = cinfo["key"].decode("utf-8")
-            logger.info("IPython kernel connection info:\n %r", ppfl(cinfo))
+                def start_jupyter_client():
+                    from jupyter_client import BlockingKernelClient
 
-            th_abandoned_plans = threading.Thread(target=self._monitor_abandoned_plans_thread, daemon=True)
-            th_abandoned_plans.start()
+                    self._ip_kernel_client = BlockingKernelClient()
+                    self._ip_kernel_client.load_connection_info(self._ip_connect_info)
+                    logger.info(
+                        "Session ID for communication with IP kernel: %s", self._ip_kernel_client.session.session
+                    )
+                    self._ip_kernel_client.start_channels()
+
+                    ip_kernel_iopub_monitor_thread = Thread(
+                        target=self._ip_kernel_iopub_monitor_thread,
+                        kwargs=dict(output_stream=out_stream, error_stream=err_stream),
+                        daemon=True,
+                    )
+                    ip_kernel_iopub_monitor_thread.start()
+
+                start_jupyter_client()
+
+                self._ip_kernel_monitor_always_allow_types = ["error"]
+                self._ip_kernel_monitor_collected_tracebacks = []
+
+                ttime.sleep(0.5)  # Wait unitl 0MQ monitor is connected to the kernel ports
+
+                logger.info("Initializing IPython kernel ...")
+                self._ip_kernel_app.initialize([])
+
+                ttime.sleep(0.2)  # Wait until the error message are delivered (if startup fails)
+
+                self._ip_kernel_monitor_always_allow_types = ["stream", "error", "execute_result"]
+                collected_tracebacks = self._ip_kernel_monitor_collected_tracebacks
+                self._ip_kernel_monitor_collected_tracebacks = None
+
+                self._ip_connect_file = self._ip_kernel_app.connection_file
+
+                # This is a very naive idea: if no exceptions were raised during kernel initialization
+                #   the we consider that startup code was loaded and the environment is fully functional
+                #   Otherwise we assume that loading failed and the collected tracebacks are used
+                #   to generate report (if needed). TODO: there could be some other non-obvious way to
+                #   detect if startup code was loaded. Ideas are appreciated.
+                if collected_tracebacks:
+                    self._success_startup = False
+                    logger.error("The environment can not be opened: failed to load startup code.")
+
+                # Disable echoing, since startup code is already loaded
+                self._ip_kernel_app.quiet = True
+                self._ip_kernel_app.init_io()
+
+                # Print connect info for the kernel (after kernel initialization)
+                cinfo = copy.deepcopy(self._ip_connect_info)
+                cinfo["key"] = cinfo["key"].decode("utf-8")
+                logger.info("IPython kernel connection info:\n %r", ppfl(cinfo))
+
+                th_abandoned_plans = threading.Thread(target=self._monitor_abandoned_plans_thread, daemon=True)
+                th_abandoned_plans.start()
 
             # --------------------------------------------------------------------------
             #               Run startup code outside the IPython kernel1

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -415,6 +415,8 @@ periodically requests and displays the status of Queue Server.
     qserver ping     # Send 'ping' request to RE Manager via ZMQ
     qserver status   # Request status of RE Manager
 
+    qserver config   # Get RE Manager config
+
     qserver environment open         # Open RE environment
     qserver environment close        # Close RE environment
     qserver environment destroy      # Destroy RE environment (kill RE worker process)

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -732,3 +732,40 @@ address is different from default, the correct address must be passed using the 
     --redis-addr REDIS_ADDR
                       The address of Redis server, e.g. 'localhost', '127.0.0.1',
                       'localhost:6379' (default: localhost).
+
+
+.. _qserver_console_cli:
+
+qserver-console
+---------------
+
+Starts Jupyter Console connected to IPython kernel running in the worker process.
+RE Manager must be started with enabled ``--use-ipython-kernel`` option (using CLI
+parameter, config file parameter or the environment variable). The console can not
+be started if the worker environment is closed and the kernel is not running.
+Use ``Ctrl-D`` to exit the console. Typing ``quit`` or ``exit`` in the console will
+close the worker environment.
+
+.. code-block::
+
+  $ qserver-console -h
+  usage: qserver-console [-h] [--zmq-control-addr ZMQ_CONTROL_ADDR]
+
+  Bluesky-QServer: Start Jupyter console for IPython kernel running in the worker process.
+  bluesky-queueserver version 0.0.18.post117.dev0+ged01cde.
+
+  Requests IPython kernel connection info from RE Manager and starts Jupyter Console. The RE Worker
+  must be running (environment opened) and using IPython kernel. The address of 0MQ control port of
+  RE Manager can be passed as a parameter or an environment variable. If encryption of the control
+  channel is enabled, the public key can be passed by setting QSERVER_ZMQ_PUBLIC_KEY environment
+  variable. Use 'Ctrl-D' to exit the console. Typing 'quit' or 'exit' in the console will close
+  the worker environment.
+
+  options:
+    -h, --help        show this help message and exit
+    --zmq-control-addr ZMQ_CONTROL_ADDR, -a ZMQ_CONTROL_ADDR
+                      Address of the control socket of RE Manager. The parameter overrides
+                      the address set using the environment variable
+                      QSERVER_ZMQ_CONTROL_ADDRESS. The default value is used if the address
+                      is not set using the parameter or the environment variable. Address
+                      format: 'tcp://127.0.0.1:60615' (default: 'tcp://localhost:60615').

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -10,6 +10,7 @@ The CLI tools are installed with the *bluesky-queueserver* package:
 - :ref:`qserver_zmq_keys_cli` - generate key pair for encryption of 0MQ control channel.
 - :ref:`qserver_console_monitor_cli` - simple monitor of RE Manager console output.
 - :ref:`qserver_clear_lock_cli` - unlock RE Manager if the lock key is lost.
+- :ref:`qserver_console_cli` - start Jupyter Console connected to IPython kernel running in the worker.
 
 .. _start_re_manager_cli:
 

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -67,10 +67,11 @@ raise the exception (default) or return the error message. If reference to a cal
 is passed to `send_message` (in thread-based API), the communication error message will be
 passed as `msg_err` parameter of the callback function
 
-Get status information from RE Manager:
+Get status and configuration information from RE Manager:
 
 - :ref:`method_ping`
 - :ref:`method_status`
+- :ref:`method_config_get`
 
 Existing and allowed plans and devices:
 
@@ -308,6 +309,39 @@ Returns       **msg**: *str*
 
                   - **queue** (*boolean*) - indicates if the queue is locked. See the **lock** API
                     for details.
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
+============  =========================================================================================
+
+
+.. _method_config_get:
+
+**'config_get'**
+^^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'config_get'**
+------------  -----------------------------------------------------------------------------------------
+Description   Returns config info for RE Manager.
+
+              *The request always succeeds*.
+------------  -----------------------------------------------------------------------------------------
+Parameters    ---
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+
+              **config**: *dict*
+                  config information for RE Manager:
+
+                  - **'ip_connect_info'** (*dict*) - connect info for IPython kernel running in 
+                    the worker process, empty dictionary if IPython kernel is not running.
+                    The returned dictionary may be saved as JSON to create IPython kernel connection 
+                    file. The connection file may be passed to Jupyter Console with 
+                    **'--existing'** parameter.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================

--- a/docs/source/startup_code.rst
+++ b/docs/source/startup_code.rst
@@ -44,3 +44,25 @@ with the user) when experiments are controlled remotely:
     is_re_worker_active
     set_re_worker_active
     clear_re_worker_active
+
+
+.. _detecting_if_code_executed_in_ipython:
+
+Detecting if the Code is Executed in IPython Kernel
+---------------------------------------------------
+
+The function ``is_ipython_mode()`` returns ``True`` if the code is executed in IPython environment
+and ``False`` if the environment is pure Python. The function corectly detects IPython
+environment even if the code with patched ``IPython.get_ipython()`` is loaded.
+The function is used similarly to ``is_re_worker_active()``. The functions may be used
+in startup code and uploaded scripts to identify whether the code is run in the worker environment
+and whether the IPython features can be used.
+
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
+    is_ipython_mode
+    set_re_worker_active
+    clear_re_worker_active

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -47,6 +47,7 @@ The following tutorials are available:
 - :ref:`tutorial_executing_functions`
 - :ref:`tutorial_uploading_scripts`
 - :ref:`tutorial_queue_autostart_mode`
+- :ref:`tutorial_start_queue_server_ipython`
 - :ref:`tutorial_locking_re_manager`
 - :ref:`tutorial_changing_user_group_permissions`
 - :ref:`tutorial_running_custom_startup_code`
@@ -1193,6 +1194,7 @@ Make sure that the queue and the history are empty and the autostart mode is dis
   ... }
 
 Clear the queue and the history if necessary::
+
   $ qserver queue clear
   $ qserver history clear
 
@@ -1211,12 +1213,12 @@ Check the autostart mode is enabled::
   'queue_autostart_enabled': True,
   ... }
 
-Add a plan to the queue:
+Add a plan to the queue::
 
   $ qserver queue add plan '{"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 10, "delay": 1}}'
 
-Observe that the execution of the plan start automatically. Check status to see that the executed plan
-was added to the plan history and the autostart mode is still on::
+Observe that the execution of the plan starts automatically. Check the status to make sure that
+the executed plan was added to the plan history and the autostart mode is still on::
 
   $ qserver status
   { ...
@@ -1226,7 +1228,7 @@ was added to the plan history and the autostart mode is still on::
   'queue_autostart_enabled': True,
   ... }
 
-Close the environment:
+Close the environment::
 
   $ qserver environment close
 
@@ -1260,7 +1262,7 @@ while the first plan is still running::
   $ qserver re pause
   $ qserver re stop
 
-Observer the RE Manager console output to make sure that the plan stops. Now check the status
+Observe the RE Manager console output to verify that the plan stops. Now check the status
 to make sure that one plan remains in the queue and autostart mode is disabled::
 
   $ qserver status
@@ -1274,6 +1276,128 @@ to make sure that one plan remains in the queue and autostart mode is disabled::
 API used in this tutorial: :ref:`method_queue_autostart`, :ref:`method_status`,
 :ref:`method_environment_open`, :ref:`method_environment_close`, :ref:`method_re_pause`,
 :ref:`method_re_resume_stop_abort_halt`.
+
+.. _tutorial_start_queue_server_ipython:
+
+Start Queue Server in IPython Mode
+----------------------------------
+
+Queue Server may be configured to run the worker environment in IPython kernel. In this mode,
+the worker accepts startup code and uploaded scripts that contain IPython-specific features,
+such as magics, ``user_ns``, etc. Users may also connect to the kernel directly using
+Jupyter Console and run plans and execute IPython commands interactively. This allows to
+implement dual workflows, that include API-based control of execution of typical plans
+(e.g. to support user-friendly GUI) and interactive IPython access to the environment
+for expert use.
+
+See more information on IPython mode in :ref:`worker_ipython_kernel`.
+
+RE Manager can be started in IPython mode using the parameter ``--use-ipython-kernel=ON``::
+
+  $ start-re-manager --use-ipython-kernel=ON
+
+By default, IPython kernel is using ``agg`` Matplotlib backend, which prevents Matplotlib
+plots from being displayed. To enable plotting, pass a different backend using
+``--ipython-matplotlib`` parameter::
+
+  $ start-re-manager --use-ipython-kernel=ON --ipython-matplotlib=qt5
+
+Now start RE Manager (with or without setting Matplotlib backend), then open the environment::
+
+  $ qserver environment open
+
+The console output of RE Manager will contain the following::
+
+  [I 2023-04-30 17:31:45,811 bluesky_queueserver.manager.worker] Initializing IPython kernel ...
+  NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.
+
+  To exit, you will have to explicitly quit this process, by either sending
+  "quit" from a client, or using Ctrl-\ in UNIX-like environments.
+
+  To read more about this, see https://github.com/ipython/ipython/issues/2049
+
+  To connect another client to this kernel, use:
+      --existing kernel-824988.json
+  Loading file '/tmp/qserver/ipython/profile_collection_sim/startup/00-ophyd.py'
+  Loading file '/tmp/qserver/ipython/profile_collection_sim/startup/15-plans.py'
+  Loading file '/tmp/qserver/ipython/profile_collection_sim/startup/99-custom.py'
+  [I 2023-04-30 17:31:46,817 bluesky_queueserver.manager.worker] IPython kernel connection info:
+  {'transport': 'tcp',
+  'ip': '127.0.0.1',
+  'shell_port': 45493,
+  'iopub_port': 34885,
+  'stdin_port': 43199,
+  'hb_port': 39801,
+  'control_port': 57395,
+  'signature_scheme': 'hmac-sha256',
+  'key': '070a4a0d-a4e8199193269ca4f2785595'}
+
+Check RE Manager status::
+
+  $ qserver status
+  { ...
+  'ip_kernel_state': 'idle',
+  'ip_kernel_captured': False,
+  ... }
+
+The kernel is in the ``'idle'`` state and ready to execute tasks, the
+parameter ``ip_kernel_captured`` indicates if the kernel is executing a foreground task
+(plan, function or script) started by RE Manager.
+
+Add a plan to the queue and start the queue::
+
+  $ qserver queue add plan '{"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 10, "delay": 1}}'
+  $ qserver queue start
+
+Check the status while the plan is running. The kernel state is now ``busy`` and the kernel is
+'captured' by RE Manager::
+
+  $ qserver status
+  { ...
+  'ip_kernel_state': 'busy',
+  'ip_kernel_captured': True,
+  ... }
+
+Now open another terminal and connect to the kernel using Jupyter Console.
+The ``qserver-console`` CLI tool downloads current kernel connection info from
+RE Manager and passes it to the Jupyter Console::
+
+  $ qserver-console
+
+Start a plan in the IPython prompt::
+
+  In [1]: RE(count([det1, det2], num=10, delay=1))
+
+As the plan is executed in Jupyter Console, the output is also displayed
+in RE Manager console output. Jupyter Console may be closed while the plan is running
+(Ctrl-C then Ctrl-D) but the plan will continue to run in the kernel. Check the status
+while the plan is running::
+
+  $ qserver status
+  { ...
+  'ip_kernel_state': 'busy',
+  'ip_kernel_captured': False,
+  ... }
+
+The kernel state is ``busy``, but it is not 'captured' by the manager. RE Manager can not
+start execution of a foreground task (plan/function/script) until the task started from
+the console is completed and the kernel is ``idle``.
+
+.. note::
+
+  Use ``Ctrl-D`` to exit Jupyter Console: typing ``quit`` or ``exit`` will close the kernel
+  and, respectively, the worker environment.
+
+Close the environment::
+
+  $ qserver environment close
+
+The environment can be closed only if the kernel is ``idle``. The operation of destroying
+the environment will kill the worker process and, respectively, the kernel independent
+of its state.
+
+API used in this tutorial: :ref:`method_status`, :ref:`method_queue_item_add`,
+:ref:`method_queue_start`, :ref:`method_environment_open`, :ref:`method_environment_close`.
 
 
 .. _tutorial_locking_re_manager:

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -602,11 +602,16 @@ set of values as the ``--matplotlib`` parameter of ``ipython``. The backend is s
 by default, which disables plotting and should be used when running RE Manager on a remote server.
 Select another appriate backend (e.g. ``qt5``) to enable plotting.
 
-Checking if IPython Mode is Enabled
-***********************************
+Monitoring the State of IPython Kernel
+**************************************
 
-Once in IPython mode,
-RE Worker will accept the startup code with IPython-specific features (e.g. magics, user_ns etc.).
-Client code may check if IPython mode is enabled by checking  ... parameter of status API
-(add the parameter to the status API docs). The startup code running in the environment
-may check if IPython is used using ... API
+The state of the running IPython kernel can be monitored by checking ``ip_kernel_state``
+parameter of RE Manager status (see :ref:`method_status` API). The status parameter
+``ip_kernel_captured`` indicates if the running kernel is 'captured' by RE Manager.
+The parameter is ``True`` if the kernel is running foreground task started by
+the manager and ``False`` otherwise. External clients can not interact with the kernel
+while it is 'captured' by the manager. Both parameters are *None* if the environment is
+not running or the worker is not using IPython kernel.
+
+Loading Connection Info
+***********************

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -524,3 +524,41 @@ The autostart may be also enabled and disabled using CLI interface::
   qserver queue autostart disable
 
 See documentation on :ref:`method_queue_autostart` API for more details.
+
+
+.. _worker_ipython_kernel:
+
+Running RE Worker with IPython Kernel
+-------------------------------------
+
+RE Manager can be configured to create worker execution environment in IPython kernel. 
+In this mode, RE Worker starts embedded IPython kernel, loading the startup code, IPython 
+configuration and IPython history during kernel initialization. The location of the
+startup code is determined based on ``--startup-profile``, ``--startup-module``,
+``--startup-script`` and ``--startup-dir`` parameters of ``start-re-manager`` 
+(``startup/startup_profile``, ``startup/startup_module``, ``startup/startup_script`` and 
+``startup/startup_dir`` parameters in the config file). The kernel looks for the startup
+code in ``<ipythondir>/profile_<profile_name>/startup``, where ``<ipythondir>`` is 
+the value of the environment variable ``IPYTHONDIR``, which determines the location of 
+IPython profiles (default location is ``~/.ipython``) and ``profile_name`` is 
+the name passed using ``--startup-profile`` parameter. The location of IPython profiles 
+may also be specified using ``--ipython-dir`` parameter, which overrides ``IPYTHONDIR`` 
+environment variable. Alternatively, the location of startup profile may be specified 
+using ``--startup-dir`` parameter. If RE Manager is configured to use IPython kernel, 
+the startup directory must match the standard pattern (``<ipythondir>/profile_<profile_name>/startup``),
+so that it could be successfully parsed to extract the profile name and IPython directory.
+
+In addition to the startup code in IPython profile, the IPython kernel may also load 
+a startup script or a startup module if path to a script or a path to a module is specified.
+This behavior is different from the behavior of the worker using pure Python. If loading of startup
+code is undesirable, create a profile with empty ``startup`` directory and pass the profile
+name to RE Manager. If ``--startup-script`` or ``--startup-module`` is specified, but no
+profile name is passed, then default IPython profile (``$IPYTHONDIR/profile_default``) is loaded.
+
+RE Manager is configured to use IPython kernel by passing ``--use-ipython-kernel=ON`` parameter
+to ``start-re-manager``, setting config parameter ``startup/use_ipython_kernel: True`` or 
+environment variable ``QSERVER_USE_IPYTHON_KERNEL=True``. Once in IPython mode,
+RE Worker will accept the startup code with IPython-specific features (e.g. magics, user_ns etc.).
+Client code may check if IPython mode is enabled by checking  ... parameter of status API 
+(add the parameter to the status API docs). The startup code running in the environment
+may check if IPython is used using ... API

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -613,5 +613,42 @@ the manager and ``False`` otherwise. External clients can not interact with the 
 while it is 'captured' by the manager. Both parameters are *None* if the environment is
 not running or the worker is not using IPython kernel.
 
-Loading Connection Info
-***********************
+Downloading Kernel Connection Info
+**********************************
+
+Connection info for a running IPython kernel can be downloaded at any time by sending
+:ref:`method_config_get` API request to RE Manager (CLI command: ``qserver config``).
+The connection info (``ip_connect_info`` key) is a dictionary, which contains network
+IP address of the host running the kernel, numbers of 0MQ ports, etc. The connection
+info dictionary is empty if the kernel is not running for any reason. Since the old
+kernel is destroyed each time the environment is closed and a new kernel is created each
+time the environment is opened, the updated connection info must be downloaded again
+for the new environment. The ``qserver-console`` CLI tool automatically loads
+the connection info from RE Manager and starts Jupyter Console connected to the kernel.
+
+Connecting to Running IPython Kernel Using Jupyter Console
+**********************************************************
+
+Once IPython kernel is running in the worker process (RE Manager is started with
+enabled IPython option and the environment is open), users may connect to it directly
+using Jupyter Console by running :ref:`qserver_console_cli` CLI tool, which loads connection
+info from RE Manager and passes it to Jupyter Console application.
+
+.. note::
+
+    If the kernel is running any foreground tasks (plans, functions, scripts) started by
+    RE Manager, Jupyter Console will remain unresponsive until the task is complete
+    and the 'captured' kernel is freed.
+
+Jupyter Console works similarly to IPython terminal, except that closing the console
+does not interrupt tasks started from the console. For example, a plan started manually
+from the console will continue running after console is closed. The plan execution will not
+be managed by RE Manager, but the plan output will be included in RE Manager console output
+and streamed to all subscribed consumers.
+
+.. note::
+
+    Use ``Ctrl-D`` to close the Jupyter Console. Typing ``quit`` or ``exit`` in Jupyter
+    console will close the kernel and cause the worker environment to close.
+
+See documentation on :ref:`qserver_console_cli` for more information.

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -531,34 +531,82 @@ See documentation on :ref:`method_queue_autostart` API for more details.
 Running RE Worker with IPython Kernel
 -------------------------------------
 
-RE Manager can be configured to create worker execution environment in IPython kernel. 
-In this mode, RE Worker starts embedded IPython kernel, loading the startup code, IPython 
+Queue Server can be configured to run worker execution environment in IPython kernel.
+The kernel is created in the worker process and used to execute plans, functions and script.
+In IPython mode, the worker can load startup code and scripts with IPython-specific
+features, such as magics, ``user_ns``, etc. Users may also connect to the kernel directly
+bypassing RE Manager using Jupyter Console.
+
+Starting RE Manager in IPython Mode
+***********************************
+
+RE Manager is configured to use IPython kernel by passing ``--use-ipython-kernel=ON`` parameter
+to ``start-re-manager``, setting config parameter ``startup/use_ipython_kernel: True`` or
+environment variable ``QSERVER_USE_IPYTHON_KERNEL=True``.
+
+Specifying IPython Kernel IP Address
+************************************
+
+The IPython kernel IP address is set using ``--ipython-kernel-ip`` parameter of
+``start-re-manager``, setting ``QSERVER_IPYTHON_KERNEL_IP`` environment variable or
+or by setting config parameter ``startup/ipython_kernel_ip``. The parameter values
+are ``'localhost'`` (default), ``'auto'`` or a string represting valid network
+IP address of the host running the kernel, such as ``127.0.0.1`` or ``192.168.50.49``.
+If the IP address is ``'localhost'`` (default) or ``127.0.0.1``, the kernel does not accept
+connections from other hosts. If the parameter is set to ``'auto'``, Queue Server attempts
+to automatically determine network IP address of the host and passes it to the kernel.
+If the network IP address is determined correctly, the kernel will accept connections
+from other hosts. If automatic mode fails, the correct IP address may be explicitly passed to
+the server. The IP address passed to the kernel is returned as part of connection info,
+which is used by client applications to connect to the kernel
+(see :ref:`method_config_get` API).
+
+Specifying Location of Startup Code
+***********************************
+
+In this mode, RE Worker starts embedded IPython kernel, loading the startup code, IPython
 configuration and IPython history during kernel initialization. The location of the
 startup code is determined based on ``--startup-profile``, ``--startup-module``,
-``--startup-script`` and ``--startup-dir`` parameters of ``start-re-manager`` 
-(``startup/startup_profile``, ``startup/startup_module``, ``startup/startup_script`` and 
+``--startup-script`` and ``--startup-dir`` parameters of ``start-re-manager``
+(``startup/startup_profile``, ``startup/startup_module``, ``startup/startup_script`` and
 ``startup/startup_dir`` parameters in the config file). The kernel looks for the startup
-code in ``<ipythondir>/profile_<profile_name>/startup``, where ``<ipythondir>`` is 
-the value of the environment variable ``IPYTHONDIR``, which determines the location of 
-IPython profiles (default location is ``~/.ipython``) and ``profile_name`` is 
-the name passed using ``--startup-profile`` parameter. The location of IPython profiles 
-may also be specified using ``--ipython-dir`` parameter, which overrides ``IPYTHONDIR`` 
-environment variable. Alternatively, the location of startup profile may be specified 
-using ``--startup-dir`` parameter. If RE Manager is configured to use IPython kernel, 
+code in ``<ipythondir>/profile_<profile_name>/startup``, where ``<ipythondir>`` is
+the value of the environment variable ``IPYTHONDIR``, which determines the location of
+IPython profiles (default location is ``~/.ipython``) and ``profile_name`` is
+the name passed using ``--startup-profile`` parameter. The location of IPython profiles
+may also be specified using ``--ipython-dir`` parameter, which overrides ``IPYTHONDIR``
+environment variable. Alternatively, the location of startup profile may be specified
+using ``--startup-dir`` parameter. If RE Manager is configured to use IPython kernel,
 the startup directory must match the standard pattern (``<ipythondir>/profile_<profile_name>/startup``),
 so that it could be successfully parsed to extract the profile name and IPython directory.
 
-In addition to the startup code in IPython profile, the IPython kernel may also load 
+In addition to the startup code in IPython profile, the IPython kernel may also load
 a startup script or a startup module if path to a script or a path to a module is specified.
-This behavior is different from the behavior of the worker using pure Python. If loading of startup
-code is undesirable, create a profile with empty ``startup`` directory and pass the profile
-name to RE Manager. If ``--startup-script`` or ``--startup-module`` is specified, but no
-profile name is passed, then default IPython profile (``$IPYTHONDIR/profile_default``) is loaded.
+This behavior is different from the behavior of the Python-based worker, which does not attempt
+to load the profile startup files if a path to a script or module name is specified.
+If loading of startup code is undesirable, create a profile with empty ``startup`` directory
+and pass the profile name to RE Manager. If ``--startup-script`` or ``--startup-module`` is specified,
+but no profile name is passed, then default IPython profile (``$IPYTHONDIR/profile_default``) is loaded.
 
-RE Manager is configured to use IPython kernel by passing ``--use-ipython-kernel=ON`` parameter
-to ``start-re-manager``, setting config parameter ``startup/use_ipython_kernel: True`` or 
-environment variable ``QSERVER_USE_IPYTHON_KERNEL=True``. Once in IPython mode,
+Setting Matplotlib Backend
+**************************
+
+If RE Manager is running on the local machine and IPython mode is enabled, the in-process live
+plotting may be performed directly from the worker environment. This feature may be convenient
+for users, who wish to keep the existing interactive IPython-based workflows, but may
+want to mix REPL interactions with API control of the environment (e.g. for GUI or autonomous
+control). In order to enable plotting, the appropriate Matplotlib backend must be set
+using ``--ipython-matplotlib`` parameter of ``start-re-manager`` or ``worker/ipython_matplotlib``
+config parameter. The parameter is passed directly to IPython kernel and accepts the same
+set of values as the ``--matplotlib`` parameter of ``ipython``. The backend is set to ``agg``
+by default, which disables plotting and should be used when running RE Manager on a remote server.
+Select another appriate backend (e.g. ``qt5``) to enable plotting.
+
+Checking if IPython Mode is Enabled
+***********************************
+
+Once in IPython mode,
 RE Worker will accept the startup code with IPython-specific features (e.g. magics, user_ns etc.).
-Client code may check if IPython mode is enabled by checking  ... parameter of status API 
+Client code may check if IPython mode is enabled by checking  ... parameter of status API
 (add the parameter to the status API docs). The startup code running in the environment
 may check if IPython is used using ... API

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ ipykernel
 json-rpc
 jsonschema
 jupyter-client>=7.4.2
+jupyter-console
 matplotlib # Needed for BEC, should be factored out
 scikit-image # Needed for BEC/other stuff to run, factor out
 msgpack>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
             "profile_ops:gen_list_of_plans_and_devices_cli",
             "qserver-zmq-keys = bluesky_queueserver.manager.qserver_cli:qserver_zmq_keys",
             "qserver-clear-lock = bluesky_queueserver.manager.qserver_cli:qserver_clear_lock",
+            "qserver-console = bluesky_queueserver.manager.qserver_cli:qserver_console",
             "qserver-console-monitor = bluesky_queueserver.manager.output_streaming:qserver_console_monitor_cli",
         ],
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

New `qserver-console` endpoint, which downloads connection info for the running from RE Manager and starts Jupyter Console application. New `config_get` API, which returns kernel connection info.

The PR contains documentation on IPython mode and tutorials for 'autostart' feature and IPython mode.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR contain additional features required for full support of IPython mode.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New `config_get` API. Currently returns IPython kernel connect info (`ip_connect_info` key).
- New parameter of `start-re-manager`: `--ipython-kernel-ip` sets IP address of the kernel, the respective config file parameter is `worker/ipython_kernel_ip` and environment variable `QSERVER_IPYTHON_KERNEL_IP`.
- `qserver-console` CLI tool, which downloads kernel connection info and starts Jupyter Console.
- `qserver config` option for `qserver` CLI tool.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were implemented.

<!--
## Screenshots (if appropriate):
-->
