### PR TITLE
New 'environment_update' and 'kernel_interrupt' API

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         use-ipykernel: [false, true]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
 
     steps:

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -3074,7 +3074,7 @@ class RunEngineManager(Process):
         variable).
         """
         logger.info("Processing request to interrupt IPython kernel ...")
-        success, msg, lock_info, lock_info_uid = True, "", {}, None
+        success, msg = True, ""
 
         try:
             supported_param_names = ["lock_key", "interrupt_task", "interrupt_plan"]
@@ -3092,7 +3092,7 @@ class RunEngineManager(Process):
         except Exception as ex:
             success, msg = False, f"Error: {ex}"
 
-        return {"success": success, "msg": msg, "lock_info": lock_info, "lock_info_uid": lock_info_uid}
+        return {"success": success, "msg": msg}
 
     async def _re_pause_handler(self, request):
         """

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1375,7 +1375,7 @@ class RunEngineManager(Process):
             if not interrupt_plan and self._manager_state in (MState.STARTING_QUEUE, MState.EXECUTING_QUEUE):
                 raise RuntimeError("Not allowed to interrupt running plan")
 
-            if not interrupt_plan and self._manager_state == MState.EXECUTING_TASK:
+            if not interrupt_task and self._manager_state == MState.EXECUTING_TASK:
                 raise RuntimeError("Not allowed to interrupt running task")
 
             success, msg = await self._worker_command_kernel_interrupt(
@@ -3076,8 +3076,8 @@ class RunEngineManager(Process):
 
             self._validate_lock_key(request.get("lock_key", None), check_environment=True)
 
-            interrupt_task = request.get("interrupt_task", False)
-            interrupt_plan = request.get("interrupt_plan", False)
+            interrupt_task = bool(request.get("interrupt_task", False))
+            interrupt_plan = bool(request.get("interrupt_plan", False))
 
             success, msg = await self._kernel_interrupt_send(
                 interrupt_task=interrupt_task, interrupt_plan=interrupt_plan

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -2800,7 +2800,7 @@ class RunEngineManager(Process):
         unless RE Manager is idle. To run the update in the background thread, call the API with
         ``run_in_background=True``.
         """
-        logger.info("Uploading RE environment ...")
+        logger.info("Updating RE environment ...")
         try:
             supported_param_names = ["run_in_background", "lock_key"]
             self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1802,15 +1802,21 @@ class RunEngineManager(Process):
         Returns config information.
         """
         success, msg = True, ""
-        if self._use_ipython_kernel and self._environment_exists:
-            payload, msg = await self._worker_request_ip_connect_info()
-            ip_connect_info = payload.get("ip_connect_info", {})
-        else:
-            ip_connect_info = {}
+        try:
+            supported_param_names = []
+            self._check_request_for_unsupported_params(request=request, param_names=supported_param_names)
 
-        config = {
-            "ip_connect_info": ip_connect_info,
-        }
+            if self._use_ipython_kernel and self._environment_exists:
+                payload, msg = await self._worker_request_ip_connect_info()
+                ip_connect_info = payload.get("ip_connect_info", {})
+            else:
+                ip_connect_info = {}
+
+            config = {
+                "ip_connect_info": ip_connect_info,
+            }
+        except Exception as ex:
+            success, msg, config = False, str(ex), {}
 
         return {"success": success, "msg": msg, "config": config}
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -612,6 +612,12 @@ def load_script_into_existing_nspace(
     """
     global _n_running_scripts
 
+    # There is nothing to do if the script is an empty string or None
+    if not script:
+        return
+    elif not isinstance(script, str):
+        ScriptLoadingError(f"Script must be a string: (type(script)={type(script)!r})", "")
+
     importlib.invalidate_caches()
 
     root_path_exists = script_root_path and os.path.isdir(script_root_path)

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -64,6 +64,9 @@ qserver environment open         # Open RE environment
 qserver environment close        # Close RE environment
 qserver environment destroy      # Destroy RE environment (kill RE worker process)
 
+qserver environment update             # Update the worker state based on contents of worker namespace
+qserver environment update background  # Update the worker state as a background task
+
 qserver existing plans           # Request the list of existing plans
 qserver existing devices         # Request the list of existing devices
 qserver allowed plans            # Request the list of allowed plans
@@ -864,10 +867,23 @@ def create_msg(params, *, lock_key):
 
     # ----------- environment ------------
     elif command == "environment":
-        if len(params) != 1:
-            raise CommandParameterError(f"Request '{command}' must include only one parameter")
-        supported_params = ("open", "close", "destroy")
+        if len(params) not in (1, 2):
+            raise CommandParameterError(f"Request '{command}' must include at one or two parameters")
+        supported_params = ("open", "close", "destroy", "update")
         if params[0] in supported_params:
+            if params[0] == "update":
+                if len(params) == 2:
+                    if params[1] == "background":
+                        prms["run_in_background"] = True
+                    else:
+                        raise CommandParameterError(
+                            f"Request '{command} {params[0]} {params[1]}' is not supported"
+                        )
+            else:
+                if len(params) == 2:
+                    raise CommandParameterError(
+                        f"Request '{command} {params[1]}' may have no additional parameters"
+                    )
             method = f"{command}_{params[0]}"
             if lock_key:
                 prms["lock_key"] = lock_key

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -173,6 +173,11 @@ qserver script upload <path-to-file> keep-lists   # ... leave lists of allowed a
 qserver task result <task-uid>  # Load status or result of a task with the given UID
 qserver task status <task-uid>  # Check status of a task with the given UID
 
+qserver kernel interrupt            # Send interrupt (Ctrl-C) to IPython kernel
+qserver kernel interrupt task       # ... if the manager is executing a task
+qserver kernel interrupt plan       # ... if the manager is executing a plan
+qserver kernel interrupt task plan  # ... if the manager is executing a plan or a task
+
 qserver lock environment  -k 90g94                   # Lock the environment
 qserver lock environment "Locked for 1 hr" -k 90g94  # Add a text note
 qserver lock queue -k 90g94                          # Lock the queue
@@ -1142,6 +1147,22 @@ def create_msg(params, *, lock_key):
                 raise CommandParameterError(
                     f"Unsupported number or combination of parameters: {format_list_as_command(params)}"
                 )
+        else:
+            raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
+
+    elif command == "kernel":
+        if len(params) < 1:
+            raise CommandParameterError(f"Request '{command}' must include at least one parameter")
+        if params[0] == "interrupt":
+            method = f"{command}_{params[0]}"
+            prms = {}
+            for p in params[1:]:
+                if p not in ("task", "plan"):
+                    raise CommandParameterError(f"Unsupported parameter {p!r}: {format_list_as_command(params)}")
+                if p == "task":
+                    prms.update(dict(interrupt_task=True))
+                elif p == "plan":
+                    prms.update(dict(interrupt_plan=True))
         else:
             raise CommandParameterError(f"Request '{command} {params[0]}' is not supported")
 

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -277,6 +277,10 @@ def condition_manager_paused(msg):
     return msg["manager_state"] == "paused"
 
 
+def condition_manager_idle_or_paused(msg):
+    return ("manager_state" in msg) and (msg["manager_state"] in ("idle", "paused"))
+
+
 def condition_manager_executing_queue(msg):
     return ("manager_state" in msg) and (msg["manager_state"] == "executing_queue")
 

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -242,7 +242,7 @@ def zmq_secure_request(method, params=None, *, zmq_server_address=None, server_p
     )
 
 
-def get_queue_state():
+def get_manager_status():
     method, params = "status", None
     msg, _ = zmq_secure_request(method, params)
     if msg is None:
@@ -261,8 +261,8 @@ def get_queue():
     return msg
 
 
-def get_reduced_state_info():
-    msg = get_queue_state()
+def get_queue_state():
+    msg = get_manager_status()
     items_in_queue = msg["items_in_queue"]
     queue_is_running = msg["manager_state"] == "executing_queue"
     items_in_history = msg["items_in_history"]
@@ -317,7 +317,7 @@ def wait_for_condition(time, condition):
     while ttime.time() < time_stop:
         ttime.sleep(dt / 2)
         try:
-            msg = get_queue_state()
+            msg = get_manager_status()
             if condition(msg):
                 return True
         except TimeoutError:

--- a/bluesky_queueserver/manager/tests/test_comms.py
+++ b/bluesky_queueserver/manager/tests/test_comms.py
@@ -74,11 +74,13 @@ def test_CommJsonRpcError_3_fail():
     err_msg, err_code, err_type = "Some error occured", 25, "RuntimeError"
     ex = CommJsonRpcError(err_msg, err_code, err_type)
 
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    # The pattern 'can't set attribute': Python 3.10 and older
+    # The pattern 'object has no setter': Python 3.11
+    with pytest.raises(AttributeError, match="can't set attribute|object has no setter"):
         ex.message = err_msg
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    with pytest.raises(AttributeError, match="can't set attribute|object has no setter"):
         ex.error_code = err_code
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    with pytest.raises(AttributeError, match="can't set attribute|object has no setter"):
         ex.error_type = err_type
 
 

--- a/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
+++ b/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
@@ -20,7 +20,7 @@ from .common import (
     condition_manager_paused,
     condition_queue_processing_finished,
     copy_default_profile_collection,
-    get_queue_state,
+    get_manager_status,
     use_ipykernel_for_tests,
     wait_for_condition,
     wait_for_task_result,
@@ -123,7 +123,7 @@ def test_ip_kernel_run_plans_01(re_manager, plan_option, resume_option):  # noqa
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state, pprint.pformat(status)
@@ -159,7 +159,7 @@ def test_ip_kernel_run_plans_01(re_manager, plan_option, resume_option):  # noqa
         else:
             assert False, f"Unsupported option: {plan_option!r}"
 
-        s = get_queue_state()  # Kernel may not be 'captured' at this point
+        s = get_manager_status()  # Kernel may not be 'captured' at this point
         assert s["manager_state"] in ("starting_queue", "executing_queue")
         assert s["worker_environment_state"] in ("idle", "executing_plan")
 
@@ -184,7 +184,7 @@ def test_ip_kernel_run_plans_01(re_manager, plan_option, resume_option):  # noqa
         assert resp["success"] is True, pprint.pformat(resp)
 
         if resume_option == "resume":
-            s = get_queue_state()  # Kernel may not be 'captured' at this point
+            s = get_manager_status()  # Kernel may not be 'captured' at this point
             assert s["manager_state"] == "executing_queue"
             assert s["worker_environment_state"] in ("idle", "executing_plan")
 
@@ -196,7 +196,7 @@ def test_ip_kernel_run_plans_01(re_manager, plan_option, resume_option):  # noqa
 
         assert wait_for_condition(time=20, condition=condition_manager_idle)
 
-        s = get_queue_state()
+        s = get_manager_status()
         n_items_in_queue = 1 if resume_option in ["halt", "abort"] and plan_option == "queue" else 0
         assert s["items_in_queue"] == n_items_in_queue
         assert s["items_in_history"] == 1
@@ -238,7 +238,7 @@ def test_ip_kernel_run_plans_02(re_manager, ip_kernel_simple_client, plan_option
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -293,7 +293,7 @@ def test_ip_kernel_run_plans_02(re_manager, ip_kernel_simple_client, plan_option
 
     assert wait_for_condition(time=20, condition=condition_manager_idle)
 
-    s = get_queue_state()
+    s = get_manager_status()
     n_items_in_queue = 1 if resume_option in ["halt", "abort"] and plan_option == "queue" else 0
     n_items_in_queue = n_items_in_queue if plan_option == "plan" else n_items_in_queue + 1
     assert s["items_in_queue"] == n_items_in_queue
@@ -349,7 +349,7 @@ def test_ip_kernel_run_plans_03(re_manager, ip_kernel_simple_client, plan_option
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -411,7 +411,7 @@ def test_ip_kernel_run_plans_03(re_manager, ip_kernel_simple_client, plan_option
     assert wait_for_condition(time=20, condition=condition_manager_idle)
     assert wait_for_condition(time=20, condition=condition_ip_kernel_idle)
 
-    s = get_queue_state()
+    s = get_manager_status()
     n_items_in_queue = 0 if plan_option == "plan" else 2
     assert s["items_in_queue"] == n_items_in_queue
     assert s["items_in_history"] == 1
@@ -449,7 +449,7 @@ def test_ip_kernel_run_plans_04(re_manager, ip_kernel_simple_client, plan_option
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -515,7 +515,7 @@ def test_ip_kernel_run_plans_04(re_manager, ip_kernel_simple_client, plan_option
     assert resp["success"] is True, pprint.pformat(resp)
 
     if resume_option == "resume":
-        s = get_queue_state()  # Kernel may not be 'captured' at this point
+        s = get_manager_status()  # Kernel may not be 'captured' at this point
         assert s["manager_state"] == "executing_queue"
         assert s["worker_environment_state"] in ("idle", "executing_plan")
 
@@ -527,7 +527,7 @@ def test_ip_kernel_run_plans_04(re_manager, ip_kernel_simple_client, plan_option
 
     assert wait_for_condition(time=20, condition=condition_manager_idle)
 
-    s = get_queue_state()
+    s = get_manager_status()
 
     if resume_option in ["halt", "abort"]:
         n_items_in_queue = 0 if plan_option == "plan" else 2
@@ -578,7 +578,7 @@ def test_ip_kernel_execute_tasks_01(re_manager, option, run_in_background):  # n
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -634,7 +634,7 @@ def test_ip_kernel_execute_tasks_01(re_manager, option, run_in_background):  # n
         assert False, f"Unsupported option: {option!r}"
 
     if not run_in_background:
-        s = get_queue_state()  # Kernel may or may not be captured at this point
+        s = get_manager_status()  # Kernel may or may not be captured at this point
         assert s["manager_state"] == "executing_task"
         assert s["worker_environment_state"] in ("idle", "executing_task")
 
@@ -678,7 +678,7 @@ def test_ip_kernel_execute_tasks_02(re_manager):  # noqa: F811
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -765,7 +765,7 @@ def test_ip_kernel_direct_connection_01(re_manager, ip_kernel_simple_client):  #
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -820,7 +820,7 @@ def test_ip_kernel_direct_connection_02(re_manager, ip_kernel_simple_client, pla
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -909,7 +909,7 @@ def test_ip_kernel_direct_connection_03(re_manager, ip_kernel_simple_client, opt
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -994,7 +994,7 @@ def test_ip_kernel_direct_connection_04(re_manager, ip_kernel_simple_client, opt
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -1098,7 +1098,7 @@ def test_ip_kernel_reserve_01(re_manager, option):  # noqa: F811
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -1210,7 +1210,7 @@ def test_ip_kernel_interrupt_02(re_manager, ip_kernel_simple_client, option):  #
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -1318,7 +1318,7 @@ def test_ip_kernel_interrupt_03(
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state
@@ -1353,7 +1353,7 @@ def test_ip_kernel_interrupt_03(
 
     assert wait_for_condition(5, condition_manager_idle_or_paused)
 
-    status = get_queue_state()
+    status = get_manager_status()
     if is_paused:
         assert status["manager_state"] == "paused"
 
@@ -1366,7 +1366,7 @@ def test_ip_kernel_interrupt_03(
         # Plan was completed
         assert status["manager_state"] == "idle"
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["items_in_queue"] == 0
     assert status["items_in_history"] == 1
 
@@ -1423,7 +1423,7 @@ def test_ip_kernel_interrupt_04(
 
     def check_status(ip_kernel_state, ip_kernel_captured):
         # Returned status may be used to do additional checks
-        status = get_queue_state()
+        status = get_manager_status()
         if isinstance(ip_kernel_state, (str, type(None))):
             ip_kernel_state = [ip_kernel_state]
         assert status["ip_kernel_state"] in ip_kernel_state

--- a/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
+++ b/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
@@ -1136,7 +1136,7 @@ def test_ip_kernel_reserve_01(re_manager, option):  # noqa: F811
         check_status("busy", True)
         ttime.sleep(t_reserve - 0.5)
         check_status("busy", True)
-        ttime.sleep(1)
+        ttime.sleep(2)
         check_status("idle", False)
     else:
         assert False, f"Unknown option: {option!r}"
@@ -1273,6 +1273,8 @@ def test_ip_kernel_interrupt_02(re_manager, ip_kernel_simple_client, option):  #
         result = resp["result"]
         assert result["success"] is False, pprint.pformat(result)
         assert "KeyboardInterrupt" in result["traceback"], pprint.pformat(result)
+
+    ttime.sleep(1)  # The pause makes it more reliable on CI
 
     # Now run a simple plan to make sure the worker is still functional
     params = {"item": _plan1, "user": _user, "user_group": _user_group}

--- a/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
+++ b/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
@@ -16,6 +16,7 @@ from .common import (
     condition_ip_kernel_busy,
     condition_ip_kernel_idle,
     condition_manager_idle,
+    condition_manager_idle_or_paused,
     condition_manager_paused,
     condition_queue_processing_finished,
     copy_default_profile_collection,
@@ -1084,7 +1085,7 @@ def test_ip_kernel_direct_connection_04(re_manager, ip_kernel_simple_client, opt
 @pytest.mark.parametrize("option", ["single", "repeated"])
 # fmt: on
 @pytest.mark.skipif(not use_ipykernel_for_tests(), reason="Test is run only with IPython worker")
-def test_ip_kernel_reserve_01(re_manager, ip_kernel_simple_client, option):  # noqa: F811
+def test_ip_kernel_reserve_01(re_manager, option):  # noqa: F811
     """
     Test if the internal functionality for reserving IPython kernel works as expected:
     kernel is reserved upon request and stayed reserved for preset period; repeated
@@ -1171,6 +1172,214 @@ def test_ip_kernel_interrupt_01(re_manager):  # noqa: F811
 
     if using_ipython:
         ttime.sleep(0.5)  # Short pause may be needed
+
+    resp9, _ = zmq_single_request("environment_close")
+    assert resp9["success"] is True
+    assert resp9["msg"] == ""
+
+    assert wait_for_condition(time=3, condition=condition_environment_closed)
+
+
+_busy_script_01 = """
+import time
+for n in range(30):
+    time.sleep(1)
+"""
+
+_busy_script_02 = """
+# Define function
+import time
+
+def func_for_test_sleep():
+    for n in range(30):
+        time.sleep(1)
+"""
+
+
+# fmt: off
+@pytest.mark.parametrize("option", ["ip_client", "script", "func"])
+# fmt: on
+@pytest.mark.skipif(not use_ipykernel_for_tests(), reason="Test is run only with IPython worker")
+def test_ip_kernel_interrupt_02(re_manager, ip_kernel_simple_client, option):  # noqa: F811
+    """
+    "kernel_interrupt": test that the API interrupts a command started using IP client, an upload
+    of a script ('script_upload' API) or execution of a function ('function_execute' API).
+    """
+    using_ipython = use_ipykernel_for_tests()
+    assert using_ipython, "The test can be run only in IPython mode"
+
+    def check_status(ip_kernel_state, ip_kernel_captured):
+        # Returned status may be used to do additional checks
+        status = get_queue_state()
+        if isinstance(ip_kernel_state, (str, type(None))):
+            ip_kernel_state = [ip_kernel_state]
+        assert status["ip_kernel_state"] in ip_kernel_state
+        assert status["ip_kernel_captured"] == ip_kernel_captured
+        return status
+
+    resp2, _ = zmq_single_request("environment_open")
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    task_uid = None
+
+    if option == "ip_client":
+        ip_kernel_simple_client.start()
+        ip_kernel_simple_client.execute_with_check(_busy_script_01)
+        params_interrupt = {}
+    elif option == "script":
+        resp, _ = zmq_single_request("script_upload", params=dict(script=_busy_script_01))
+        assert resp["success"] is True, pprint.pformat(resp)
+        task_uid = resp["task_uid"]
+
+        params_interrupt = {"interrupt_task": True}
+    elif option == "func":
+        resp, _ = zmq_single_request("script_upload", params=dict(script=_busy_script_02))
+        assert resp["success"] is True, pprint.pformat(resp)
+        assert wait_for_condition(3, condition_manager_idle)
+
+        func_item = {"name": "func_for_test_sleep", "item_type": "function"}
+        params = {"item": func_item, "user": _user, "user_group": _user_group}
+        resp, _ = zmq_single_request("function_execute", params=params)
+        assert resp["success"] is True, pprint.pformat(resp)
+        task_uid = resp["task_uid"]
+
+        params_interrupt = {"interrupt_task": True}
+    else:
+        assert False, f"Unknown option {option!r}"
+
+    ttime.sleep(2)
+
+    ip_kernel_captured = (option != "ip_client")
+    check_status("busy", ip_kernel_captured)
+
+    resp2, _ = zmq_single_request("kernel_interrupt", params=params_interrupt)
+    assert resp2["success"] is True, pprint.pformat(resp2)
+    assert resp2["msg"] == "", pprint.pformat(resp2)
+
+    if option == "ip_client":
+        assert wait_for_condition(3, condition_ip_kernel_idle)
+    else:
+        assert wait_for_condition(3, condition_manager_idle)
+
+    check_status("idle", False)
+
+    if task_uid:
+        resp, _ = zmq_single_request("task_result", params={"task_uid": task_uid})
+        assert resp["success"] is True, pprint.pformat(resp)
+
+        result = resp["result"]
+        assert result["success"] is False, pprint.pformat(result)
+        assert "KeyboardInterrupt" in result["traceback"], pprint.pformat(result)
+
+    # Now run a simple plan to make sure the worker is still functional
+    params = {"item": _plan1, "user": _user, "user_group": _user_group}
+    resp, _ = zmq_single_request("queue_item_add", params)
+    assert resp["success"] is True
+    resp, _ = zmq_single_request("queue_start")
+    assert resp["success"] is True
+    assert wait_for_condition(3, condition_queue_processing_finished)
+    status, _ = zmq_single_request("status")
+    assert status["items_in_queue"] == 0
+    assert status["items_in_history"] == 1
+
+    resp9, _ = zmq_single_request("environment_close")
+    assert resp9["success"] is True
+    assert resp9["msg"] == ""
+
+    assert wait_for_condition(time=3, condition=condition_environment_closed)
+
+
+_plan5_slow = {"name": "count", "args": [["det1", "det2"]], "kwargs": {"num": 2, "delay": 3}, "item_type": "plan"}
+
+
+# fmt: off
+@pytest.mark.parametrize("plan, pause_option, delay, is_paused", [
+    (_plan4, "deferred", 4, True),
+    (_plan4, "immediate", 4, True),
+    # The plan is paused during the 2nd (last) step, so the deferred pause will let the plan run
+    #   to completion and immediate pause should actually pause the plan.
+    (_plan5_slow, "deferred", 4, False),
+    (_plan5_slow, "immediate", 4, True),
+])
+# fmt: on
+@pytest.mark.skipif(not use_ipykernel_for_tests(), reason="Test is run only with IPython worker")
+def test_ip_kernel_interrupt_03(
+    re_manager, ip_kernel_simple_client, plan, pause_option, delay, is_paused  # noqa: F811
+):
+    """
+    "kernel_interrupt": test that the API can be used to cause deferred or immediate pause of a running plan.
+    This is not recommended way of pausing a plan, but it still should work.
+    """
+    using_ipython = use_ipykernel_for_tests()
+    assert using_ipython, "The test can be run only in IPython mode"
+
+    def check_status(ip_kernel_state, ip_kernel_captured):
+        # Returned status may be used to do additional checks
+        status = get_queue_state()
+        if isinstance(ip_kernel_state, (str, type(None))):
+            ip_kernel_state = [ip_kernel_state]
+        assert status["ip_kernel_state"] in ip_kernel_state
+        assert status["ip_kernel_captured"] == ip_kernel_captured
+        return status
+
+    resp2, _ = zmq_single_request("environment_open")
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    params = {"item": plan, "user": _user, "user_group": _user_group}
+    resp, _ = zmq_single_request("queue_item_add", params)
+    assert resp["success"] is True
+    resp, _ = zmq_single_request("queue_start")
+    assert resp["success"] is True
+
+    ttime.sleep(delay)
+
+    params_interrupt = dict(interrupt_plan=True)
+    if pause_option == "deferred":
+        resp, _ = zmq_single_request("kernel_interrupt", params=params_interrupt)
+        assert resp["success"] is True, pprint.pformat(resp)
+    elif pause_option == "immediate":
+        resp, _ = zmq_single_request("kernel_interrupt", params=params_interrupt)
+        assert resp["success"] is True, pprint.pformat(resp)
+        resp, _ = zmq_single_request("kernel_interrupt", params=params_interrupt)
+        assert resp["success"] is True, pprint.pformat(resp)
+    else:
+        assert False, f"Unknown pause option: {pause_option!r}"
+
+    assert wait_for_condition(5, condition_manager_idle_or_paused)
+
+    status = get_queue_state()
+    if is_paused:
+        assert status["manager_state"] == "paused"
+
+        resp, _ = zmq_single_request("re_resume")
+        assert resp["success"] is True
+
+        assert wait_for_condition(20, condition_queue_processing_finished)
+
+    else:
+        # Plan was completed
+        assert status["manager_state"] == "idle"
+
+    status = get_queue_state()
+    assert status["items_in_queue"] == 0
+    assert status["items_in_history"] == 1
+
+    # Now run a simple plan to make sure the worker is still functional
+    params = {"item": _plan1, "user": _user, "user_group": _user_group}
+    resp, _ = zmq_single_request("queue_item_add", params)
+    assert resp["success"] is True
+    resp, _ = zmq_single_request("queue_start")
+    assert resp["success"] is True
+    assert wait_for_condition(3, condition_queue_processing_finished)
+    status, _ = zmq_single_request("status")
+    assert status["items_in_queue"] == 0
+    assert status["items_in_history"] == 2
 
     resp9, _ = zmq_single_request("environment_close")
     assert resp9["success"] is True

--- a/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
+++ b/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
@@ -1147,3 +1147,33 @@ def test_ip_kernel_reserve_01(re_manager, ip_kernel_simple_client, option):  # n
     assert wait_for_condition(time=3, condition=condition_environment_closed)
 
     check_status(None, None)
+
+
+def test_ip_kernel_interrupt_01(re_manager):  # noqa: F811
+    """
+    "kernel_interrupt": basic test. API call succeeds if IP kernel is active and fails otherwise.
+    """
+    using_ipython = use_ipykernel_for_tests()
+
+    resp2, _ = zmq_single_request("environment_open")
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    resp2, _ = zmq_single_request("kernel_interrupt")
+    if using_ipython:
+        assert resp2["success"] is True, pprint.pformat(resp2)
+        assert resp2["msg"] == "", pprint.pformat(resp2)
+    else:
+        assert resp2["success"] is False, pprint.pformat(resp2)
+        assert "RE Manager is not in IPython mode: IPython kernel is not used" in resp2["msg"]
+
+    if using_ipython:
+        ttime.sleep(0.5)  # Short pause may be needed
+
+    resp9, _ = zmq_single_request("environment_close")
+    assert resp9["success"] is True
+    assert resp9["msg"] == ""
+
+    assert wait_for_condition(time=3, condition=condition_environment_closed)

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -1617,8 +1617,7 @@ for n in range(30):
 @pytest.mark.skipif(not use_ipykernel_for_tests(), reason="Test is run only with IPython worker")
 def test_qserver_kernel_interrupt_01(re_manager, ip_kernel_simple_client, option):  # noqa: F811
     """
-    "kernel_interrupt": test that the API interrupts a command started using IP client, an upload
-    of a script ('script_upload' API) or execution of a function ('function_execute' API).
+    "qserver kernel interrupt":  basic test.
     """
     using_ipython = use_ipykernel_for_tests()
     assert using_ipython, "The test can be run only in IPython mode"

--- a/bluesky_queueserver/manager/tests/test_qserver_cli.py
+++ b/bluesky_queueserver/manager/tests/test_qserver_cli.py
@@ -16,9 +16,9 @@ from .common import (  # noqa: F401
     condition_manager_idle,
     condition_manager_paused,
     condition_queue_processing_finished,
+    get_manager_status,
     get_queue,
     get_queue_state,
-    get_reduced_state_info,
     patch_first_startup_file,
     patch_first_startup_file_undo,
     re_manager,
@@ -67,14 +67,14 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "queue", "add", "plan", plan_2]) == SUCCESS
     assert subprocess.call(["qserver", "queue", "add", "plan", plan_3]) == SUCCESS
 
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 3, "Incorrect number of plans in the queue"
     assert not is_plan_running, "Plan is executed while it shouldn't"
 
     assert subprocess.call(["qserver", "queue", "get"]) == SUCCESS
     assert subprocess.call(["qserver", "queue", "item", "remove"]) == SUCCESS
 
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 2, "Incorrect number of plans in the queue"
 
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
@@ -91,7 +91,7 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     # Queue is expected to be empty (processed). Load one more plan.
     assert subprocess.call(["qserver", "queue", "add", "plan", plan_3]) == SUCCESS
 
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 1, "Incorrect number of plans in the queue"
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
@@ -117,7 +117,7 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "queue", "add", "plan", plan_1]) == SUCCESS
     assert subprocess.call(["qserver", "queue", "add", "plan", plan_1]) == SUCCESS
 
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 2, "Incorrect number of plans in the queue"
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
@@ -132,7 +132,7 @@ def test_qserver_cli_and_manager(re_manager):  # noqa: F811
     assert subprocess.call(["qserver", "queue", "add", "plan", plan_3]) == SUCCESS
     assert subprocess.call(["qserver", "queue", "add", "plan", plan_3]) == SUCCESS
     assert subprocess.call(["qserver", "queue", "add", "plan", plan_3]) == SUCCESS
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 3, "Incorrect number of plans in the queue"
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
@@ -163,7 +163,7 @@ def test_qserver_environment_close(re_manager):  # noqa: F811
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':5, 'delay':1}}"
     assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == SUCCESS
 
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 1, "Incorrect number of plans in the queue"
     assert is_plan_running is False
 
