### PR TITLE
Support for in-header annotations of devices and callables

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2816,7 +2816,7 @@ def _process_plan(plan, *, existing_devices, existing_plans):
         """
         from bluesky.protocols import Flyable, Movable, Readable
 
-        protocols_mapping = {"__READABLE__": Readable, "__MOVABLE__": Movable, "__FLYABLE": Flyable}
+        protocols_mapping = {"__READABLE__": Readable, "__MOVABLE__": Movable, "__FLYABLE__": Flyable}
         protocols_inv = {v: k for k, v in protocols_mapping.items()}
 
         ns = {"typing": typing, "NoneType": type(None), **protocols_mapping}

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -2993,6 +2993,68 @@ _pf4d_processed = {
 }
 
 
+@parameter_annotation_decorator(
+    {
+        "parameters": {
+            "p1": {
+                "annotation": "__DEVICE__",
+            },
+            "p2": {
+                "annotation": "__READABLE__",
+            },
+            "p3": {
+                "annotation": "__MOVABLE__",
+            },
+            "p4": {
+                "annotation": "__FLYABLE__",
+            },
+            "p5": {
+                "annotation": "__CALLABLE__",
+            },
+        }
+    }
+)
+def _pf4e(p1, p2, p3, p4, p5):
+    yield from [p1, p2, p3, p4, p5]
+
+
+_pf4e_processed = {
+    "parameters": [
+        {
+            "annotation": {"type": "__DEVICE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "p1",
+        },
+        {
+            "annotation": {"type": "__READABLE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "p2",
+        },
+        {
+            "annotation": {"type": "__MOVABLE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "p3",
+        },
+        {
+            "annotation": {"type": "__FLYABLE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "p4",
+        },
+        {
+            "annotation": {"type": "__CALLABLE__"},
+            "eval_expressions": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "p5",
+        },
+    ],
+    "properties": {"is_generator": True},
+}
+
+
 # fmt: off
 _pp4_allowed_devices_dict_1 = {
     "da0_motor": {
@@ -3046,6 +3108,7 @@ _pp4_allowed_plans_set_1 = {"plan1", "count", "count_modified", "count2"}
     (_pf4b, _pp4_allowed_devices_dict_1, _pf4b_processed),
     (_pf4c, _pp4_allowed_devices_dict_1, _pf4c_processed),
     (_pf4d, _pp4_allowed_devices_dict_1, _pf4d_processed),
+    (_pf4e, _pp4_allowed_devices_dict_1, _pf4e_processed),
 ])
 # fmt: on
 def test_process_plan_4(plan_func, existing_devices, plan_info_expected):

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -1989,6 +1989,86 @@ _pf2g_processed = {
     "properties": {"is_generator": True},
 }
 
+import bluesky.protocols
+import collections.abc
+
+def _pf2h(
+    val1: bluesky.protocols.Readable,
+    val2: typing.List[bluesky.protocols.Readable],
+    val3: list[bluesky.protocols.Readable],  
+):
+    yield from [val1, val2, val3]
+
+_pf2h_processed = {
+    "parameters": [
+        {'annotation': {'type': '__READABLE__'},
+         'convert_device_names': True,
+         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
+         'name': 'val1'},
+        {'annotation': {'type': 'typing.List[__READABLE__]'},
+         'convert_device_names': True,
+         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
+         'name': 'val2'},
+        {'annotation': {'type': 'list[__READABLE__]'},
+         'convert_device_names': True,
+         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
+         'name': 'val3'}        
+    ],
+    "properties": {"is_generator": True},
+}
+
+def _pf2i(
+    val1: bluesky.protocols.Readable,
+    val2: bluesky.protocols.Movable,
+    val3: bluesky.protocols.Flyable,  
+):
+    yield from [val1, val2, val3]
+
+_pf2i_processed = {
+    "parameters": [
+        {'annotation': {'type': '__READABLE__'},
+         'convert_device_names': True,
+         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
+         'name': 'val1'},
+        {'annotation': {'type': '__MOVABLE__'},
+         'convert_device_names': True,
+         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
+         'name': 'val2'},
+        {'annotation': {'type': '__FLYABLE__'},
+         'convert_device_names': True,
+         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
+         'name': 'val3'},
+    ],
+    "properties": {"is_generator": True},
+}
+
+
+def _pf2j(
+    val1: typing.Callable,
+    val2: typing.Callable[[int, float], str],
+    val3: typing.Union[typing.Callable[[int, float], typing.Tuple[str, str]],
+                       typing.List[typing.Callable[[int, float], str]]],  
+):
+    yield from [val1, val2, val3]
+
+_pf2j_processed = {
+    "parameters": [
+        {'annotation': {'type': '__READABLE__'},
+         'convert_device_names': True,
+         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
+         'name': 'val1'},
+        {'annotation': {'type': '__MOVABLE__'},
+         'convert_device_names': True,
+         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
+         'name': 'val2'},
+        {'annotation': {'type': '__FLYABLE__'},
+         'convert_device_names': True,
+         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
+         'name': 'val3'},
+    ],
+    "properties": {"is_generator": True},
+}
+
 
 # fmt: off
 @pytest.mark.parametrize("plan_func, plan_info_expected", [
@@ -1999,6 +2079,9 @@ _pf2g_processed = {
     (_pf2e, _pf2e_processed),
     (_pf2f, _pf2f_processed),
     (_pf2g, _pf2g_processed),
+    (_pf2h, _pf2h_processed),
+    (_pf2i, _pf2i_processed),
+    (_pf2j, _pf2j_processed),
 ])
 # fmt: on
 def test_process_plan_2(plan_func, plan_info_expected):
@@ -3064,32 +3147,38 @@ def test_process_plan_5_fail(plan_func, err_msg):
 
 
 # fmt: off
-@pytest.mark.parametrize("type_str_in, plans, devices, enums, type_str_out, convert_plans, convert_devices", [
-    ("some_type", None, None, None, "some_type", False, False),
-    ("some_type", {}, {}, {}, "some_type", False, False),
-    ("__PLAN__", {}, {}, {}, "str", True, False),
-    ("__DEVICE__", {}, {}, {}, "str", False, True),
-    ("__PLAN_OR_DEVICE__", {}, {}, {}, "str", True, True),
-    ("typing.List[__PLAN__]", {}, {}, {}, "typing.List[str]", True, False),
+@pytest.mark.parametrize(
+        "type_str_in, plans, devices, enums, type_str_out, convert_plans, convert_devices, ev_expr", [
+    ("some_type", None, None, None, "some_type", False, False, False),
+    ("some_type", {}, {}, {}, "some_type", False, False, False),
+    ("__PLAN__", {}, {}, {}, "str", True, False, False),
+    ("__DEVICE__", {}, {}, {}, "str", False, True, False),
+    ("__PLAN_OR_DEVICE__", {}, {}, {}, "str", True, True, False),
+    ("__READABLE__", {}, {}, {}, "str", False, True, False),
+    ("__MOVABLE__", {}, {}, {}, "str", False, True, False),
+    ("__FLYABLE__", {}, {}, {}, "str", False, True, False),
+    ("__CALLABLE__", {}, {}, {}, "str", False, False, True),
+    ("typing.List[__PLAN__]", {}, {}, {}, "typing.List[str]", True, False, False),
     ("typing.Union[typing.List[__PLAN__], typing.List[__DEVICE__]]", {}, {}, {},
-     "typing.Union[typing.List[str], typing.List[str]]", True, True),
-    ("__PLAN__", {"__PLAN__": {}}, {}, {}, "__PLAN__", False, False),
-    ("__DEVICE__", {}, {"__DEVICE__": {}}, {}, "__DEVICE__", False, False),
-    ("__PLAN_OR_DEVICE__", {}, {}, {"__PLAN_OR_DEVICE__": {}}, "__PLAN_OR_DEVICE__", False, False),
+     "typing.Union[typing.List[str], typing.List[str]]", True, True, False),
+    ("__PLAN__", {"__PLAN__": {}}, {}, {}, "__PLAN__", False, False, False),
+    ("__DEVICE__", {}, {"__DEVICE__": {}}, {}, "__DEVICE__", False, False, False),
+    ("__PLAN_OR_DEVICE__", {}, {}, {"__PLAN_OR_DEVICE__": {}}, "__PLAN_OR_DEVICE__", False, False, False),
 ])
 # fmt: on
 def test_find_and_replace_built_in_types_1(
-    type_str_in, plans, devices, enums, type_str_out, convert_plans, convert_devices
+    type_str_in, plans, devices, enums, type_str_out, convert_plans, convert_devices, ev_expr
 ):
     """
     ``_find_and_replace_built_in_types``: basic tests
     """
-    annotation_type_str, convert_plan_names, convert_device_names = _find_and_replace_built_in_types(
+    annotation_type_str, convert_values = _find_and_replace_built_in_types(
         type_str_in, plans=plans, devices=devices, enums=enums
     )
     assert annotation_type_str == type_str_out
-    assert convert_plan_names == convert_plans
-    assert convert_device_names == convert_devices
+    assert convert_values["convert_plan_names"] == convert_plans
+    assert convert_values["convert_device_names"] == convert_devices
+    assert convert_values["eval_expressions"] == ev_expr
 
 
 # ---------------------------------------------------------------------------------
@@ -3109,37 +3198,47 @@ def _create_schema_for_testing(annotation_type):
 
 
 # fmt: off
-@pytest.mark.parametrize("encoded_annotation, type_expected, built_in_plans, built_in_devices, success, errmsg", [
-    ({"type": "int"}, int, False, False, True, ""),
-    ({"type": "str"}, str, False, False, True, ""),
-    ({"type": "typing.List[int]"}, typing.List[int], False, False, True, ""),
+@pytest.mark.parametrize(
+        "encoded_annotation, type_expected, built_in_plans, built_in_devices, eval_expr, success, errmsg", [
+    ({"type": "int"}, int, False, False, False, True, ""),
+    ({"type": "str"}, str, False, False, False, True, ""),
+    ({"type": "typing.List[int]"}, typing.List[int], False, False, False, True, ""),
     ({"type": "typing.List[typing.Union[int, float]]"},
-     typing.List[typing.Union[int, float]], False, False, True, ""),
-    ({"type": "List[int]"}, typing.List[int], False, False, False, "name 'List' is not defined"),
+     typing.List[typing.Union[int, float]], False, False, False, True, ""),
+    ({"type": "List[int]"}, typing.List[int], False, False, False, False, "name 'List' is not defined"),
 
     #  Built-in types: allow any value to pass
-    ({"type": "__PLAN__"}, str, True, False, True, ""),
-    ({"type": "typing.List[__PLAN__]"}, typing.List[str], True, False, True, ""),
-    ({"type": "__DEVICE__"}, str, False, True, True, ""),
-    ({"type": "typing.List[__DEVICE__]"}, typing.List[str], False, True, True, ""),
-    ({"type": "__PLAN_OR_DEVICE__"}, str, True, True, True, ""),
-    ({"type": "typing.List[__PLAN_OR_DEVICE__]"}, typing.List[str], True, True, True, ""),
+    ({"type": "__PLAN__"}, str, True, False, False, True, ""),
+    ({"type": "typing.List[__PLAN__]"}, typing.List[str], True, False, False, True, ""),
+    ({"type": "__DEVICE__"}, str, False, True, False, True, ""),
+    ({"type": "typing.List[__DEVICE__]"}, typing.List[str], False, True, False, True, ""),
+    ({"type": "__READABLE__"}, str, False, True, False, True, ""),
+    ({"type": "typing.List[__READABLE__]"}, typing.List[str], False, True, False, True, ""),
+    ({"type": "__MOVABLE__"}, str, False, True, False, True, ""),
+    ({"type": "typing.List[__MOVABLE__]"}, typing.List[str], False, True, False, True, ""),
+    ({"type": "__FLYABLE__"}, str, False, True, False, True, ""),
+    ({"type": "typing.List[__FLYABLE__]"}, typing.List[str], False, True, False, True, ""),
+    ({"type": "__PLAN_OR_DEVICE__"}, str, True, True, False, True, ""),
+    ({"type": "typing.List[__PLAN_OR_DEVICE__]"}, typing.List[str], True, True, False, True, ""),
     ({"type": "typing.Union[typing.List[__PLAN__], __DEVICE__]"},
-     typing.Union[typing.List[str], str], True, True, True, ""),
+     typing.Union[typing.List[str], str], True, True, False, True, ""),
+
+    ({"type": "__CALLABLE__"}, str, False, False, True, True, ""),
+    ({"type": "typing.List[__CALLABLE__]"}, typing.List[str], False, False, True, True, ""),
 
     # Errors
     ({"type": "typing.Union[typing.List[Device1], Device2]", "devices": {"Device1": []}},
-     typing.Union[typing.List[str], str], False, False, False, "name 'Device2' is not defined"),
-    ({"type": "Enum1", "unknown": {"Enum1": []}}, str, False, False, False,
+     typing.Union[typing.List[str], str], False, False, False, False, "name 'Device2' is not defined"),
+    ({"type": "Enum1", "unknown": {"Enum1": []}}, str, False, False, False, False,
      r"Annotation contains unsupported keys: \['unknown'\]"),
-    ({"type": "str", "devices": {"Device1": []}}, str, False, False, False,
+    ({"type": "str", "devices": {"Device1": []}}, str, False, False, False, False,
      r"Type 'Device1' is defined in the annotation, but not used"),
-    ({"type": "Device1", "devices": {"Device1": None}}, str, False, False, False,
+    ({"type": "Device1", "devices": {"Device1": None}}, str, False, False, False, False,
      r"The list of items \('Device1': None\) must be a list of a tuple"),
 ])
 # fmt: on
 def test_process_annotation_1(
-    encoded_annotation, type_expected, built_in_plans, built_in_devices, success, errmsg
+    encoded_annotation, type_expected, built_in_plans, built_in_devices, eval_expr, success, errmsg
 ):
     """
     Function ``_process_annotation``: generate type based on annotation and compare it with the expected type.
