### PR TITLE
Run Jupyter Console as a separate process (qserver-console)

### DIFF
--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -1438,7 +1438,7 @@ def qserver_clear_lock():
     return exit_code
 
 
-def qserver_console():
+def qserver_console_base(*, app_name):
     logging.basicConfig(level=logging.WARNING)
     logging.getLogger("bluesky_queueserver").setLevel("INFO")
 
@@ -1530,12 +1530,12 @@ def qserver_console():
                 json.dump(connect_info, f)
 
             logger.info("Starting Jupyter Console ...")
-            path_exec = shutil.which("jupyter-console")
+            path_exec = shutil.which(app_name)
             if not path_exec:
-                logger.error("Jupyter Console is not installed.")
+                logger.error(f"{app_name!r} is not installed.")
                 exit_code = QServerExitCodes.OPERATION_FAILED
             else:
-                os.execl(path_exec, "jupyter-console", f"--existing={file_path}")
+                os.execl(path_exec, app_name, f"--existing={file_path}")
 
     except CommandParameterError as ex:
         logger.error("Invalid command or parameters: %s.", ex)
@@ -1548,3 +1548,11 @@ def qserver_console():
         exit_code = QServerExitCodes.SUCCESS
 
     return exit_code.value
+
+
+def qserver_console():
+    return qserver_console_base(app_name="jupyter-console")
+
+
+def qserver_qtconsole():
+    return qserver_console_base(app_name="jupyter-qtconsole")

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import pprint
-import subprocess
+import shutil
 import tempfile
 import time as ttime
 import uuid
@@ -1530,10 +1530,12 @@ def qserver_console():
                 json.dump(connect_info, f)
 
             logger.info("Starting Jupyter Console ...")
-            result = subprocess.run(["jupyter-console", f"--existing={file_path}"])
-            if result.returncode:
-                logger.error("Jupyter Console exited with return code %d", result.returncode)
+            path_exec = shutil.which("jupyter-console")
+            if not path_exec:
+                logger.error("Jupyter Console is not installed.")
                 exit_code = QServerExitCodes.OPERATION_FAILED
+            else:
+                os.execl(path_exec, "jupyter-console", f"--existing={file_path}")
 
     except CommandParameterError as ex:
         logger.error("Invalid command or parameters: %s.", ex)

--- a/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
+++ b/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
@@ -1,0 +1,89 @@
+import pprint
+
+from ..comms import zmq_single_request
+from .common import re_manager  # noqa: F401
+from .common import re_manager_cmd  # noqa: F401
+from .common import (
+    append_code_to_last_startup_file,
+    condition_environment_closed,
+    condition_environment_created,
+    copy_default_profile_collection,
+    use_ipykernel_for_tests,
+    wait_for_condition,
+    wait_for_task_result,
+)
+
+timeout_env_open = 10
+
+_script_with_ip_features = """
+from IPython.core.magic import register_line_magic, register_cell_magic
+
+@register_line_magic
+def lmagic(line):
+    return line
+
+@register_cell_magic
+def cmagic(line, cell):
+    return line, cell
+"""
+
+
+def test_ip_kernel_loading_script_01(tmp_path, re_manager_cmd):  # noqa: F811
+    """
+    Test that the IPython-based worker can load startup code with IPython-specific features,
+    and regular worker fails.
+    """
+    using_ipython = use_ipykernel_for_tests()
+
+    pc_path = copy_default_profile_collection(tmp_path)
+    append_code_to_last_startup_file(pc_path, additional_code=_script_with_ip_features)
+
+    params = ["--startup-dir", pc_path]
+    re_manager_cmd(params)
+
+    resp2, _ = zmq_single_request("environment_open")
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+
+    if not using_ipython:
+        assert not wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    else:
+        assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+        resp9, _ = zmq_single_request("environment_close")
+        assert resp9["success"] is True
+        assert resp9["msg"] == ""
+
+        assert wait_for_condition(time=3, condition=condition_environment_closed)
+
+
+def test_ip_kernel_loading_script_02(tmp_path, re_manager):  # noqa: F811
+    """
+    Test that the IPython-based worker accepts uploaded scripts with IPython-specific code
+    and the regular worker fails.
+    """
+    using_ipython = use_ipykernel_for_tests()
+
+    resp2, _ = zmq_single_request("environment_open")
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    resp3, _ = zmq_single_request("script_upload", params={"script": _script_with_ip_features})
+    assert resp3["success"] is True, pprint.pformat(resp3)
+
+    result = wait_for_task_result(10, resp3["task_uid"])
+    if not using_ipython:
+        assert result["success"] is False, pprint.pformat(result)
+        assert "Failed to execute stript" in result["msg"]
+    else:
+        assert result["success"] is True, pprint.pformat(result)
+        assert result["msg"] == "", pprint.pformat(result)
+
+    resp9, _ = zmq_single_request("environment_close")
+    assert resp9["success"] is True
+    assert resp9["msg"] == ""
+
+    assert wait_for_condition(time=3, condition=condition_environment_closed)

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -11,6 +11,7 @@ The CLI tools are installed with the *bluesky-queueserver* package:
 - :ref:`qserver_console_monitor_cli` - simple monitor of RE Manager console output.
 - :ref:`qserver_clear_lock_cli` - unlock RE Manager if the lock key is lost.
 - :ref:`qserver_console_cli` - start Jupyter Console connected to IPython kernel running in the worker.