@@ -172,7 +172,7 @@ def test_qserver_environment_close(re_manager):  # noqa: F811
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
     ttime.sleep(2)
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 0, "Incorrect number of plans in the queue"
     assert is_plan_running is True
 
@@ -183,7 +183,7 @@ def test_qserver_environment_close(re_manager):  # noqa: F811
         time=60, condition=condition_queue_processing_finished
     ), "Timeout while waiting for process to finish"
 
-    n_plans, is_plan_running, n_history = get_reduced_state_info()
+    n_plans, is_plan_running, n_history = get_queue_state()
     assert n_plans == 0, "Incorrect number of plans in the queue"
     assert is_plan_running is False
     assert n_history == 1
@@ -209,7 +209,7 @@ def test_qserver_environment_destroy(re_manager):  # noqa: F811
     plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':5, 'delay':1}}"
     assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == SUCCESS
 
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 1, "Incorrect number of plans in the queue"
     assert is_plan_running is False
 
@@ -218,7 +218,7 @@ def test_qserver_environment_destroy(re_manager):  # noqa: F811
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
     ttime.sleep(2)
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 0, "Incorrect number of plans in the queue"
     assert is_plan_running is True
 
@@ -227,7 +227,7 @@ def test_qserver_environment_destroy(re_manager):  # noqa: F811
         time=3, condition=condition_manager_idle
     ), "Timeout while waiting for environment to be destroyed."
 
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 1, "Incorrect number of plans in the queue"
     assert is_plan_running is False
 
