### PR TITLE
Compatibility with Pydantic v2

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,13 @@ jobs:
       matrix:
         use-ipykernel: [false, true]
         python-version: ["3.9", "3.10", "3.11"]
+        pydantic-version: ["<2.0.0", ">=2.0.0"]
         group: [1, 2, 3]
+        exclude:
+          - python-version: "3.9"
+            pydantic-version: "<2.0.0"
+          - python-version: "3.10"
+            pydantic-version: "<2.0.0"
       fail-fast: false
 
     steps:
@@ -30,6 +36,7 @@ jobs:
 
         pip install .
         pip install -r requirements-dev.txt
+        pip install "pydantic${{ matrix.pydantic-version }}"
         pip list
     - name: Test with pytest
       env:

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2180,6 +2180,7 @@ def _process_annotation(encoded_annotation, *, ns=None):
             for d in items[item_name]:
                 type_code += f"'{d}': '{d}',"
             type_code += "})"
+
             ns[type_name] = eval(type_code, ns, ns)
 
         # Once all the types are created,  execute the code for annotation.

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2420,6 +2420,8 @@ def _validate_plan_parameters(param_list, call_args, call_kwargs):
         #   recommended 'm.dict()', because 'm.dict()' was causing performance problems
         #   when validating large batches of plans. Based on testing, 'm.__dict__' seems
         #   to work fine in this application.
+        # NOTE: the following step may not be needed once Pydantic 1 is deprecated,
+        #   because Pydantic 2 performs strict type checking.
         success, msg = _compare_in_out(bound_args.arguments, m.__dict__)
         if not success:
             raise ValueError(f"Error in argument types: {msg}")

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -3,6 +3,7 @@ import copy
 import enum
 import glob
 import importlib
+import importlib.resources
 import inspect
 import logging
 import numbers
@@ -17,7 +18,6 @@ import typing
 from collections.abc import Iterable
 
 import jsonschema
-import importlib.resources
 import pydantic
 import yaml
 from numpydoc.docscrape import NumpyDocString

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -17,7 +17,7 @@ import typing
 from collections.abc import Iterable
 
 import jsonschema
-import pkg_resources
+import importlib.resources
 import pydantic
 import yaml
 from numpydoc.docscrape import NumpyDocString
@@ -173,7 +173,7 @@ def get_default_startup_dir():
     Returns the path to the default profile collection that is distributed with the package.
     The function does not guarantee that the directory exists. Used for demo with Python-based worker.
     """
-    pc_path = pkg_resources.resource_filename("bluesky_queueserver", "profile_collection_sim/")
+    pc_path = os.path.join(importlib.resources.files("bluesky_queueserver"), "profile_collection_sim", "")
     return pc_path
 
 

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -3898,7 +3898,7 @@ def test_plan(param):
 
 # Error messages may be different for Pydantic 1 and 2
 if pydantic_version_major == 2:
-    err_msg_tpp1 = "Input should be 'det1','det2' or 'det3'"
+    err_msg_tpp1 = r"Input should be 'det1','det2' or 'det3' \[type=enum, input_value='det4', input_type=str\]"
 else:
     err_msg_tpp1 = "value is not a valid enumeration member; permitted: 'det1', 'det2', 'det3'"
 
@@ -6703,7 +6703,10 @@ if pydantic_version_major == 2:
     err_msg_tvp3c = "Input should be an instance of Motors [type=is_instance_of, input_value='m2', input_type=str]"
     err_msg_tvp3d = "Input should be an instance of Motors [type=is_instance_of, input_value='m2', input_type=str]"
     err_msg_tvp3e = "Input should be a valid list [type=list_type, input_value='m2', input_type=str]"
-    err_msg_tvp3f = "Input should be a valid list [type=list_type, input_value='d4', input_type=str]"
+    err_msg_tvp3f = (
+        "Input should be an instance of Detectors2 [type=is_instance_of, input_value='d4', input_type=str]"
+    )
+    err_msg_tvp3f1 = "Input should be 'd5' [type=enum, input_value='d4', input_type=str]"
     err_msg_tvp3g = "Input should be a valid list [type=list_type, input_value='d2', input_type=str]"
     err_msg_tvp3h = "Input should be 'd1' or 'd2' [type=enum, input_value='d4', input_type=str]"
     err_msg_tvp3i = "Input should be 'p1' [type=enum, input_value='p3', input_type=str]"
@@ -6717,6 +6720,7 @@ else:
     err_msg_tvp3d = "value is not a valid enumeration member; permitted:"
     err_msg_tvp3e = "value is not a valid list"
     err_msg_tvp3f = "value is not a valid enumeration member; permitted:"
+    err_msg_tvp3f1 = "value is not a valid enumeration member; permitted:"
     err_msg_tvp3g = "value is not a valid list"
     err_msg_tvp3h = "value is not a valid enumeration member; permitted: 'd1', 'd2'"
     err_msg_tvp3i = "value is not a valid enumeration member; permitted: 'p1'"
@@ -6767,9 +6771,13 @@ else:
     # Pass single detector (allowed).
     (_vp3a, {"args": [("m1", "m2"), "d4", ("p1",), (10.0, 20.0)], "kwargs": {}},
      ("m1", "m2", "d1", "d2", "d4"), True, ""),
-    # Pass single detector from 'Detectors2' group, which is not in the list of allowed devices.
+    # Pass single detector from 'Detectors2' group, no devices from 'Detector2' group are allowed.
     (_vp3a, {"args": [("m1", "m2"), "d4", ("p1",), (10.0, 20.0)], "kwargs": {}},
      ("m1", "m2", "d1", "d2"), False, err_msg_tvp3f),
+    # Pass single detector from 'Detectors2' group, which is not in the list of allowed devices.
+    #   Detector2 group is not empty.
+    (_vp3a, {"args": [("m1", "m2"), "d4", ("p1",), (10.0, 20.0)], "kwargs": {}},
+     ("m1", "m2", "d1", "d2", "d5"), False, err_msg_tvp3f1),
     # Pass single detector from 'Detectors1' group (not allowed).
     (_vp3a, {"args": [("m1", "m2"), "d2", ("p1",), (10.0, 20.0)], "kwargs": {}},
      ("m1", "m2", "d1", "d2", "d4"), False, err_msg_tvp3g),

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -16,6 +16,7 @@ import ophyd.sim
 import pytest
 import yaml
 from bluesky import protocols
+from packaging import version
 
 from bluesky_queueserver import gen_list_of_plans_and_devices, register_device, register_plan
 from bluesky_queueserver.manager.annotation_decorator import parameter_annotation_decorator
@@ -3098,7 +3099,12 @@ def _create_schema_for_testing(annotation_type):
 
     model_kwargs = {"par": (annotation_type, ...)}
     func_model = pydantic.create_model("func_model", **model_kwargs)
-    schema = func_model.schema()
+
+    if version.parse(pydantic.__version__) < version.parse("2.0.0"):
+        schema = func_model.schema()
+    else:
+        schema = func_model.model_json_schema()
+
     return schema
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Changes:

- The original server code works with Pydantic V1 and V2. In this PR, the unit tests were modified to work with both versions of Pydantic. Pydantic V2 performs strict type checking and produces different error messages.

- Removed deprecated use of `pkg_resources.resource_filename`. Identical functionality was implemented using `importlib.resources.files`.

