### PR TITLE
Update installation instructions: supported Python versions

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,7 @@ Installation
 System Requirements
 -------------------
 
-Supported Python versions: 3.7, 3.8, 3.9, 3.10.
+Supported Python versions: 3.7, 3.8, 3.9, 3.10, 3.11.
 
 Installation Steps
 ------------------
@@ -28,11 +28,9 @@ Installation Steps
   or already existing environment can be activated. The following example illustrates how to create
   a new Conda environment with the name *queue_server* and Python 3.9 installed::
 
-    $ conda create -n queue_server python=3.9
+    $ conda create -n queue_server python=3.10
     $ activate queue_server
 
-  The Queue Server currently works with Python 3.7-3.9, but it is recommended that Python 3.9 is used
-  for development.
 
 * **Install Queue Server**
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Currently Python 3.7-3.11 are supported. CI tests are run for Python 3.9-3.11. Support for Python 3.7 will be dropped soon.