@@ -236,7 +236,7 @@ def test_qserver_environment_destroy(re_manager):  # noqa: F811
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
     ttime.sleep(2)
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 0, "Incorrect number of plans in the queue"
     assert is_plan_running is True
 
@@ -244,7 +244,7 @@ def test_qserver_environment_destroy(re_manager):  # noqa: F811
         time=60, condition=condition_queue_processing_finished
     ), "Timeout while waiting for process to finish"
 
-    n_plans, is_plan_running, n_history = get_reduced_state_info()
+    n_plans, is_plan_running, n_history = get_queue_state()
     assert n_plans == 0, "Incorrect number of plans in the queue"
     assert is_plan_running is False
     assert n_history == 2
@@ -253,6 +253,45 @@ def test_qserver_environment_destroy(re_manager):  # noqa: F811
     assert wait_for_condition(
         time=5, condition=condition_environment_closed
     ), "Timeout while waiting for environment to be closed"
+
+
+# fmt: off
+@pytest.mark.parametrize("run_in_background", [False, True])
+# fmt: on
+def test_qserver_environment_update_01(re_manager, run_in_background):  # noqa: F811
+    """
+    Test for `environment_update` command (more of a 'smoke' test)
+    """
+    plan = "{'name':'count', 'args':[['det1', 'det2']], 'kwargs':{'num':5, 'delay':1}}"
+    assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == SUCCESS
+
+    n_plans, _, _ = get_queue_state()
+    assert n_plans == 1, "Incorrect number of plans in the queue"
+
+    assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    env_update_params = ["qserver", "environment", "update"]
+    if run_in_background:
+        env_update_params.append("background")
+
+    assert subprocess.call(env_update_params) == SUCCESS
+
+    ttime.sleep(1)
+
+    assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
+    n_plans, is_plan_running, _ = get_queue_state()
+    assert n_plans == 0, "Incorrect number of plans in the queue"
+    assert is_plan_running is True
+
+    ttime.sleep(2)
+
+    assert subprocess.call(env_update_params) == SUCCESS if run_in_background else REQ_FAILED
+
+    assert wait_for_condition(time=20, condition=condition_queue_processing_finished)
+
+    assert subprocess.call(["qserver", "environment", "close"]) == SUCCESS
+    assert wait_for_condition(time=5, condition=condition_environment_closed)
 
 
 # fmt: off
