### PR TITLE
Use separate temp directories per user for IPython kernel config files

### DIFF
--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -3,6 +3,7 @@ import ast
 import asyncio
 import copy
 import enum
+import getpass
 import json
 import logging
 import os
@@ -1556,7 +1557,8 @@ def qserver_console_base(*, app_name):
         if exit_code == QServerExitCodes.SUCCESS:
             logger.info("IPython Kernel Connect Info: \n%s", pprint.pformat(connect_info))
 
-            file_dir = os.path.join(tempfile.gettempdir(), "qserver", "kernel_files")
+            username = getpass.getuser()
+            file_dir = os.path.join(tempfile.gettempdir(), f"qserver_{username}", "kernel_files")
             file_name = "kernel-" + str(uuid.uuid4()).split("-")[0] + ".json"
             file_path = os.path.join(file_dir, file_name)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The temporary IPython kernel config files were previously saved to `/tmp/qserver/kernel_files` directory. The name is now changed to `/tmp/qserver_<username>/kernel_files` to avoid issues with access permissions. A new kernel config file is created each time a console is started using `qserver-console` or `qserver-qtconsole`.

The changes are not expected to cause noticeable difference in the behavior of the queue server.

<!--- Group the changes in the following sections: -->

### Fixed

The name of temporary directory used by `qserver-console` and `qserver-qtconsole` to store IPython kernel config file now contains user name (`/tmp/qserver_<username>/kernel_files`). 

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested. The code is also covered by multiple unit tests.

<!--
## Screenshots (if appropriate):
-->
