### PR TITLE
Add username to temporary directory name (used in demo mode with IPython kernel)

### DIFF
--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -5,6 +5,7 @@ See profiles.py for client configuration.
 """
 import builtins
 import copy
+import getpass
 import logging
 import os
 import sys
@@ -683,7 +684,7 @@ class Settings:
             # If no location of startup code was specified, then load the default
             #   simulated ipython_sim/profile_collection_sim
             if not any([startup_script, startup_module, startup_profile, ipython_dir]):
-                ipython_dir = os.path.join(tempfile.gettempdir(), "qserver", "ipython")
+                ipython_dir = os.path.join(tempfile.gettempdir(), f"qserver_{getpass.getuser()}", "ipython")
                 startup_profile = default_startup_profile
                 demo_mode = True
 

--- a/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -1,4 +1,5 @@
 import copy
+import getpass
 import os
 import pprint
 import re
@@ -451,12 +452,13 @@ def test_cli_parameters_zmq_server_address_1(monkeypatch, re_manager_cmd, test_m
 
 def _get_expected_settings_default_1(tmpdir):
     use_ip_kernel = use_ipykernel_for_tests()
+    username = getpass.getuser()
     if use_ip_kernel:
         startup_dir = None
-        ipython_dir = "/tmp/qserver/ipython"
+        ipython_dir = f"/tmp/qserver_{username}/ipython"
         startup_profile = "collection_sim"
-        user_group_permissions_path = "/tmp/qserver/ipython/profile_collection_sim/startup"
-        existing_plans_and_devices_path = "/tmp/qserver/ipython/profile_collection_sim/startup"
+        user_group_permissions_path = f"/tmp/qserver_{username}/ipython/profile_collection_sim/startup"
+        existing_plans_and_devices_path = f"/tmp/qserver_{username}/ipython/profile_collection_sim/startup"
     else:
         startup_dir = "/bluesky_queueserver/profile_collection_sim/"
         ipython_dir = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add current username to the name of temporary directory. The directory used to be named `qserver`, now it is named `qserver_<username>`. The directory is created when RE Manager is started in demo mode with IPython kernel and contains the the copy of `profile_collection_sim` placed in `qserver_<username>/IPython/profile_collection_sim` directory. The `IPython` subdirectory also contains standard files created by IPython kernel, including the history. Having the same directory proved to be inconvenient if the Queue Server is started in demo mode by different users on the same machine. 

The temporary directory is used only in the demo mode if IPython kernel option is enabled. The change does not affect production environment. 

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

- The temporary directory created by RE Manager in demo mode if IPython kernel option is enabled is renamed from `qserver` to `qserver_<username>`, so that each user has individual temporary directory. The directory is used to create temporary copy of `profile_collection_sim` in demo mode. It is never used in production.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
