### PR TITLE
Support for Additional Types in Plan Header Annotations

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2953,6 +2953,7 @@ def _process_plan(plan, *, existing_devices, existing_plans):
             k: [f"bluesky.protocols.{_.__name__}" for _ in v] for k, v in protocols_mapping.items()
         }
         callables_patterns = {"__CALLABLE__": [r"typing.Callable", r"collections.abc.Callable"]}
+        # Patterns for Callable MUST go first
         type_patterns = {**callables_patterns, **protocols_patterns}
 
         ns = {
@@ -2960,10 +2961,6 @@ def _process_plan(plan, *, existing_devices, existing_plans):
             "collections": collections,
             "bluesky": bluesky,
             "NoneType": type(None),
-            "__READABLE__": Readable,
-            "__MOVABLE__": Movable,
-            "__FLYABLE__": Flyable,
-            "__DEVICE__": Movable,  # It doesn't matter what type is assigned
         }
 
         substitutions_dict = {}
@@ -2980,6 +2977,7 @@ def _process_plan(plan, *, existing_devices, existing_plans):
             mapping = {k.__name__: v for k, v in protocols_inv.items()}
             if a_str in mapping:
                 a_str = mapping[a_str]
+                ns[a_str] = annotation  # 'a_str' is __DEVICE__, __READABLE__ or similar
         else:
             # Replace each expression with a unique string in the form of '__CALLABLE<n>__'
             n_patterns = 0  # Number of detected callables

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -2059,6 +2059,88 @@ _pf2i_processed = {
 
 
 def _pf2j(
+    val1: bluesky.protocols.Configurable,
+    val2: bluesky.protocols.Triggerable,
+    val3: bluesky.protocols.Locatable,
+    val4: bluesky.protocols.Stageable,
+    val5: bluesky.protocols.Pausable,
+    val6: bluesky.protocols.Stoppable,
+    val7: bluesky.protocols.Subscribable,
+    val8: bluesky.protocols.Checkable,
+    val9: Optional[bluesky.protocols.Configurable],
+    val10: typing.Union[bluesky.protocols.Triggerable, list[bluesky.protocols.Locatable]],
+):
+    yield from [val1, val2, val3, val4, val5, val6, val7, val8]
+
+
+_pf2j_processed = {
+    "parameters": [
+        {
+            "annotation": {"type": "__DEVICE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val1",
+        },
+        {
+            "annotation": {"type": "__DEVICE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val2",
+        },
+        {
+            "annotation": {"type": "__DEVICE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val3",
+        },
+        {
+            "annotation": {"type": "__DEVICE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val4",
+        },
+        {
+            "annotation": {"type": "__DEVICE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val5",
+        },
+        {
+            "annotation": {"type": "__DEVICE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val6",
+        },
+        {
+            "annotation": {"type": "__DEVICE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val7",
+        },
+        {
+            "annotation": {"type": "__DEVICE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val8",
+        },
+        {
+            "annotation": {"type": "typing.Optional[__DEVICE__]"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val9",
+        },
+        {
+            "annotation": {"type": "typing.Union[__DEVICE__, list[__DEVICE__]]"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val10",
+        },
+    ],
+    "properties": {"is_generator": True},
+}
+
+
+def _pf2k(
     val1: typing.Callable,
     val2: typing.Callable[[int, float], str],
     val3: typing.Union[
@@ -2076,7 +2158,7 @@ def _pf2j(
     yield from [val1, val2, val3, val4, val5]
 
 
-_pf2j_processed = {
+_pf2k_processed = {
     "parameters": [
         {
             "annotation": {"type": "__CALLABLE__"},
@@ -2125,6 +2207,7 @@ _pf2j_processed = {
     (_pf2h, _pf2h_processed),
     (_pf2i, _pf2i_processed),
     (_pf2j, _pf2j_processed),
+    (_pf2k, _pf2k_processed),
 ])
 # fmt: on
 def test_process_plan_2(plan_func, plan_info_expected):

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -6952,6 +6952,13 @@ def _vp3a(
     yield from ["one", "two", "three"]
 
 
+def _vp3b(detectors: typing.Iterable[protocols.Readable]):
+    """
+    Test if type Iterable can be used for the detector (device) list.
+    """
+    yield from ["one", "two", "three"]
+
+
 # Error messages may be different for Pydantic 1 and 2
 if pydantic_version_major == 2:
     err_msg_tvp3a = "Input should be 'm2' [type=enum, input_value='m4', input_type=str]"
@@ -7060,6 +7067,19 @@ else:
     # Int instead of a motor name (validation should fail)
     (_vp3a, {"args": [(0, "m2"), ("d1", "d2"), ("p1",), ("10.0", 20.0)], "kwargs": {}},
      ("m1", "m2", "d1", "d2"), False, err_msg_tvp3l),
+
+    # Parameter "detectors" is 'typing.Iterable[protocols.Readable]'
+    (_vp3b, {"args": [("d1", "d2")], "kwargs": {}},
+     ("d1", "d2"), True, ""),
+    (_vp3b, {"args": [], "kwargs": {"detectors": ("d1", "d2")}},
+     ("d1", "d2"), True, ""),
+    (_vp3b, {"args": [("d1",)], "kwargs": {}},
+     ("d1", "d2"), True, ""),
+    (_vp3b, {"args": ["d1"], "kwargs": {}},
+     ("d1", "d2"), False, "Incorrect parameter type: key='detectors'"),
+    (_vp3b, {"args": [], "kwargs": {"detectors": 'd1'}},
+     ("d1", "d2"), False, "Incorrect parameter type: key='detectors'"),
+
 ])
 # fmt: on
 def test_validate_plan_3(plan_func, plan, allowed_devices, success, errmsg):
@@ -7070,6 +7090,7 @@ def test_validate_plan_3(plan_func, plan, allowed_devices, success, errmsg):
     plan["name"] = plan_func.__name__
     allowed_plans = {
         "_vp3a": _process_plan(_vp3a, existing_devices={}, existing_plans={}),
+        "_vp3b": _process_plan(_vp3b, existing_devices={}, existing_plans={}),
         "p1": {},  # The plan is used only as a parameter value
         "p2": {},  # The plan is used only as a parameter value
     }

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -6952,7 +6952,10 @@ def _vp3a(
     yield from ["one", "two", "three"]
 
 
-def _vp3b(detectors: typing.Iterable[protocols.Readable]):
+def _vp3b(
+    detectors: typing.Iterable[protocols.Readable],
+    motors: typing.Optional[typing.Union[protocols.Movable, typing.Iterable[protocols.Movable]]] = None,
+):
     """
     Test if type Iterable can be used for the detector (device) list.
     """
@@ -7079,6 +7082,13 @@ else:
      ("d1", "d2"), False, "Incorrect parameter type: key='detectors'"),
     (_vp3b, {"args": [], "kwargs": {"detectors": 'd1'}},
      ("d1", "d2"), False, "Incorrect parameter type: key='detectors'"),
+
+    (_vp3b, {"args": [], "kwargs": {"detectors": [], "motors": ("m1", "m2")}},
+     ("m1", "m2"), True, ""),
+    (_vp3b, {"args": [], "kwargs": {"detectors": [], "motors": ("m1",)}},
+     ("m1", "m2"), True, ""),
+    (_vp3b, {"args": [], "kwargs": {"detectors": [], "motors": "m1"}},  # String IS allowed !!
+     ("m1", "m2"), True, ""),
 
 ])
 # fmt: on

--- a/docs/source/plan_annotation.rst
+++ b/docs/source/plan_annotation.rst
@@ -295,8 +295,26 @@ The server can recognize and properly handle the following types used in the pla
 * ``bluesky.protocols.Readable`` (replaced by ``__READABLE__`` built-in type);
 * ``bluesky.protocols.Movable`` (replaced by ``__MOVABLE__`` built-in type);
 * ``bluesky.protocols.Flyable`` (replaced by ``__FLYABLE__`` built-in type);
+* ``bluesky.protocols.Configurable`` (replaced by ``__DEVICE__`` built-in type);
+* ``bluesky.protocols.Triggerable`` (replaced by ``__DEVICE__`` built-in type);
+* ``bluesky.protocols.Locatable`` (replaced by ``__DEVICE__`` built-in type);
+* ``bluesky.protocols.Stageable`` (replaced by ``__DEVICE__`` built-in type);
+* ``bluesky.protocols.Pausable`` (replaced by ``__DEVICE__`` built-in type);
+* ``bluesky.protocols.Stoppable`` (replaced by ``__DEVICE__`` built-in type);
+* ``bluesky.protocols.Subscribable`` (replaced by ``__DEVICE__`` built-in type);
+* ``bluesky.protocols.Checkable`` (replaced by ``__DEVICE__`` built-in type);
 * ``collections.abc.Callable`` (replaced by ``__CALLABLE__`` built-in type);
 * ``typing.Callable`` (replaced by ``__CALLABLE__`` built-in type).
+
+.. note::
+
+  Note, that ``typing.Iterable`` can be used with the types listed above with certain restrictions.
+  If a parameter is annotated as ``typing.Iterable[bluesky.protocols.Readable]``, then the validation
+  will succeed for a list of devices (names of devices), but fails if a single device name is
+  passed to a plan. If a parameter is expected to accept a single device or a list (iterable) of devices,
+  the parameter should be annotated as
+  ``typing.Union[bluesky.protocols.Readable, typing.Iterable[bluesky.protocols.Readable]]``.
+  Validation will fail for a single device if the order of types in the union is reversed.
 
 **Supported types of default values.** The default values can be objects of native Python
 types and literal expressions with objects of native Python types. The default value should
@@ -375,9 +393,9 @@ of plans with type hints:
       #   correctly processed by the Queue Server.
       <code implementing the plan>
 
-The server can process the annotations containing Bluesky protocols ``bluesky.protocols.Readable``,
-``bluesky.protocols.Movable`` and ``bluesky.protocols.flyable`` and callable types
-``collections.abc.Callable`` and ``typing.Callable`` with or without type parameters.
+The server can process the annotations containing Bluesky protocols such as
+``bluesky.protocols.Readable``, ```bluesky.protocols.Movable`` and ``bluesky.protocols.Flyable``
+and callable types ``collections.abc.Callable`` and ``typing.Callable`` with or without type parameters.
 Those types are replaced with ``__READABLE__``, ``__MOVABLE__``, ``__FLYABLE__``
 and ``__CALLABLE__`` built-in types respectively. See the details on built-in types in
 :ref:`parameter_annotation_decorator_parameter_types`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Extend support of types in plan annotation. New supported types:

- typing.Iterable,
- bluesky.protocols.Configurable,
- bluesky.protocols.Triggerable,
- bluesky.protocols.Locatable,
- bluesky.protocols.Stageable,
- bluesky.protocols.Pausable,
- bluesky.protocols.Stoppable,
- bluesky.protocols.Subscribable,
- bluesky.protocols.Checkable,

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The implemented functionality is needed to complete https://github.com/bluesky/bluesky/pull/1610

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Extemded support of types in plan annotation. New supported types: `typing.Iterable`, `bluesky.protocols.Configurable`, `bluesky.protocols.Triggerable`, `bluesky.protocols.Locatable`, `bluesky.protocols.Stageable`, `bluesky.protocols.Pausable`, `bluesky.protocols.Stoppable`, `bluesky.protocols.Subscribable`, `bluesky.protocols.Checkable`. 

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
