### PR TITLE
Shift from aioredis to redis

### DIFF
--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -5,13 +5,10 @@ import logging
 import time as ttime
 import uuid
 
-import aioredis
+import redis.asyncio
 from packaging import version
 
 logger = logging.getLogger(__name__)
-
-# Check if 'aioredis' v2 is installed. TODO: remove support for 'aioredis' v1 when it is deprecated.
-aioredis_v2 = version.parse(aioredis.__version__) >= version.parse("2.0.0")
 
 
 class PlanQueueOperations:
@@ -246,11 +243,8 @@ class PlanQueueOperations:
             async with self._lock:
                 try:
                     host = f"redis://{self._redis_host}"
-                    if aioredis_v2:
-                        self._r_pool = aioredis.from_url(host, encoding="utf-8", decode_responses=True)
-                        await self._r_pool.ping()
-                    else:
-                        self._r_pool = await aioredis.create_redis_pool(host, encoding="utf8")
+                    self._r_pool = redis.asyncio.from_url(host, encoding="utf-8", decode_responses=True)
+                    await self._r_pool.ping()
                 except Exception as ex:
                     error_msg = (
                         f"Failed to create the Redis pool: "
@@ -904,16 +898,11 @@ class PlanQueueOperations:
                     qsize = await self._r_pool.lpush(self._name_plan_queue, json.dumps(item))
             else:
                 item_to_displace = self._uid_dict_get_item(uid)
-                if aioredis_v2:
-                    where = "BEFORE" if (uid == before_uid) else "AFTER"
-                    qsize = await self._r_pool.linsert(
-                        self._name_plan_queue, where, json.dumps(item_to_displace), json.dumps(item)
-                    )
-                else:
-                    before = uid == before_uid
-                    qsize = await self._r_pool.linsert(
-                        self._name_plan_queue, json.dumps(item_to_displace), json.dumps(item), before=before
-                    )
+                where = "BEFORE" if (uid == before_uid) else "AFTER"
+                qsize = await self._r_pool.linsert(
+                    self._name_plan_queue, where, json.dumps(item_to_displace), json.dumps(item)
+                )
+
         elif pos == "back":
             qsize = await self._r_pool.rpush(self._name_plan_queue, json.dumps(item))
         elif pos == "front":
@@ -923,14 +912,9 @@ class PlanQueueOperations:
 
             item_to_displace = await self._get_item(pos=pos_reference)
             if item_to_displace:
-                if aioredis_v2:
-                    qsize = await self._r_pool.linsert(
-                        self._name_plan_queue, "BEFORE", json.dumps(item_to_displace), json.dumps(item)
-                    )
-                else:
-                    qsize = await self._r_pool.linsert(
-                        self._name_plan_queue, json.dumps(item_to_displace), json.dumps(item), before=True
-                    )
+                qsize = await self._r_pool.linsert(
+                    self._name_plan_queue, "BEFORE", json.dumps(item_to_displace), json.dumps(item)
+                )
             else:
                 raise RuntimeError(f"Could not find an existing plan at {pos}. Queue size: {qsize0}")
         else:
@@ -1126,12 +1110,10 @@ class PlanQueueOperations:
 
         # Insert the new item after the old one and remove the old one. At this point it is guaranteed
         #   that they are not equal.
-        if aioredis_v2:
-            await self._r_pool.linsert(
-                self._name_plan_queue, "AFTER", json.dumps(item_to_replace), json.dumps(item)
-            )
-        else:
-            await self._r_pool.linsert(self._name_plan_queue, json.dumps(item_to_replace), json.dumps(item))
+        await self._r_pool.linsert(
+            self._name_plan_queue, "AFTER", json.dumps(item_to_replace), json.dumps(item)
+        )
+
         await self._remove_item(item_to_replace)
 
         # Update self._uid_dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-aioredis
 bluesky>=1.7.0
 bluesky-kafka
 databroker
@@ -20,5 +19,6 @@ pydantic
 python-multipart
 pyyaml
 pyzmq
+redis[hiredis]
 requests
 typing-extensions;python_version<'3.8'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Aioredis is now, more or less, merged into redis. As aioredis is now archived, better to shift to redis directly.

## Description
Modify imports to use redis. Remove code that handles older versions of aioredis.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Attempting to shift to python3.11 showed up a couple of issues with aioredis, and that led me down the path of discovering that it's now archived.
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

We've tested this, in a limited way, on AS beamlines. We can start the queueserver, add and run plans.

I could not run the tests by following the contributing guide, hoping the CI does that.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