@@ -283,7 +322,7 @@ def test_qserver_re_pause_continue(re_manager, option_pause, option_continue):  
     assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == SUCCESS
     assert subprocess.call(["qserver", "queue", "add", "plan", plan]) == SUCCESS
 
-    n_plans, is_plan_running, _ = get_reduced_state_info()
+    n_plans, is_plan_running, _ = get_queue_state()
     assert n_plans == 2, "Incorrect number of plans in the queue"
     assert is_plan_running is False
 
@@ -301,10 +340,10 @@ def test_qserver_re_pause_continue(re_manager, option_pause, option_continue):  
         time=3, condition=condition_manager_paused
     ), "Timeout while waiting for manager to pause"
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["manager_state"] == "paused"
 
-    n_plans, is_plan_running, n_history = get_reduced_state_info()
+    n_plans, is_plan_running, n_history = get_queue_state()
     assert n_plans == 1, "Incorrect number of plans in the queue"
     assert is_plan_running is False
     assert n_history == 0
@@ -319,7 +358,7 @@ def test_qserver_re_pause_continue(re_manager, option_pause, option_continue):  
     else:
         assert wait_for_condition(time=3, condition=condition_manager_idle)
 
-        n_plans, is_plan_running, n_history = get_reduced_state_info()
+        n_plans, is_plan_running, n_history = get_queue_state()
         assert n_plans == (1 if option_continue == "stop" else 2), "Incorrect number of plans in the queue"
         assert is_plan_running is False
         assert n_history == 1
@@ -331,7 +370,7 @@ def test_qserver_re_pause_continue(re_manager, option_pause, option_continue):  
 
     ttime.sleep(1)
 
-    n_plans, is_plan_running, n_history = get_reduced_state_info()
+    n_plans, is_plan_running, n_history = get_queue_state()
     assert n_plans == (0 if option_continue == "stop" else 1), "Incorrect number of plans in the queue"
     assert is_plan_running is True
     assert n_history == n_history_expected - (1 if option_continue == "stop" else 2)
@@ -340,7 +379,7 @@ def test_qserver_re_pause_continue(re_manager, option_pause, option_continue):  
         time=60, condition=condition_queue_processing_finished
     ), "Timeout while waiting for process to finish"
 
-    n_plans, is_plan_running, n_history = get_reduced_state_info()
+    n_plans, is_plan_running, n_history = get_queue_state()
     assert n_plans == 0, "Incorrect number of plans in the queue"
     assert is_plan_running is False
     assert n_history == n_history_expected
@@ -389,7 +428,7 @@ def test_qserver_manager_kill(re_manager, time_kill):  # noqa: F811
         assert subprocess.call(["qserver", "manager", "kill", "test"]) == COM_ERROR
         ttime.sleep(8)  # It takes 5 seconds before the manager is restarted
 
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["manager_state"] == "idle"
 
     # Start queue processing
@@ -401,7 +440,7 @@ def test_qserver_manager_kill(re_manager, time_kill):  # noqa: F811
         assert subprocess.call(["qserver", "manager", "kill", "test"]) == COM_ERROR
         ttime.sleep(8)  # It takes 5 seconds before the manager is restarted
 
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["manager_state"] == "executing_queue"
 
     elif time_kill == "paused":
@@ -411,7 +450,7 @@ def test_qserver_manager_kill(re_manager, time_kill):  # noqa: F811
         assert subprocess.call(["qserver", "manager", "kill", "test"]) == COM_ERROR
         ttime.sleep(8)  # It takes 5 seconds before the manager is restarted
 
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["manager_state"] == "paused"
 
         assert subprocess.call(["qserver", "re", "resume"]) == SUCCESS
@@ -420,7 +459,7 @@ def test_qserver_manager_kill(re_manager, time_kill):  # noqa: F811
         time=60, condition=condition_queue_processing_finished
     ), "Timeout while waiting for process to finish"
 
-    n_plans, is_plan_running, n_history = get_reduced_state_info()
+    n_plans, is_plan_running, n_history = get_queue_state()
     assert n_plans == 0, "Incorrect number of plans in the queue"
     assert is_plan_running is False
     assert n_history == 2
