### PR TITLE
'Reserve' IPython kernel before sending plans/tasks to the worker

### DIFF
--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1088,6 +1088,8 @@ class RunEngineManager(Process):
             success, err_msg = await self._worker_command_reserve_kernel()
             if success:
                 success, err_msg = await self._worker_command_continue_plan(option)
+            else:
+                err_msg = f"Failed to capture IPython kernel: {err_msg}"
 
             success = bool(success)  # Convert 'None' to False
             if success:

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1028,7 +1028,7 @@ class RunEngineWorker(Process):
         status, err_msg = "accepted", ""
         logger.debug("Attempting to reserve (capture) IPython kernel ...")
         if not self._ip_kernel_capture(timeout=0.2):
-            status, err_msg = "failed", "Failed to reserve IPython kernel"
+            status, err_msg = "failed", "Timeout occurred while trying to reserve IPython kernel"
         msg_out = {"status": status, "err_msg": err_msg}
         return msg_out
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add additional step of 'reserving' IPython kernel before starting a queue, execution of a plan or a task. To 'reserve' the kernel, the manager is sending a request to the worker, and the worker attempts to start execution loop in IPython kernel. If the kernel is busy or the loop fails to start within short period (timeout is 0.2 s), the `reserve_kernel` request fails, which causes the respective operation (e.g. starting the queue) to fail. 'Reservation' must complete before the manager returns operation result to the client, i. e. if the API request to start the queue (`queue_start`) returns `success=True`, it is guaranteed that the IPython kernel is already running the execution loop and ready to execute plans.

New API `manager_test` was added. The API will be used exclusively for unit tests. No CLI access or python API support for this API will be implemented in the future.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The worker state information held by the manager process is delayed and the manager may consider IPython kernel idle, while it could already be busy running some code started by a directly connected client (e.g. Jupyter Console). In some rare cases, API requests that start execution of the queue, a plan or a task could return `success=True` to the client, but then fail to start execution loop in the kernel. This would cause the respective plan or a task to fail and the queue to be stopped. The changes in this PR are intended to fix this issue and make the behavior more consistent.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were implemented

<!--
## Screenshots (if appropriate):
-->