@@ -3147,10 +3246,11 @@ def test_process_annotation_1(
     """
     if success:
         # Compare types directly
-        type_recovered, conv_plan_nms, conv_dev_nms, ns = _process_annotation(encoded_annotation)
+        type_recovered, convert_values, ns = _process_annotation(encoded_annotation)
         assert type_recovered == type_expected
-        assert conv_plan_nms == built_in_plans
-        assert conv_dev_nms == built_in_devices
+        assert convert_values["convert_plan_names"] == built_in_plans
+        assert convert_values["convert_device_names"] == built_in_devices
+        assert convert_values["eval_expressions"] == eval_expr
 
         # Compare generated JSON schemas
         schema_recovered = _create_schema_for_testing(type_recovered)
@@ -3227,7 +3327,7 @@ def test_process_annotation_2(encoded_annotation, type_expected, success, errmsg
     a meaningful test.
     """
     if success:
-        type_recovered, _, _, ns = _process_annotation(encoded_annotation)
+        type_recovered, _, ns = _process_annotation(encoded_annotation)
 
         schema_recovered = _create_schema_for_testing(type_recovered)
         schema_expected = _create_schema_for_testing(type_expected)
@@ -3262,7 +3362,7 @@ def test_process_annotation_3(encoded_annotation, type_expected, success, errmsg
     type definitions are different.
     """
     if success:
-        type_recovered, _, _, ns = _process_annotation(encoded_annotation)
+        type_recovered, _, ns = _process_annotation(encoded_annotation)
 
         schema_recovered = _create_schema_for_testing(type_recovered)
         schema_expected = _create_schema_for_testing(type_expected)

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -4526,9 +4526,9 @@ else:
     err_msg_tpp2d = "value is not a valid enumeration member"
     err_msg_tpp2e = "value is not a valid enumeration member"
     err_msg_tpp2f = "Incorrect parameter type: key='b', value='50'"
-    err_msg_tpp2g = "Incorrect parameter type"
+    err_msg_tpp2g = r"value is not a valid list \(type=type_error.list\)"
     err_msg_tpp2h = "Incorrect parameter type"
-    err_msg_tpp2i = "Incorrect parameter type"
+    err_msg_tpp2i = r"value is not a valid list \(type=type_error.list\)"
 
 
 # fmt: off

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -1,3 +1,4 @@
+import collections.abc
 import copy
 import enum
 import inspect
@@ -11,6 +12,7 @@ import typing
 from collections.abc import Callable
 from typing import Dict, Optional
 
+import bluesky.protocols
 import ophyd
 import ophyd.sim
 import pydantic
@@ -1989,55 +1991,68 @@ _pf2g_processed = {
     "properties": {"is_generator": True},
 }
 
-import bluesky.protocols
-import collections.abc
 
 def _pf2h(
     val1: bluesky.protocols.Readable,
     val2: typing.List[bluesky.protocols.Readable],
-    val3: list[bluesky.protocols.Readable],  
+    val3: list[bluesky.protocols.Readable],
 ):
     yield from [val1, val2, val3]
 
+
 _pf2h_processed = {
     "parameters": [
-        {'annotation': {'type': '__READABLE__'},
-         'convert_device_names': True,
-         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
-         'name': 'val1'},
-        {'annotation': {'type': 'typing.List[__READABLE__]'},
-         'convert_device_names': True,
-         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
-         'name': 'val2'},
-        {'annotation': {'type': 'list[__READABLE__]'},
-         'convert_device_names': True,
-         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
-         'name': 'val3'}        
+        {
+            "annotation": {"type": "__READABLE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val1",
+        },
+        {
+            "annotation": {"type": "typing.List[__READABLE__]"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val2",
+        },
+        {
+            "annotation": {"type": "list[__READABLE__]"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val3",
+        },
     ],
     "properties": {"is_generator": True},
 }
 
+
 def _pf2i(
     val1: bluesky.protocols.Readable,
     val2: bluesky.protocols.Movable,
-    val3: bluesky.protocols.Flyable,  
+    val3: bluesky.protocols.Flyable,
 ):
     yield from [val1, val2, val3]
 
+
 _pf2i_processed = {
     "parameters": [
-        {'annotation': {'type': '__READABLE__'},
-         'convert_device_names': True,
-         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
-         'name': 'val1'},
-        {'annotation': {'type': '__MOVABLE__'},
-         'convert_device_names': True,
-         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
-         'name': 'val2'},
-        {'annotation': {'type': '__FLYABLE__'},
-         'convert_device_names': True,
-         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
-         'name': 'val3'},
+        {
+            "annotation": {"type": "__READABLE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val1",
+        },
+        {
+            "annotation": {"type": "__MOVABLE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val2",
+        },
+        {
+            "annotation": {"type": "__FLYABLE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val3",
+        },
     ],
     "properties": {"is_generator": True},
 }
@@ -2046,25 +2061,43 @@ _pf2i_processed = {
 def _pf2j(
     val1: typing.Callable,
     val2: typing.Callable[[int, float], str],
-    val3: typing.Union[typing.Callable[[int, float], typing.Tuple[str, str]],
-                       typing.List[typing.Callable[[int, float], str]]],  
+    val3: typing.Union[
+        typing.Callable[[int, float], typing.Tuple[str, str]], typing.List[typing.Callable[[int, float], str]]
+    ],
+    val4: typing.Union[
+        collections.abc.Callable[[int, float], typing.Tuple[str, str]],
+        list[collections.abc.Callable[[int, float], str]],
+    ],
 ):
-    yield from [val1, val2, val3]
+    yield from [val1, val2, val3, val4]
+
 
 _pf2j_processed = {
     "parameters": [
-        {'annotation': {'type': '__READABLE__'},
-         'convert_device_names': True,
-         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
-         'name': 'val1'},
-        {'annotation': {'type': '__MOVABLE__'},
-         'convert_device_names': True,
-         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
-         'name': 'val2'},
-        {'annotation': {'type': '__FLYABLE__'},
-         'convert_device_names': True,
-         'kind': {'name': 'POSITIONAL_OR_KEYWORD', 'value': 1},
-         'name': 'val3'},
+        {
+            "annotation": {"type": "__CALLABLE__"},
+            "eval_expressions": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val1",
+        },
+        {
+            "annotation": {"type": "__CALLABLE__"},
+            "eval_expressions": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val2",
+        },
+        {
+            "annotation": {"type": "typing.Union[__CALLABLE__, " "typing.List[__CALLABLE__]]"},
+            "eval_expressions": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val3",
+        },
+        {
+            "annotation": {"type": "typing.Union[__CALLABLE__, " "list[__CALLABLE__]]"},
+            "eval_expressions": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val4",
+        },
     ],
     "properties": {"is_generator": True},
 }
@@ -3148,23 +3181,23 @@ def test_process_plan_5_fail(plan_func, err_msg):
 
 # fmt: off
 @pytest.mark.parametrize(
-        "type_str_in, plans, devices, enums, type_str_out, convert_plans, convert_devices, ev_expr", [
-    ("some_type", None, None, None, "some_type", False, False, False),
-    ("some_type", {}, {}, {}, "some_type", False, False, False),
-    ("__PLAN__", {}, {}, {}, "str", True, False, False),
-    ("__DEVICE__", {}, {}, {}, "str", False, True, False),
-    ("__PLAN_OR_DEVICE__", {}, {}, {}, "str", True, True, False),
-    ("__READABLE__", {}, {}, {}, "str", False, True, False),
-    ("__MOVABLE__", {}, {}, {}, "str", False, True, False),
-    ("__FLYABLE__", {}, {}, {}, "str", False, True, False),
-    ("__CALLABLE__", {}, {}, {}, "str", False, False, True),
-    ("typing.List[__PLAN__]", {}, {}, {}, "typing.List[str]", True, False, False),
-    ("typing.Union[typing.List[__PLAN__], typing.List[__DEVICE__]]", {}, {}, {},
-     "typing.Union[typing.List[str], typing.List[str]]", True, True, False),
-    ("__PLAN__", {"__PLAN__": {}}, {}, {}, "__PLAN__", False, False, False),
-    ("__DEVICE__", {}, {"__DEVICE__": {}}, {}, "__DEVICE__", False, False, False),
-    ("__PLAN_OR_DEVICE__", {}, {}, {"__PLAN_OR_DEVICE__": {}}, "__PLAN_OR_DEVICE__", False, False, False),
-])
+    "type_str_in, plans, devices, enums, type_str_out, convert_plans, convert_devices, ev_expr", [
+        ("some_type", None, None, None, "some_type", False, False, False),
+        ("some_type", {}, {}, {}, "some_type", False, False, False),
+        ("__PLAN__", {}, {}, {}, "str", True, False, False),
+        ("__DEVICE__", {}, {}, {}, "str", False, True, False),
+        ("__PLAN_OR_DEVICE__", {}, {}, {}, "str", True, True, False),
+        ("__READABLE__", {}, {}, {}, "str", False, True, False),
+        ("__MOVABLE__", {}, {}, {}, "str", False, True, False),
+        ("__FLYABLE__", {}, {}, {}, "str", False, True, False),
+        ("__CALLABLE__", {}, {}, {}, "str", False, False, True),
+        ("typing.List[__PLAN__]", {}, {}, {}, "typing.List[str]", True, False, False),
+        ("typing.Union[typing.List[__PLAN__], typing.List[__DEVICE__]]", {}, {}, {},
+            "typing.Union[typing.List[str], typing.List[str]]", True, True, False),
+        ("__PLAN__", {"__PLAN__": {}}, {}, {}, "__PLAN__", False, False, False),
+        ("__DEVICE__", {}, {"__DEVICE__": {}}, {}, "__DEVICE__", False, False, False),
+        ("__PLAN_OR_DEVICE__", {}, {}, {"__PLAN_OR_DEVICE__": {}}, "__PLAN_OR_DEVICE__", False, False, False),
+    ])
 # fmt: on
 def test_find_and_replace_built_in_types_1(
     type_str_in, plans, devices, enums, type_str_out, convert_plans, convert_devices, ev_expr
@@ -3199,43 +3232,43 @@ def _create_schema_for_testing(annotation_type):
 
 # fmt: off
 @pytest.mark.parametrize(
-        "encoded_annotation, type_expected, built_in_plans, built_in_devices, eval_expr, success, errmsg", [
-    ({"type": "int"}, int, False, False, False, True, ""),
-    ({"type": "str"}, str, False, False, False, True, ""),
-    ({"type": "typing.List[int]"}, typing.List[int], False, False, False, True, ""),
-    ({"type": "typing.List[typing.Union[int, float]]"},
-     typing.List[typing.Union[int, float]], False, False, False, True, ""),
-    ({"type": "List[int]"}, typing.List[int], False, False, False, False, "name 'List' is not defined"),
+    "encoded_annotation, type_expected, built_in_plans, built_in_devices, eval_expr, success, errmsg", [
+        ({"type": "int"}, int, False, False, False, True, ""),
+        ({"type": "str"}, str, False, False, False, True, ""),
+        ({"type": "typing.List[int]"}, typing.List[int], False, False, False, True, ""),
+        ({"type": "typing.List[typing.Union[int, float]]"},
+         typing.List[typing.Union[int, float]], False, False, False, True, ""),
+        ({"type": "List[int]"}, typing.List[int], False, False, False, False, "name 'List' is not defined"),
 
-    #  Built-in types: allow any value to pass
-    ({"type": "__PLAN__"}, str, True, False, False, True, ""),
-    ({"type": "typing.List[__PLAN__]"}, typing.List[str], True, False, False, True, ""),
-    ({"type": "__DEVICE__"}, str, False, True, False, True, ""),
-    ({"type": "typing.List[__DEVICE__]"}, typing.List[str], False, True, False, True, ""),
-    ({"type": "__READABLE__"}, str, False, True, False, True, ""),
-    ({"type": "typing.List[__READABLE__]"}, typing.List[str], False, True, False, True, ""),
-    ({"type": "__MOVABLE__"}, str, False, True, False, True, ""),
-    ({"type": "typing.List[__MOVABLE__]"}, typing.List[str], False, True, False, True, ""),
-    ({"type": "__FLYABLE__"}, str, False, True, False, True, ""),
-    ({"type": "typing.List[__FLYABLE__]"}, typing.List[str], False, True, False, True, ""),
-    ({"type": "__PLAN_OR_DEVICE__"}, str, True, True, False, True, ""),
-    ({"type": "typing.List[__PLAN_OR_DEVICE__]"}, typing.List[str], True, True, False, True, ""),
-    ({"type": "typing.Union[typing.List[__PLAN__], __DEVICE__]"},
-     typing.Union[typing.List[str], str], True, True, False, True, ""),
+        #  Built-in types: allow any value to pass
+        ({"type": "__PLAN__"}, str, True, False, False, True, ""),
+        ({"type": "typing.List[__PLAN__]"}, typing.List[str], True, False, False, True, ""),
+        ({"type": "__DEVICE__"}, str, False, True, False, True, ""),
+        ({"type": "typing.List[__DEVICE__]"}, typing.List[str], False, True, False, True, ""),
+        ({"type": "__READABLE__"}, str, False, True, False, True, ""),
+        ({"type": "typing.List[__READABLE__]"}, typing.List[str], False, True, False, True, ""),
+        ({"type": "__MOVABLE__"}, str, False, True, False, True, ""),
+        ({"type": "typing.List[__MOVABLE__]"}, typing.List[str], False, True, False, True, ""),
+        ({"type": "__FLYABLE__"}, str, False, True, False, True, ""),
+        ({"type": "typing.List[__FLYABLE__]"}, typing.List[str], False, True, False, True, ""),
+        ({"type": "__PLAN_OR_DEVICE__"}, str, True, True, False, True, ""),
+        ({"type": "typing.List[__PLAN_OR_DEVICE__]"}, typing.List[str], True, True, False, True, ""),
+        ({"type": "typing.Union[typing.List[__PLAN__], __DEVICE__]"},
+         typing.Union[typing.List[str], str], True, True, False, True, ""),
 
-    ({"type": "__CALLABLE__"}, str, False, False, True, True, ""),
-    ({"type": "typing.List[__CALLABLE__]"}, typing.List[str], False, False, True, True, ""),
+        ({"type": "__CALLABLE__"}, str, False, False, True, True, ""),
+        ({"type": "typing.List[__CALLABLE__]"}, typing.List[str], False, False, True, True, ""),
 
-    # Errors
-    ({"type": "typing.Union[typing.List[Device1], Device2]", "devices": {"Device1": []}},
-     typing.Union[typing.List[str], str], False, False, False, False, "name 'Device2' is not defined"),
-    ({"type": "Enum1", "unknown": {"Enum1": []}}, str, False, False, False, False,
-     r"Annotation contains unsupported keys: \['unknown'\]"),
-    ({"type": "str", "devices": {"Device1": []}}, str, False, False, False, False,
-     r"Type 'Device1' is defined in the annotation, but not used"),
-    ({"type": "Device1", "devices": {"Device1": None}}, str, False, False, False, False,
-     r"The list of items \('Device1': None\) must be a list of a tuple"),
-])
+        # Errors
+        ({"type": "typing.Union[typing.List[Device1], Device2]", "devices": {"Device1": []}},
+         typing.Union[typing.List[str], str], False, False, False, False, "name 'Device2' is not defined"),
+        ({"type": "Enum1", "unknown": {"Enum1": []}}, str, False, False, False, False,
+         r"Annotation contains unsupported keys: \['unknown'\]"),
+        ({"type": "str", "devices": {"Device1": []}}, str, False, False, False, False,
+         r"Type 'Device1' is defined in the annotation, but not used"),
+        ({"type": "Device1", "devices": {"Device1": None}}, str, False, False, False, False,
+         r"The list of items \('Device1': None\) must be a list of a tuple"),
+    ])
 # fmt: on
 def test_process_annotation_1(
     encoded_annotation, type_expected, built_in_plans, built_in_devices, eval_expr, success, errmsg

--- a/bluesky_queueserver/manager/tests/test_zmq_api.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api.py
@@ -823,22 +823,51 @@ def unit_test_read_counter():
 
 def custom_count(
     detectors: typing.List[bluesky.protocols.Readable],
-    num: int=1, delay: typing.Optional[float]=None,
+    num: int=1,
+    delay: typing.Optional[float]=None,
     *,
     per_shot: typing.Optional[typing.Callable]=None,
     md: typing.Optional[dict]=None
 ):
     yield from count(detectors, num=num, delay=delay, per_shot=per_shot, md=md)
 
+@parameter_annotation_decorator(
+    {
+        "description": "Custom 'count' plan with annotated parameters.",
+        "parameters": {
+            "detectors": {
+                "annotation": "typing.List[__READABLE__]",
+            },
+            "num": {
+                "annotation": "int",
+                "default": 1,
+            },
+            "delay": {
+                "annotation": "typing.Optional[float]",
+                "default": None,
+            },
+            "per_shot": {
+                "annotation": "typing.Optional[__CALLABLE__]",
+                "default": None,
+            },
+        },
+    }
+)
+def custom_count2(detectors, num=1, delay=None, *, per_shot=None, md=None):
+    yield from count(detectors, num=num, delay=delay, per_shot=per_shot, md=md)
 """
 
 
-def test_zmq_api_queue_item_add_10(re_manager):  # noqa: F811
+# fmt: off
+@pytest.mark.parametrize("plan_name", ["custom_count", "custom_count2"])
+# fmt: on
+def test_zmq_api_queue_item_add_10(re_manager, plan_name):  # noqa: F811
     """
-    Add and execute custom 'count' plan with custom 'per_shot' plan.
+    Add and execute custom 'count' plan with custom 'per_shot' plan. Test plans with
+    annotations in the header and in the ``parameter_annotation_decorator``.
     """
     _plan_custom = {
-        "name": "custom_count",
+        "name": plan_name,
         "args": [["det1", "det2"]],
         "kwargs": {"num": 5, "per_shot": "custom_one_shot", "delay": 1},
         "item_type": "plan",

--- a/docs/source/plan_annotation.rst
+++ b/docs/source/plan_annotation.rst
@@ -285,10 +285,18 @@ if the default value defined in the plan header or in the decorator has unsuppor
 
 **Supported types for type annotations.** Type annotations may be native Python types
 (such as ``int``, ``float``, ``str``, etc.), ``NoneType``, or generic types that are based
-on native Python types (such as ``typing.List[typing.Union[int, str]]``). Technically the type will
-be accepted if the operation of recreating the type object from its string representation
-using ``eval`` function is successful with the namespace that contains imported ``typing``
-module and ``NoneType`` type.
+on native Python types (such as ``list[int]``, ``typing.List[typing.Union[int, str]]``).
+Technically the type will be accepted if the operation of recreating the type object
+from its string representation using ``eval`` function is successful with the namespace
+that contains imported ``typing`` and ``collections.abc`` modules and ``NoneType`` type.
+The server can recognize and properly handle the following types used in the plan headers
+(see :ref:`defining_types_in_plan_header` and :ref:`parameter_annotation_decorator_parameter_types`):
+
+* ``bluesky.protocols.Readable`` (replaced by ``__READABLE__`` built-in type);
+* ``bluesky.protocols.Movable`` (replaced by ``__MOVABLE__`` built-in type);
+* ``bluesky.protocols.Flyable`` (replaced by ``__FLYABLE__`` built-in type);
+* ``collections.abc.Callable`` (replaced by ``__CALLABLE__`` built-in type);
+* ``typing.Callable`` (replaced by ``__CALLABLE__`` built-in type).
 
 **Supported types of default values.** The default values can be objects of native Python
 types and literal expressions with objects of native Python types. The default value should
@@ -324,6 +332,8 @@ using ``parameter_annotation_decorator`` (:ref:`parameter_annotation_decorator`)
      <code implementing the plan>
 
 
+.. _defining_types_in_plan_header:
+
 Defining Types in Plan Header
 -----------------------------
 
@@ -339,8 +349,9 @@ as having no type hints (unless type annotations for those parameters are define
   Queue Server ignores type hints defined in the plan signature for parameters that have
   type annotations defined in ``parameter_annotation_decorator``.
 
-The acceptable types include Python base types, ``NoneType`` and imports from ``typing`` module
-(see :ref:`supported_types`). Following are the examples of plans with type hints:
+The acceptable types include Python base types, ``NoneType`` and imports from ``typing``
+and ``collections.abc`` modules (see :ref:`supported_types`). Following are the examples
+of plans with type hints:
 
 .. code-block:: python
 
@@ -363,6 +374,13 @@ The acceptable types include Python base types, ``NoneType`` and imports from ``
       #   converted to 'typing.Union[typing.List[float], NoneType]' and
       #   correctly processed by the Queue Server.
       <code implementing the plan>
+
+The server can process the annotations containing Bluesky protocols ``bluesky.protocols.Readable``,
+``bluesky.protocols.Movable`` and ``bluesky.protocols.flyable`` and callable types
+``collections.abc.Callable`` and ``typing.Callable`` with or without type parameters.
+Those types are replaced with ``__READABLE__``, ``__MOVABLE__``, ``__FLYABLE__``
+and ``__CALLABLE__`` built-in types respectively. See the details on built-in types in
+:ref:`parameter_annotation_decorator_parameter_types`.
 
 
 Defining Default Values in Plan Header
@@ -485,6 +503,7 @@ example, the description for the parameter `npts` is not overridden in the decor
       """
       <code implementing the plan>
 
+.. _parameter_annotation_decorator_parameter_types:
 
 Parameter Types
 +++++++++++++++
@@ -575,12 +594,18 @@ The lists of plan and device may contain a mix of explicitly listed plan/device 
 regular expressions used to select plans and devices. See :ref:`lists_of_device_and_plan_names`
 for detailed reference to writing lists of devices and plans.
 
-The decorator supports three built-in types: ``__PLAN__``, ``__DEVICE__`` and
-``__PLAN_OR_DEVICE__``. The built-in types are replaced by ``str`` for type validation and
+The decorator supports the following built-in types: ``__PLAN__``, ``__DEVICE__``,
+``__READABLE__``, ``__MOVABLE__``, ``__FLYABLE__``, ``__PLAN_OR_DEVICE__`` and
+``__CALLABLE__``. The types ``__DEVICES__``, ``__READABLE__``, ``__MOVABLE__`` and ``__FLYABLE__``
+are treated identically by the server, but additional type checks could be added in the future.
+The built-in types are replaced by ``str`` for type validation and
 conversion of plan and/or device names enabled for this parameter. No plan/device lists
 are generated and plan/device name is not validated. The built-in types should not be
 defined in ``devices``, ``plans`` or ``enum`` sections of the parameter annotation, since
-it is going to be treated as a regular custom enum type.
+it is going to be treated as a regular custom enum type. The ``__CALLABLE__`` type is
+treated similary to the other built-in types during parameter validation. The strings
+passed as the parameter values and representing names of python variables or class object
+attributes are converted to references to the respective objects from the worker namespace.
 
 .. code-block:: python
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->

Add new 'default' types for use in plan descriptions: `__READABLE__`, `__MOVABLE__`, `__FLYABLE__` and `__CALLABLE__`. The `__READABLE__`, `__MOVABLE__` and `__FLYABLE__` types are handled by the server identically to the `__DEVICE__` type: the type is treated as `str` for parameter validation, then all the strings passed with the parameter value (elements of a list, values of a dictionary, etc.) are converted to device objects from the list of allowed devices. The strings that do not match device names from the list of allowed devices are passed to the plan as strings (and if those are expected to be device object, the plan fails during execution). 
Proper validation of parameters based of the list of all allowed devices or lists of readable, movable or flyable subsets of the list could be implemented in the future if requested.

The server can identify the following device types in annotations included in plan headers: `bluesky.protocols.Readable`, `bluesky.protocols.Movable`, `bluesky.protocols.Flyable`. Those types are replaced by the default Queue Server types `__READABLE__`, `__MOVABLE__` and `__FLYABLE__`. For example, in the following startup code

```
from typing import List
from bluesky.protocols import Readable, Movable

def plan1(detectors: List[Readable]):
    ...

def plan2(motor: Movable):
    ...
```

the server assigns the parameter `detectors` type `typing.List[__READABLE__]` and the parameter `motor` type `__MOVABLE__`.

Similarly, `__CALLABLE__` type is treated as `str` during parameter validation. All parameter values that have type `str` and match the rules for python variables or dot-separated python variables (e.g. methods of a class), are converted to the respective callable objects. If no respective object is found in namespace, parameter values are passed to the plan as strings. Also, there is no type checking performed on objects, so the plan may still fail if the object is not a callable or a callable with non-matching signature. The server can recognize `collections.abc.Callable` or deprecated `typing.Callable` with or without parameters in plan signatures and replace it with `__CALLABLE__` in plan description.

When finished, this PR is expected to enable completion of https://github.com/bluesky/bluesky/pull/1600

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New default parameter types: `__READABLE__`, `__MOVABLE__`, `__FLYABLE__` and `__CALLABLE__`.
- Support for `bluesky.protocols.Readable`, `bluesky.protocols.Movable`, `bluesky.protocols.Flyable`, `collections.abc.Callable` and `typing.Callable` in plan headers.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were added.

<!--
## Screenshots (if appropriate):
-->