@@ -466,7 +505,7 @@ def test_qserver_env_open_various_cases(re_manager_pc_copy, additional_code, suc
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
     assert wait_for_condition(time=30, condition=condition_manager_idle)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["worker_environment_exists"] == success
 
     if not success:
@@ -482,11 +521,11 @@ def test_qserver_env_open_various_cases(re_manager_pc_copy, additional_code, suc
     # Start queue processing
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
     ttime.sleep(2)
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["manager_state"] == "executing_queue"
 
     assert wait_for_condition(time=60, condition=condition_queue_processing_finished)
-    n_plans, is_plan_running, n_history = get_reduced_state_info()
+    n_plans, is_plan_running, n_history = get_queue_state()
     assert n_plans == 0, "Incorrect number of plans in the queue"
     assert is_plan_running is False
     assert n_history == 1
@@ -539,7 +578,7 @@ def test_qserver_manager_stop_2(re_manager, option):  # noqa: F811
 
     assert subprocess.call(["qserver", "queue", "start"]) == SUCCESS
     ttime.sleep(2)
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["manager_state"] == "executing_queue"
 
     cmd = ["qserver", "manager", "stop"]
@@ -556,7 +595,7 @@ def test_qserver_manager_stop_2(re_manager, option):  # noqa: F811
         assert subprocess.call(cmd) == REQ_FAILED
 
         assert wait_for_condition(time=60, condition=condition_queue_processing_finished)
-        n_plans, is_plan_running, n_history = get_reduced_state_info()
+        n_plans, is_plan_running, n_history = get_queue_state()
         assert n_plans == 0, "Incorrect number of plans in the queue"
         assert is_plan_running is False
         assert n_history == 2
@@ -567,19 +606,19 @@ def test_qserver_queue_mode_set_1(re_manager):  # noqa F811
     Basic test for ``qserver queue mode set`` command
     """
     assert subprocess.call(["qserver", "queue", "mode", "set", "loop", "True"]) == SUCCESS
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["plan_queue_mode"]["loop"] is True
 
     assert subprocess.call(["qserver", "queue", "mode", "set", "loop", "False"]) == SUCCESS
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["plan_queue_mode"]["loop"] is False
 
     assert subprocess.call(["qserver", "queue", "mode", "set", "ignore_failures", "True"]) == SUCCESS
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["plan_queue_mode"]["ignore_failures"] is True
 
     assert subprocess.call(["qserver", "queue", "mode", "set", "ignore_failures", "False"]) == SUCCESS
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["plan_queue_mode"]["ignore_failures"] is False
 
 
@@ -607,15 +646,15 @@ def test_qserver_queue_autostart_1(re_manager):  # noqa F811
     """
     Basic test for ``qserver queue autostart`` command
     """
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is False
 
     assert subprocess.call(["qserver", "queue", "autostart", "enable"]) == SUCCESS
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True
 
     assert subprocess.call(["qserver", "queue", "autostart", "disable"]) == SUCCESS
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is False
 
 
@@ -920,7 +959,7 @@ def test_qserver_item_execute_1(re_manager, item_type, env_exists):  # noqa: F81
             time=5, condition=condition_environment_closed
         ), "Timeout while waiting for environment to be closed"
 
-    n_plans, is_plan_running, n_history = get_reduced_state_info()
+    n_plans, is_plan_running, n_history = get_queue_state()
     assert n_plans == 0
     assert is_plan_running is False
     assert n_history == expected_n_history
@@ -1076,30 +1115,30 @@ def test_qserver_queue_stop(re_manager, deactivate):  # noqa: F811
 
     # Queue is not running, so the request is expected to fail
     assert subprocess.call(["qserver", "queue", "stop"]) != 0
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_stop_pending"] is False
 
     assert subprocess.call(["qserver", "queue", "start"]) == 0
     ttime.sleep(2)
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["manager_state"] == "executing_queue"
 
     assert subprocess.call(["qserver", "queue", "stop"]) == 0
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_stop_pending"] is True
 
     if deactivate:
         ttime.sleep(1)
         assert subprocess.call(["qserver", "queue", "stop", "cancel"]) == 0
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["queue_stop_pending"] is False
 
     assert wait_for_condition(time=60, condition=condition_manager_idle)
-    n_plans, is_plan_running, n_history = get_reduced_state_info()
+    n_plans, is_plan_running, n_history = get_queue_state()
     assert n_plans == (0 if deactivate else 1)
     assert is_plan_running is False
     assert n_history == (2 if deactivate else 1)
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_stop_pending"] is False
 
 
@@ -1412,7 +1451,7 @@ def test_qserver_secure_1(monkeypatch, re_manager_cmd, test_mode):  # noqa: F811
     assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
     assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == 2
     assert state["items_in_history"] == 0
 
@@ -1421,7 +1460,7 @@ def test_qserver_secure_1(monkeypatch, re_manager_cmd, test_mode):  # noqa: F811
         time=20, condition=condition_queue_processing_finished
     ), "Timeout while waiting for process to finish"
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == 0
     assert state["items_in_history"] == 2
 
@@ -1479,7 +1518,7 @@ def test_qserver_parameters_1(monkeypatch, re_manager_cmd, test_mode):  # noqa: 
 
 def test_qserver_lock_01(re_manager):  # noqa: F811
     def check_state(environment, queue):
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["lock"]["environment"] == environment
         assert status["lock"]["queue"] == queue
 
@@ -1545,7 +1584,7 @@ def test_qserver_config_01(re_manager, env_open):  # noqa: F811
         assert subprocess.call(["qserver", "environment", "open"]) == SUCCESS
         assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["worker_environment_exists"] == env_open
 
     assert subprocess.call(["qserver", "config"]) == SUCCESS
@@ -1556,7 +1595,7 @@ def test_qserver_config_01(re_manager, env_open):  # noqa: F811
         assert subprocess.call(["qserver", "environment", "close"]) == SUCCESS
         assert wait_for_condition(time=timeout_env_open, condition=condition_environment_closed)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["worker_environment_exists"] is False
 
 
@@ -1570,7 +1609,7 @@ def test_qserver_clear_lock_01(re_manager_cmd):  # noqa: F811
     """
 
     def check_state(environment, queue):
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["lock"]["environment"] == environment
         assert status["lock"]["queue"] == queue
 

--- a/bluesky_queueserver/manager/tests/test_scenarios.py
+++ b/bluesky_queueserver/manager/tests/test_scenarios.py
@@ -16,7 +16,7 @@ from .common import (  # noqa: F401
     condition_manager_paused,
     condition_queue_processing_finished,
     db_catalog,
-    get_queue_state,
+    get_manager_status,
     re_manager,
     re_manager_cmd,
     re_manager_pc_copy,
@@ -125,7 +125,7 @@ class UidChecker:
         self.pq_uid, self.ph_uid = self.get_queue_uids()
 
     def get_queue_uids(self):
-        status = get_queue_state()
+        status = get_manager_status()
         return status["plan_queue_uid"], status["plan_history_uid"]
 
     def verify_uid_changes(self, *, pq_changed, ph_changed):
@@ -426,7 +426,7 @@ def test_blocking_plan_01(re_manager):  # noqa: F811
     resp6, _ = zmq_single_request("re_pause")
     assert resp6["success"] is True, resp6
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["pause_pending"] is True
 
     ttime.sleep(1)
@@ -540,7 +540,7 @@ def test_large_datasets_01(re_manager, background):  # noqa: F811
 
     assert wait_for_condition(time=30, condition=condition_manager_idle)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["items_in_queue"] == 0
     assert status["items_in_history"] == (1 if background else 0)
 
@@ -597,7 +597,7 @@ def test_large_datasets_02(re_manager):  # noqa: F811
 
     assert wait_for_condition(time=30, condition=condition_manager_idle)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["items_in_queue"] == 0
     assert status["items_in_history"] == 1
 
@@ -632,7 +632,7 @@ def test_large_datasets_03(re_manager, plan, n_plans, timeout_ms):  # noqa: F811
     assert "success" in resp, pprint.pformat(resp)
     assert resp["success"] is True, pprint.pformat(resp)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["items_in_queue"] == n_plans
     assert status["items_in_history"] == 0
 
@@ -645,6 +645,6 @@ def test_large_datasets_03(re_manager, plan, n_plans, timeout_ms):  # noqa: F811
     assert "success" in resp, pprint.pformat(resp)
     assert resp["success"] is True, pprint.pformat(resp)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["items_in_queue"] == 0
     assert status["items_in_history"] == 0

--- a/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -22,7 +22,7 @@ from .common import (
     condition_manager_idle,
     condition_queue_processing_finished,
     copy_default_profile_collection,
-    get_queue_state,
+    get_manager_status,
     set_qserver_zmq_address,
     set_qserver_zmq_public_key,
     use_ipykernel_for_tests,
@@ -1006,12 +1006,12 @@ def test_cli_ignore_invalid_plans_01(tmp_path, re_manager_cmd, ignore_invalid_pl
 
     if not ignore_invalid_plans:
         assert wait_for_condition(time=timeout_env_open, condition=condition_manager_idle)
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["worker_environment_exists"] is False
         assert status["worker_environment_state"] == "closed"
     else:
         assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["worker_environment_exists"] is True
         assert status["worker_environment_state"] == "idle"
 
@@ -1049,7 +1049,7 @@ def test_cli_ignore_invalid_plans_02(tmp_path, re_manager_cmd, ignore_invalid_pl
     assert resp["msg"] == ""
 
     assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["worker_environment_exists"] is True
     assert status["worker_environment_state"] == "idle"
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -2532,8 +2532,11 @@ RE = RunEngine()
 
 def test_zmq_api_environment_update_02(re_manager, ip_kernel_simple_client):  # noqa: F811
     """
-    'environment_update' API: basic test - upload a script, update environment,
-    then check that the plan and the device are in the lists.
+    'environment_update' API: test that RE can be replaced by executing a script using
+    'scipt_upload' API or by executing a cell in the IPython kernel. Test that if RE
+    is not a valid RunEngine object, the Queue Server is still functional, though it can
+    not execute plans. If RE is restored to a valid object, then Queue Server becomes
+    fully functional.
     """
     using_ipython = use_ipykernel_for_tests()
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -6101,6 +6101,8 @@ def test_zmq_api_unsupported_parameters(re_manager):  # noqa: F811
         "plans_allowed",
         "devices_allowed",
         "permissions_reload",
+        "permissions_get",
+        "permissions_set",
         "queue_get",
         "queue_mode_set",
         "queue_item_add",
@@ -6118,10 +6120,12 @@ def test_zmq_api_unsupported_parameters(re_manager):  # noqa: F811
         "environment_open",
         "environment_close",
         "environment_destroy",
+        "environment_update",
         "queue_start",
         "queue_stop",
         "queue_stop_cancel",
         "queue_autostart",
+        "kernel_interrupt",
         "re_pause",
         "re_resume",
         "re_stop",
@@ -6133,6 +6137,7 @@ def test_zmq_api_unsupported_parameters(re_manager):  # noqa: F811
         "lock",
         "lock_info",
         "unlock",
+        "config_get",
     )
     unsupported_param = {"unsupported_param": 10}
 

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -48,7 +48,7 @@ from .common import (  # noqa: F401
     condition_queue_processing_finished,
     copy_default_profile_collection,
     db_catalog,
-    get_queue_state,
+    get_manager_status,
     ip_kernel_simple_client,
     re_manager,
     re_manager_cmd,
@@ -259,7 +259,7 @@ def test_zmq_api_environment_open_close_1(re_manager):  # noqa F811
     """
     Basic test for `environment_open` and `environment_close` methods.
     """
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["re_state"] is None
     assert state["worker_environment_state"] == "closed"
 
@@ -269,7 +269,7 @@ def test_zmq_api_environment_open_close_1(re_manager):  # noqa F811
 
     assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["re_state"] == "idle"
     assert state["worker_environment_state"] == "idle"
 
@@ -279,7 +279,7 @@ def test_zmq_api_environment_open_close_1(re_manager):  # noqa F811
 
     assert wait_for_condition(time=3, condition=condition_environment_closed)
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["re_state"] is None
     assert state["worker_environment_state"] == "closed"
 
@@ -359,7 +359,7 @@ def test_zmq_api_queue_item_add_01(re_manager):  # noqa F811
     """
     Basic test for `queue_item_add` method.
     """
-    status0 = get_queue_state()
+    status0 = get_manager_status()
 
     resp1, _ = zmq_single_request("queue_item_add", {"item": _plan1, "user": _user, "user_group": _user_group})
     assert resp1["success"] is True
@@ -370,7 +370,7 @@ def test_zmq_api_queue_item_add_01(re_manager):  # noqa F811
     assert resp1["item"]["user_group"] == _user_group
     assert "item_uid" in resp1["item"]
 
-    status1 = get_queue_state()
+    status1 = get_manager_status()
     assert status1["plan_queue_uid"] != status0["plan_queue_uid"]
     assert status1["plan_history_uid"] == status0["plan_history_uid"]
 
@@ -533,7 +533,7 @@ def test_zmq_api_queue_item_add_04(re_manager):  # noqa F811
         time=20, condition=condition_queue_processing_finished
     ), "Timeout while waiting for environment to be opened"
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == 0
     assert state["items_in_history"] == 3
 
@@ -609,7 +609,7 @@ def test_zmq_api_queue_item_add_05(re_manager, plan_to_add, ugroup, success_subm
     assert resp0a["success"] is success_submit
     response_msg = resp0a["msg"]
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == (1 if success_submit else 0)
     assert state["items_in_history"] == 0
 
@@ -629,7 +629,7 @@ def test_zmq_api_queue_item_add_05(re_manager, plan_to_add, ugroup, success_subm
 
         assert wait_for_condition(time=10, condition=condition_manager_idle)
 
-        state = get_queue_state()
+        state = get_manager_status()
         assert state["items_in_queue"] == (0 if success_run else 1)
         assert state["items_in_history"] == 1
 
@@ -680,7 +680,7 @@ def test_zmq_api_queue_item_add_06(re_manager, value, err_msg):  # noqa: F811
     resp3, _ = zmq_single_request("queue_item_add", params=params)
     assert resp3["success"] is True, resp3
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == 1
     assert state["items_in_history"] == 0
 
@@ -688,7 +688,7 @@ def test_zmq_api_queue_item_add_06(re_manager, value, err_msg):  # noqa: F811
     assert resp4["success"] is True
     assert wait_for_condition(time=10, condition=condition_manager_idle)
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == 1
     assert state["items_in_history"] == 1
 
@@ -1172,7 +1172,7 @@ def test_zmq_api_queue_item_add_batch_1(
         resp1a, _ = zmq_single_request("queue_item_add", params)
         assert resp1a["success"] is True
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == len(queue_seq)
     assert state["items_in_history"] == 0
 
@@ -1243,7 +1243,7 @@ def test_zmq_api_queue_item_add_batch_1(
     queue_final_seq = "".join(queue_final_seq)
     assert queue_final_seq == expected_seq
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == len(expected_seq)
     assert state["items_in_history"] == 0
 
@@ -1273,7 +1273,7 @@ def test_zmq_api_queue_item_add_batch_2(re_manager):  # noqa: F811
         resp1a, _ = zmq_single_request("queue_item_add", params)
         assert resp1a["success"] is True
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == len(queue_seq)
     assert state["items_in_history"] == 0
 
@@ -1340,7 +1340,7 @@ def test_zmq_api_queue_item_add_batch_3(re_manager):  # noqa: F811
         else:
             assert "kwargs" not in item_res
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == 4
     assert state["items_in_history"] == 0
 
@@ -1352,7 +1352,7 @@ def test_zmq_api_queue_item_add_batch_3(re_manager):  # noqa: F811
     assert resp3["success"] is True
     assert wait_for_condition(time=30, condition=condition_manager_idle)
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == 1
     assert state["items_in_history"] == 2
 
@@ -1360,7 +1360,7 @@ def test_zmq_api_queue_item_add_batch_3(re_manager):  # noqa: F811
     assert resp4["success"] is True
     assert wait_for_condition(time=10, condition=condition_queue_processing_finished)
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == 0
     assert state["items_in_history"] == 3
 
@@ -1396,7 +1396,7 @@ def test_zmq_api_queue_item_add_batch_4_fail(re_manager):  # noqa: F811
         assert res["success"] == success_expected[n], str(res)
         assert msg_expected[n] in res["msg"], str(res)
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == 0
     assert state["items_in_history"] == 0
 
@@ -1434,7 +1434,7 @@ def test_zmq_api_queue_item_update_1(re_manager, replace):  # noqa F811
     if replace is not None:
         params["replace"] = replace
 
-    status1 = get_queue_state()
+    status1 = get_manager_status()
 
     resp2, _ = zmq_single_request("queue_item_update", params)
     assert resp2["success"] is True
@@ -1449,7 +1449,7 @@ def test_zmq_api_queue_item_update_1(re_manager, replace):  # noqa F811
     else:
         assert resp2["item"]["item_uid"] == uid
 
-    status2 = get_queue_state()
+    status2 = get_manager_status()
     assert status2["plan_queue_uid"] != status1["plan_queue_uid"]
     assert status2["plan_history_uid"] == status1["plan_history_uid"]
 
@@ -3281,7 +3281,7 @@ def test_zmq_api_queue_item_get_remove_1(re_manager):  # noqa F811
         resp0, _ = zmq_single_request("queue_item_add", {"item": plan, "user": _user, "user_group": _user_group})
         assert resp0["success"] is True
 
-    status0 = get_queue_state()
+    status0 = get_manager_status()
 
     resp1, _ = zmq_single_request("queue_get")
     assert resp1["items"] != []
@@ -3306,7 +3306,7 @@ def test_zmq_api_queue_item_get_remove_1(re_manager):  # noqa F811
     assert resp2["item"]["kwargs"] == _plan3["kwargs"]
     assert "item_uid" in resp3["item"]
 
-    status1 = get_queue_state()
+    status1 = get_manager_status()
     assert status1["plan_queue_uid"] != status0["plan_queue_uid"]
 
 
@@ -3436,7 +3436,7 @@ def test_zmq_api_queue_item_get_remove_3(re_manager):  # noqa F811
         time=10, condition=condition_queue_processing_finished
     ), "Timeout while waiting for environment to be opened"
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == 0
     assert state["items_in_history"] == 1
 
@@ -3500,7 +3500,7 @@ def test_zmq_api_item_remove_batch_1(
         resp1a, _ = zmq_single_request("queue_item_add", params)
         assert resp1a["success"] is True
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == len(queue_seq)
     assert state["items_in_history"] == 0
 
@@ -3548,7 +3548,7 @@ def test_zmq_api_item_remove_batch_1(
     queue_final_seq = "".join(queue_final_seq)
     assert queue_final_seq == expected_seq
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == len(expected_seq)
     assert state["items_in_history"] == 0
 
@@ -3642,7 +3642,7 @@ def test_zmq_api_item_move_1(re_manager, params, src, order, success, msg):  # n
 
         assert item_uids_from_queue == item_uids_reordered
 
-        status = get_queue_state()
+        status = get_manager_status()
         if order != [0, 1, 2]:
             # The queue actually changed, so UID is expected to change
             assert status["plan_queue_uid"] != pq_uid
@@ -3656,7 +3656,7 @@ def test_zmq_api_item_move_1(re_manager, params, src, order, success, msg):  # n
         assert resp2["item"] == {}
         assert msg in resp2["msg"]
 
-        status = get_queue_state()
+        status = get_manager_status()
         # Queue did not change, so UID should remain the same
         assert status["plan_queue_uid"] == pq_uid
 
@@ -3722,7 +3722,7 @@ def test_zmq_api_item_move_batch_1(
         resp1a, _ = zmq_single_request("queue_item_add", params)
         assert resp1a["success"] is True
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == len(queue_seq)
     assert state["items_in_history"] == 0
 
@@ -3778,7 +3778,7 @@ def test_zmq_api_item_move_batch_1(
     queue_final_seq = "".join(queue_final_seq)
     assert queue_final_seq == expected_seq
 
-    state = get_queue_state()
+    state = get_manager_status()
     assert state["items_in_queue"] == len(expected_seq)
     assert state["items_in_history"] == 0
 
@@ -3798,20 +3798,20 @@ def test_zmq_api_queue_mode_set_1(re_manager):  # noqa: F811
     """
     Basic tests for ``queue_mode_set`` API
     """
-    status = get_queue_state()
+    status = get_manager_status()
     queue_mode_default = status["plan_queue_mode"]
 
     # Send empty dictionary, this should not change the mode
     resp1, _ = zmq_single_request("queue_mode_set", params={"mode": {}})
     assert resp1["success"] is True, str(resp1)
     assert resp1["msg"] == ""
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["plan_queue_mode"] == queue_mode_default
 
     # Meaningful change: enable the LOOP mode
     resp2, _ = zmq_single_request("queue_mode_set", params={"mode": {"loop": True}})
     assert resp2["success"] is True, str(resp2)
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["plan_queue_mode"] != queue_mode_default
     queue_mode_expected = queue_mode_default.copy()
     queue_mode_expected["loop"] = True
@@ -3820,14 +3820,14 @@ def test_zmq_api_queue_mode_set_1(re_manager):  # noqa: F811
     # Enable 'ignore_failures'
     resp3, _ = zmq_single_request("queue_mode_set", params={"mode": {"ignore_failures": True}})
     assert resp3["success"] is True, str(resp3)
-    status = get_queue_state()
+    status = get_manager_status()
     queue_mode_expected["ignore_failures"] = True
     assert status["plan_queue_mode"] == queue_mode_expected
 
     # Reset to default
     resp4, _ = zmq_single_request("queue_mode_set", params={"mode": "default"})
     assert resp4["success"] is True, str(resp4)
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["plan_queue_mode"] == queue_mode_default
 
 
@@ -3844,14 +3844,14 @@ def test_zmq_api_queue_mode_set_2_fail(re_manager, mode, msg_expected):  # noqa:
     """
     Failing cases for ``queue_mode_set`` API
     """
-    status = get_queue_state()
+    status = get_manager_status()
     queue_mode_default = status["plan_queue_mode"]
 
     resp, _ = zmq_single_request("queue_mode_set", params={"mode": mode})
     assert resp["success"] is False
     assert msg_expected in resp["msg"]
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["plan_queue_mode"] == queue_mode_default
 
 
@@ -3880,7 +3880,7 @@ def test_zmq_api_queue_mode_set_3_loop_mode(re_manager):  # noqa: F811
         resp2, _ = zmq_single_request("queue_mode_set", params={"mode": {"loop": loop_mode}})
         assert resp2["success"] is True
 
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["items_in_queue"] == 3, f"loop_mode={loop_mode}"
         assert status["items_in_history"] == (0 if loop_mode else 4), f"loop_mode={loop_mode}"
 
@@ -3889,7 +3889,7 @@ def test_zmq_api_queue_mode_set_3_loop_mode(re_manager):  # noqa: F811
 
         assert wait_for_condition(time=10, condition=condition_manager_idle)
 
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["items_in_queue"] == (3 if loop_mode else 0), f"loop_mode={loop_mode}"
         assert status["items_in_history"] == (2 if loop_mode else 6), f"loop_mode={loop_mode}"
 
@@ -3898,7 +3898,7 @@ def test_zmq_api_queue_mode_set_3_loop_mode(re_manager):  # noqa: F811
 
         assert wait_for_condition(time=10, condition=condition_manager_idle)
 
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["items_in_queue"] == (3 if loop_mode else 0), f"loop_mode={loop_mode}"
         assert status["items_in_history"] == (4 if loop_mode else 6), f"loop_mode={loop_mode}"
 
@@ -3956,7 +3956,7 @@ def test_zmq_api_queue_mode_set_4_ignore_failures(re_manager):  # noqa: F811
 
         assert wait_for_condition(time=10, condition=condition_manager_idle)
 
-        status = get_queue_state()
+        status = get_manager_status()
         if ignore_failures:
             assert status["items_in_queue"] == 0
             assert status["items_in_history"] == 3
@@ -3981,7 +3981,7 @@ def test_zmq_api_queue_autostart_01(re_manager):  # noqa: F811
     resp1, _ = zmq_single_request("queue_autostart", params={"enable": True})
     assert resp1["success"] is True, f"resp={resp1}"
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True
 
     # The second call must return 'success'
@@ -3991,7 +3991,7 @@ def test_zmq_api_queue_autostart_01(re_manager):  # noqa: F811
     resp2, _ = zmq_single_request("queue_autostart", params={"enable": False})
     assert resp2["success"] is True, f"resp={resp2}"
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is False
 
     # The second call must return 'success'
@@ -4060,20 +4060,20 @@ def test_zmq_api_queue_autostart_03(re_manager, open_env_first, autostart_first,
     # It may take some time for the queue to start
     assert wait_for_condition(time=3, condition=condition_manager_executing_queue)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True, pprint.pformat(status)
     assert status["manager_state"] == "executing_queue", pprint.pformat(status)
 
     assert wait_for_condition(time=30, condition=condition_queue_processing_finished)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True
 
     resp, _ = zmq_single_request("environment_close")
     assert resp["success"] is True
     assert wait_for_condition(time=10, condition=condition_environment_closed)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True
     assert status["items_in_queue"] == 0
     assert status["items_in_history"] == 1
@@ -4108,7 +4108,7 @@ def test_zmq_api_queue_autostart_04(re_manager, ip_kernel_simple_client):  # noq
     resp, _ = zmq_single_request("queue_autostart", params={"enable": True})
     assert resp["success"] is True, f"resp={resp}"
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True, pprint.pformat(status)
     assert status["manager_state"] == "idle", pprint.pformat(status)
     assert status["worker_environment_state"] == "idle", pprint.pformat(status)
@@ -4117,13 +4117,13 @@ def test_zmq_api_queue_autostart_04(re_manager, ip_kernel_simple_client):  # noq
 
     assert wait_for_condition(15, condition_manager_executing_queue)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True, pprint.pformat(status)
     assert status["manager_state"] in ("starting_queue", "executing_queue"), pprint.pformat(status)
 
     ttime.sleep(1)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True, pprint.pformat(status)
     assert status["manager_state"] == "executing_queue", pprint.pformat(status)
     assert status["worker_environment_state"] == "executing_plan", pprint.pformat(status)
@@ -4132,14 +4132,14 @@ def test_zmq_api_queue_autostart_04(re_manager, ip_kernel_simple_client):  # noq
 
     wait_for_condition(time=30, condition=condition_queue_processing_finished)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True
 
     resp, _ = zmq_single_request("environment_close")
     assert resp["success"] is True
     assert wait_for_condition(time=10, condition=condition_environment_closed)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True
     assert status["items_in_queue"] == 0
     assert status["items_in_history"] == 1
@@ -4195,7 +4195,7 @@ def test_zmq_api_queue_autostart_05(re_manager, ip_kernel_simple_client, option,
 
     expected_autostart = True if option in ("resume", "stop") else False
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is expected_autostart, pprint.pformat(status)
     assert status["manager_state"] == "idle", pprint.pformat(status)
     assert status["worker_environment_state"] == "idle", pprint.pformat(status)
@@ -4289,14 +4289,14 @@ def test_zmq_api_queue_autostart_06(re_manager, option):  # noqa: F811
     wait_for_condition(time=30, condition=condition_manager_idle)
 
     expected_state = option in ("normal", "resume")
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] == expected_state
 
     resp, _ = zmq_single_request("environment_close")
     assert resp["success"] is True
     assert wait_for_condition(time=10, condition=condition_environment_closed)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] == expected_state
 
     if option in ("normal", "resume"):
@@ -4388,14 +4388,14 @@ def test_zmq_api_queue_autostart_07(re_manager, option):  # noqa: F811
 
     wait_for_condition(time=30, condition=condition_manager_idle)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True
 
     resp, _ = zmq_single_request("environment_close")
     assert resp["success"] is True
     assert wait_for_condition(time=10, condition=condition_environment_closed)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is True
 
     if option in "immediate_plan":
@@ -4449,7 +4449,7 @@ def test_zmq_api_queue_autostart_08(re_manager, option, autostart_on, apply_queu
         resp, _ = zmq_single_request("queue_stop")
         assert resp["success"] is True, f"resp={resp}"
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_stop_pending"] == apply_queue_stop
 
     if option == "restart_middle":
@@ -4464,7 +4464,7 @@ def test_zmq_api_queue_autostart_08(re_manager, option, autostart_on, apply_queu
 
     wait_for_condition(time=30, condition=condition_manager_idle)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] == (autostart_on and not apply_queue_stop)
     assert status["queue_stop_pending"] is False
 
@@ -4476,14 +4476,14 @@ def test_zmq_api_queue_autostart_08(re_manager, option, autostart_on, apply_queu
     ttime.sleep(1.5)
     wait_for_condition(time=30, condition=condition_manager_idle)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] == (autostart_on and not apply_queue_stop)
 
     resp, _ = zmq_single_request("environment_close")
     assert resp["success"] is True
     assert wait_for_condition(time=10, condition=condition_environment_closed)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] == (autostart_on and not apply_queue_stop)
     assert status["queue_stop_pending"] is False
 
@@ -4545,7 +4545,7 @@ def test_zmq_api_queue_autostart_09(re_manager, autostart_on):  # noqa: F811
     ttime.sleep(1.5)
     wait_for_condition(time=30, condition=condition_manager_idle)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["queue_autostart_enabled"] is False
     assert status["queue_stop_pending"] is False
 
@@ -4761,7 +4761,7 @@ def test_permissions_reload_3(re_manager_pc_copy, allow_count_plan):  # noqa: F8
 
     # Attempt to add the second plan
     resp4, _ = zmq_single_request("queue_item_add", {"item": _plan1, "user": _user, "user_group": _user_group})
-    status = get_queue_state()
+    status = get_manager_status()
 
     # The following checks verify that the permissions are properly reloaded by the manager process
     if allow_count_plan:
@@ -4780,7 +4780,7 @@ def test_permissions_reload_3(re_manager_pc_copy, allow_count_plan):  # noqa: F8
 
     assert wait_for_condition(time=30, condition=condition_manager_idle)
 
-    status = get_queue_state()
+    status = get_manager_status()
 
     if allow_count_plan:
         assert status["items_in_queue"] == 0
@@ -4824,7 +4824,7 @@ def test_permissions_set_get_1(re_manager, restart_manager):  # noqa: F811
     the last set of permissions is loaded from Redis and the correct list of available plans
     is generated.
     """
-    status = get_queue_state()
+    status = get_manager_status()
     plans_allowed_uid_1 = status["plans_allowed_uid"]
 
     resp1, _ = zmq_single_request("plans_allowed", params={"user_group": _user_group})
@@ -4842,7 +4842,7 @@ def test_permissions_set_get_1(re_manager, restart_manager):  # noqa: F811
         assert err_msg != ""
         ttime.sleep(6)
 
-    status = get_queue_state()
+    status = get_manager_status()
     plans_allowed_uid2 = status["plans_allowed_uid"]
     assert plans_allowed_uid2 != plans_allowed_uid_1
 
@@ -4863,7 +4863,7 @@ def test_permissions_set_get_2(re_manager):  # noqa: F811
     Test that repeatedly uploading the same permissions dictionary does not update
     the lists of allowed plans and devices (UIDs)
     """
-    status = get_queue_state()
+    status = get_manager_status()
     plans_allowed_uid_0 = status["plans_allowed_uid"]
     devices_allowed_uid_0 = status["devices_allowed_uid"]
 
@@ -4873,7 +4873,7 @@ def test_permissions_set_get_2(re_manager):  # noqa: F811
     )
     assert resp1["success"] is True, pprint.pformat(resp1)
 
-    status = get_queue_state()
+    status = get_manager_status()
     plans_allowed_uid_1 = status["plans_allowed_uid"]
     devices_allowed_uid_1 = status["devices_allowed_uid"]
 
@@ -4893,7 +4893,7 @@ def test_permissions_set_get_2(re_manager):  # noqa: F811
     )
     assert resp3["success"] is True, pprint.pformat(resp3)
 
-    status = get_queue_state()
+    status = get_manager_status()
     plans_allowed_uid_2 = status["plans_allowed_uid"]
     devices_allowed_uid_2 = status["devices_allowed_uid"]
 
@@ -4954,12 +4954,12 @@ def test_zmq_api_environment_destroy_01(re_manager, destroy_while_opening, delay
     assert resp1["success"] is True
     if not destroy_while_opening:
         assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["manager_state"] == "idle"
         assert status["worker_environment_exists"] is True
     else:
         ttime.sleep(delay)
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["manager_state"] == "creating_environment"
         assert status["worker_environment_exists"] is False
 
@@ -4983,7 +4983,7 @@ def test_zmq_api_environment_destroy_02(re_manager):  # noqa: F811
     """
     resp0, _ = zmq_single_request("queue_item_add", {"item": _plan3, "user": _user, "user_group": _user_group})
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["items_in_queue"] == 1, "Incorrect number of plans in the queue"
     assert status["running_item_uid"] is None
     assert status["re_state"] is None
@@ -4995,14 +4995,14 @@ def test_zmq_api_environment_destroy_02(re_manager):  # noqa: F811
     assert resp1["success"] is True
     assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["re_state"] == "idle"
 
     resp2, _ = zmq_single_request("queue_start")
     assert resp2["success"] is True
 
     ttime.sleep(2)
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["items_in_queue"] == 0, "Incorrect number of plans in the queue"
     assert status["running_item_uid"] is not None
     assert status["re_state"] == "running"
@@ -5011,7 +5011,7 @@ def test_zmq_api_environment_destroy_02(re_manager):  # noqa: F811
     assert resp1["success"] is True
     assert wait_for_condition(time=10, condition=condition_environment_closed)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["items_in_queue"] == 1, "Incorrect number of plans in the queue"
     assert status["items_in_history"] == 1, "Incorrect number of plans in the history"
     assert status["running_item_uid"] is None
@@ -5024,21 +5024,21 @@ def test_zmq_api_environment_destroy_02(re_manager):  # noqa: F811
     assert resp4["success"] is True
     assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["re_state"] == "idle"
 
     resp5, _ = zmq_single_request("queue_start")
     assert resp5["success"] is True
 
     ttime.sleep(2)
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["items_in_queue"] == 0, "Incorrect number of plans in the queue"
     assert status["running_item_uid"] is not None
     assert status["re_state"] == "running"
 
     assert wait_for_condition(time=60, condition=condition_queue_processing_finished)
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["items_in_queue"] == 0, "Incorrect number of plans in the queue"
     assert status["items_in_history"] == 2, "Incorrect number of plans in the history"
     assert status["running_item_uid"] is None
@@ -5539,7 +5539,7 @@ def test_zmq_api_lock_1(monkeypatch, re_manager_cmd, em_lock_code):  # noqa: F81
         assert lock_info["emergency_lock_key_is_set"] == em_lock_key
 
     def check_status(environment, queue, uid):
-        status = get_queue_state()
+        status = get_manager_status()
         assert status["lock"]["environment"] == environment
         assert status["lock"]["queue"] == queue
         if uid:
@@ -6033,7 +6033,7 @@ def test_manager_kill_1(re_manager_pc_copy):  # noqa: F811
     ttime.sleep(1)
     # Verify that the manager is not responsive
     with pytest.raises(TimeoutError):
-        get_queue_state()
+        get_manager_status()
     ttime.sleep(7)  # Wait until the manager is back online
 
     # Attempt to add 'count' plan. RE Manager is expected to use user group permissions and
@@ -6041,7 +6041,7 @@ def test_manager_kill_1(re_manager_pc_copy):  # noqa: F811
     resp3, _ = zmq_single_request("queue_item_add", params2)
     assert resp3["success"] is True, f"resp={resp3}"
 
-    status = get_queue_state()
+    status = get_manager_status()
     assert status["items_in_queue"] == 2
 
     # Close the environment

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -2449,6 +2449,149 @@ def test_zmq_api_script_upload_11_fail(re_manager, test_with_plan):  # noqa: F81
 
 
 # ===========================================================================================
+#                                'environment_update' API
+
+_script_to_upload_eu2 = """
+# Device
+from ophyd import Device
+dev_test = Device(name="dev_test")
+
+# Trivial plan
+def sleep_for_a_few_sec(tt=1):
+    yield from bps.sleep(tt)
+"""
+
+# fmt: off
+@pytest.mark.parametrize("use_bg_task", [False, True])
+# fmt: on
+def test_zmq_api_environment_update_01(re_manager, use_bg_task):  # noqa: F811
+    """
+    'environment_update' API: basic test - upload a script, update environment,
+    then check that the plan and the device are in the lists.
+    """
+
+    def get_plans_devices():
+        resp, _ = zmq_single_request("plans_allowed", params={"user_group": _user_group})
+        assert resp["success"] is True, resp
+        plans_allowed = resp["plans_allowed"]
+
+        resp, _ = zmq_single_request("devices_allowed", params={"user_group": _user_group})
+        assert resp["success"] is True, resp
+        devices_allowed = resp["devices_allowed"]
+
+        return plans_allowed, devices_allowed
+
+    resp1, _ = zmq_single_request("environment_open")
+    assert resp1["success"] is True
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    params={"script": _script_to_upload_eu2, "update_lists": False}
+    resp2, _ = zmq_single_request("script_upload", params=params)
+    assert resp2["success"] is True, pprint.pformat(resp2)
+    assert resp2["msg"] == ""
+    task_uid = resp2["task_uid"]
+
+    result = wait_for_task_result(10, task_uid)
+    assert result["return_value"] is None
+
+    plans_allowed, devices_allowed = get_plans_devices()
+    assert "sleep_for_a_few_sec" not in plans_allowed
+    assert "dev_test" not in devices_allowed
+
+    params = {}
+    resp6, _ = zmq_single_request("environment_update", params=params)
+    assert resp6["success"] is True, pprint.pformat(resp6)
+    assert resp6["msg"] == ""
+
+    task_uid = resp6["task_uid"]
+
+    result = wait_for_task_result(10, task_uid)
+    assert result["return_value"] is None
+
+    plans_allowed, devices_allowed = get_plans_devices()
+    assert "sleep_for_a_few_sec" in plans_allowed
+    assert "dev_test" in devices_allowed
+
+    resp6, _ = zmq_single_request("environment_close")
+    assert resp6["success"] is True, f"resp={resp6}"
+    assert wait_for_condition(time=5, condition=condition_environment_closed)
+
+
+_script_to_upload_eu_re1 = """
+# Replace RE with junk
+RE = "junk"
+"""
+
+_script_to_upload_eu_re2 = """
+# Restore valid RE
+from bluesky import RunEngine
+RE = RunEngine()
+"""
+
+
+# fmt: off
+@pytest.mark.parametrize("use_bg_task", [False, True])
+# fmt: on
+def test_zmq_api_environment_update_02(re_manager, ip_kernel_simple_client, use_bg_task):  # noqa: F811
+    """
+    'environment_update' API: basic test - upload a script, update environment,
+    then check that the plan and the device are in the lists.
+    """
+    using_ipython = use_ipykernel_for_tests()
+
+    resp1, _ = zmq_single_request("environment_open")
+    assert resp1["success"] is True
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    if using_ipython:
+        ip_kernel_simple_client.start()
+        ip_kernel_simple_client.execute_with_check(_script_to_upload_eu_re1)
+        assert wait_for_condition(10, condition_ip_kernel_idle)
+
+    else:
+        params={"script": _script_to_upload_eu_re1, "update_re": True}
+        resp, _ = zmq_single_request("script_upload", params=params)
+        assert resp["success"] is True, pprint.pformat(resp)
+        assert resp["msg"] == ""
+        task_uid = resp["task_uid"]
+
+        result = wait_for_task_result(10, task_uid)
+        assert result["return_value"] is None
+
+    params = {}
+    resp, _ = zmq_single_request("environment_update", params=params)
+    assert resp["success"] is True, pprint.pformat(resp)
+    assert resp["msg"] == ""
+    task_uid = resp["task_uid"]
+
+    result = wait_for_task_result(10, task_uid)
+    assert result["return_value"] is None
+
+    # Get 're_state' in status (it should be 'None', because RE is not RunEngine object)
+    status, _ = zmq_single_request("status")
+    assert status["re_state"] is None, pprint.pformat(status)
+
+    assert status["items_in_queue"] == 1, pprint.pformat(status)
+    assert status["items_in_history"] == 0, pprint.pformat(status)
+
+
+    # Try to run a plan (it should fail)
+    params = {"item": _plan1, "user": _user, "user_group": _user_group}
+    resp, _ = zmq_single_request("queue_item_add", params=params)
+    assert resp["success"] is True, str(resp)
+
+    resp, _ = zmq_single_request("queue_start")
+    assert resp["success"] is True, str(resp)
+
+    assert wait_for_condition(10, condition_ip_kernel_idle)
+
+
+    resp6, _ = zmq_single_request("environment_close")
+    assert resp6["success"] is True, f"resp={resp6}"
+    assert wait_for_condition(time=5, condition=condition_environment_closed)
+
+
+# ===========================================================================================
 #                                'task_status' API
 
 

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -451,7 +451,7 @@ class RunEngineWorker(Process):
             #   exceptions and handling execution results.
             func()
 
-        except Exception as ex:
+        except BaseException as ex:
             # The exception was raised while preparing the function for execution.
             logger.exception("Failed to execute task in main thread: %s", ex)
         else:
@@ -564,7 +564,7 @@ class RunEngineWorker(Process):
                     raise ValueError(f"Task result can not be serialized as JSON: {ex_json}") from ex_json
 
                 success, err_msg, err_tb = True, "", ""
-            except Exception as ex:
+            except BaseException as ex:
                 s = f"Error occurred while executing {name!r}"
                 err_msg = f"{s}: {str(ex)}"
                 if hasattr(ex, "tb"):  # ScriptLoadingError
@@ -740,7 +740,7 @@ class RunEngineWorker(Process):
 
         except RejectedError as ex:
             status, msg = "rejected", f"Task {name!r} was rejected by RE Worker process: {ex}"
-        except Exception as ex:
+        except BaseException as ex:
             status, msg = "error", f"Error occurred while starting the task {name!r}: {ex}"
 
         logger.debug(
@@ -1452,7 +1452,7 @@ class RunEngineWorker(Process):
 
             logger.info("Startup code was successfully loaded.")
 
-        except Exception as ex:
+        except BaseException as ex:
             s = "Failed to start RE Worker environment. Error while loading startup code"
             if hasattr(ex, "tb"):  # ScriptLoadingError
                 logger.error("%s:\n%s\n", s, ex.tb)
@@ -1682,7 +1682,7 @@ class RunEngineWorker(Process):
                     pass
             except queue.Empty:
                 pass
-            except Exception as ex:
+            except BaseException as ex:
                 logger.exception(ex)
 
     def _ip_kernel_execute_command(self, *, command: str, except_on: bool = False):

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -827,11 +827,11 @@ class RunEngineWorker(Process):
         if update_re:
             if ("RE" in self._re_namespace) and (self._RE != self._re_namespace["RE"]):
                 self._RE = self._re_namespace["RE"]
-                logger.info("Run Engine instance ('RE') was replaced while executing the uploaded script.")
+                logger.info("Run Engine instance ('RE') was replaced.")
 
             if ("db" in self._re_namespace) and (self._db != self._re_namespace["db"]):
                 self._db = self._re_namespace["db"]
-                logger.info("Data Broker instance ('db') was replaced while executing the uploaded script.")
+                logger.info("Data Broker instance ('db') was replaced.")
 
         if update_lists:
             logger.info("Updating lists of existing and available plans and devices ...")
@@ -862,7 +862,10 @@ class RunEngineWorker(Process):
                 self._generate_lists_of_allowed_plans_and_devices()
                 self._update_existing_pd_file(options=("ALWAYS",))
 
-            logger.info("The script was successfully loaded into RE environment")
+            if script:
+                logger.info("The script was successfully loaded into RE environment")
+            else:
+                logger.info("RE environment was successfully updated")
 
         else:
             # The script was executed, but the lists were not updated and may be out of sync.

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -93,6 +93,7 @@ Open and close RE Worker environment:
 - :ref:`method_environment_open`
 - :ref:`method_environment_close`
 - :ref:`method_environment_destroy`
+- :ref:`method_environment_update`
 
 
 Operations with the plan queue:
@@ -763,6 +764,46 @@ Execution     The request initiates the sequence of destroying the environment.
               'destroying_environment' while operation is in progress and switch to 'idle' when
               the operation completes and 'worker_environment_exists' is set False if environment
               was destroyed successfully.
+============  =========================================================================================
+
+
+.. _method_environment_update:
+
+**'environment_update'**
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'environment_update'**
+------------  -----------------------------------------------------------------------------------------
+Description   Update the state and cached parameters of the worker environment based on contents of the 
+              worker namespace. The updated parameters include the reference to the Run Engine and lists of
+              existing and available plans and devices. The API is intended for using in cases when 
+              users bypass RE Manager to modify contents of the namespace, for example by connecting 
+              directly to IPython kernel (IPython mode) and executing commands via Jupyter Console.
+------------  -----------------------------------------------------------------------------------------
+Parameters    **run_in_background**: *boolean* (optional, default *False*)
+                  Set this parameter *True* to execute the update in the background thread (while a plan or 
+                  another foreground task is running). Generally, it is recommended to run the update 
+                  in the main thread. **Developers of data acquisition workflows and/or user specific code 
+                  are responsible for thread safety.**
+
+              **lock_key**: *str* (optional)
+                  Lock key. The API fails if **the environment** is locked and no valid key is submitted
+                  with the request. See documentation on :ref:`method_lock` API for more details.
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
+
+              **task_uid**: *str* or *None*
+                  Task UID can be used to check status of the task and download results once the task
+                  is completed (see *task_result* API).
+------------  -----------------------------------------------------------------------------------------
+Execution     The request initiates the update. The update is not instant, especially if the namespace
+              is large. Monitor 'manager_state' (foreground task) or use 'task_uid' to check if 
+              the task execution is completed or the update is successful.
 ============  =========================================================================================
 
 

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -140,6 +140,10 @@ Lock/unlock RE Manager:
 - :ref:`method_lock_info`
 - :ref:`method_unlock`
 
+Management of IPython kernel (IPython mode):
+
+- :ref:`method_kernel_interrupt`
+
 Stopping RE Manager (mostly used in testing):
 
 - :ref:`method_manager_stop`
@@ -2102,6 +2106,46 @@ Returns       **success**: *boolean*
               **lock_info_uid**: *str*
                   UID of *lock_info*. The UID is also returned in RE Manager status and could be
                   monitored to detect updates of *lock_info*.
+------------  -----------------------------------------------------------------------------------------
+Execution     Immediate: no follow-up requests are required.
+============  =========================================================================================
+
+
+.. _method_kernel_interrupt:
+
+**'kernel_interrupt'**
+^^^^^^^^^^^^^^^^^^^^^^
+
+============  =========================================================================================
+Method        **'kernel_interrupt'**
+------------  -----------------------------------------------------------------------------------------
+Description   Send interrupt request (Ctrl-C) to the running IPython kernel. The API call fails if
+              IPython mode is not enabled or environment does not exist (there is no IPython kernel).
+              The API is primarily intended to interrupt tasks started by clients connected directly
+              to IPython kernel (such as Jupyter Console) and by default it fails if the manager is
+              executing a plan or a task. Set the **interrupt_task** and/or **interrupt_plan**
+              parameters *True* in order to be able to interrupt a running foreground task or a plan
+              (single interrupt initiates deferred pause, two consecutive interrupts initiate immediate
+              pause). Note, that :ref:`method_re_pause` API is more reliable method of pausing the plan. 
+------------  -----------------------------------------------------------------------------------------
+Parameters    **interrupt_task**: *boolean* (optional, default: *False*)
+                  Allow interrupting a foreground task (e.g. a function or a script) started by RE Manager.
+            
+              **interrupt_plan**: *boolean* (optional, default: *False*)
+                  Allow interrupting a running plan. By default the API fails if a plan is running in 
+                  the worker environment (Run Engine is in the *'running'* state), whether the plan
+                  was started by RE Manager or by connecting directly to the kernel (e.g. using Jupyter Console).
+                  Note, that using :ref:`method_re_pause` API is the preferred way of pausing a running plan
+                  even if the plan was started bypassing the manager.
+
+              **task_uid**: *str*
+                  Task UID.
+------------  -----------------------------------------------------------------------------------------
+Returns       **success**: *boolean*
+                  indicates if the request was processed successfully.
+
+              **msg**: *str*
+                  error message in case of failure, empty string ('') otherwise.
 ------------  -----------------------------------------------------------------------------------------
 Execution     Immediate: no follow-up requests are required.
 ============  =========================================================================================

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -665,3 +665,26 @@ and streamed to all subscribed consumers.
     console will close the kernel and cause the worker environment to close.
 
 See documentation on :ref:`qserver_console_cli` for more information.
+
+Updating the Worker Environment Cache
+*************************************
+
+Users connected directly to the IPython kernel via Jupyter Console may change the contents
+of the worker namespace, including operations such as adding, deleting or modifying plans 
+and devices in the namespace. To make RE Manager aware of the changes and make the updated
+plans and devices reflected in the lists of existing/allowed plans and devices call the 
+:ref:`method_environment_update` API. 
+
+Interrupting the IPython Kernel
+*******************************
+
+The IPython kernel can be interrupted (equivalent to ``Ctrl-C``) using :ref:`method_kernel_interrupt`
+API. By default, the API fails if called while the RE Manager is executing a plan or a foreground task
+(a script or a function) started via the manager. The API parameters ``interrupt_plan`` and 
+``interrupt_task`` of the API can be used to override the default behavior.
+
+.. note::
+      
+      Though a plan can be paused by sending the interrupt once (deferred pause) or twice (immediate pause),
+      using :ref:`method_re_pause` API is a preferable way to pause a plan started via RE Manager or directly
+      using Jupyter Console.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

New API: `environment_update` and `kernel_interrupt`. CLI interface: `qserver environment update` and `qserver kernel interrupt`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The new API to cover the gaps in functionality:

- `environment_update` API updates cached objects in the worker environment based on contents of the worker namespace. The API updates cached reference to RE and lists of existing/allowed plans and devices.

- `kernel_interrupt` API sends interrupt request (Ctrl-C) to IPython kernel.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New API: `environment_open` and `kernel_interrupt`.
- CLI implementation: `qserver environment open` and `kernel_interrupt`.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