+- :ref:`qserver_qtconsole_cli` - start Jupyter Qt Console connected to IPython kernel running in the worker.
 
 .. _start_re_manager_cli:
 
@@ -772,3 +773,13 @@ close the worker environment.
                       QSERVER_ZMQ_CONTROL_ADDRESS. The default value is used if the address
                       is not set using the parameter or the environment variable. Address
                       format: 'tcp://127.0.0.1:60615' (default: 'tcp://localhost:60615').
+
+
+.. _qserver_qtconsole_cli:
+
+qserver-qtconsole
+-----------------
+
+Starts Jupyter Qt Console connected to the IPython kernel running in the worker process.
+Jupyter Qt Console is extended Qt-based version of Jupyter Console. The command behaves similarly
+to :ref:`qserver_console_cli`.

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1364,6 +1364,10 @@ RE Manager and passes it to the Jupyter Console::
 
   $ qserver-console
 
+Alternatively, ``qserver-qtconsole`` may be used to start Jupyter Qt Console::
+
+  $ qserver-qtconsole
+
 Start a plan in the IPython prompt::
 
   In [1]: RE(count([det1, det2], num=10, delay=1))

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
             "qserver-zmq-keys = bluesky_queueserver.manager.qserver_cli:qserver_zmq_keys",
             "qserver-clear-lock = bluesky_queueserver.manager.qserver_cli:qserver_clear_lock",
             "qserver-console = bluesky_queueserver.manager.qserver_cli:qserver_console",
+            "qserver-qtconsole = bluesky_queueserver.manager.qserver_cli:qserver_qtconsole",
             "qserver-console-monitor = bluesky_queueserver.manager.output_streaming:qserver_console_monitor_cli",
         ],
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Minor change to functionality of `qserver-console` CLI app. Jupyter Console is now started using `os.execl` (replaces the current process) instead of being started as a subprocess. The `qserver-console` application is loading connection info from RE Manager, creates the connection file and starts Jupyter Console. 
Jupyter Console exhibited some strange behavior when running as a subprocess. For example the Linux terminal had to be reset to continue operation after quitting the console while running a plan. Now the console is running as an individual process.

Added new entry point: `qserver-qtconsole`, which behaves similary to `qserver-console`, but starts Jupyter Qt Console connected to IPython kernel running in the worker process.

The PR also contains small number of tests for basic functionality of IPython-based worker.


Added
--------
- `qserver-qtconsole` entry point (starts Jupyter Qt Console).
