### PR TITLE
Add custom prefix to Redis keys

### DIFF
--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -184,6 +184,7 @@ _key_mapping = {
     "zmq_info_addr": "network/zmq_info_addr",
     "zmq_publish_console": "network/zmq_publish_console",
     "redis_addr": "network/redis_addr",
+    "redis_name_prefix": "network/redis_name_prefix",
     "keep_re": "startup/keep_re",
     "ignore_invalid_plans": "startup/ignore_invalid_plans",
     "existing_plans_and_devices_path": "startup/existing_plans_and_devices_path",
@@ -344,6 +345,7 @@ class Settings:
 
         redis_name_prefix = self._get_param(
             value_default=self._args.redis_name_prefix,
+            value_config=self._get_value_from_config("redis_name_prefix"),
             value_cli=self._args_existing("redis_name_prefix"),
         )
         if not isinstance(redis_name_prefix, str):

--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -342,6 +342,14 @@ class Settings:
             raise ConfigError(f"Redis address is incorrectly formatted: {redis_addr}")
         self._settings["redis_addr"] = redis_addr
 
+        redis_name_prefix = self._get_param(
+            value_default=self._args.redis_name_prefix,
+            value_cli=self._args_existing("redis_name_prefix"),
+        )
+        if not isinstance(redis_name_prefix, str):
+            raise ConfigError(f"Redis name prefix must be a string: {redis_name_prefix!r}")
+        self._settings["redis_name_prefix"] = redis_name_prefix
+
         self._settings["keep_re"] = self._get_param_boolean(
             value_default=args.keep_re,
             value_config=self._get_value_from_config("keep_re"),

--- a/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -21,6 +21,8 @@ properties:
         type: boolean
       redis_addr:
         type: string
+      redis_name_prefix:
+        type: string
   worker:
     type: object
     additionalProperties: false

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -266,6 +266,10 @@ class RunEngineManager(Process):
         if config and ("redis_addr" in config):
             self._ip_redis_server = config["redis_addr"]
 
+        self._redis_name_prefix = "qs_default"
+        if config and ("redis_name_prefix" in config):
+            self._redis_name_prefix = config["redis_name_prefix"]
+
         self._plan_queue = None  # Object of class plan_queue_ops.PlanQueueOperations
 
         self._heartbeat_generator_task = None  # Task for heartbeat generator
@@ -3641,7 +3645,9 @@ class RunEngineManager(Process):
         self._heartbeat_generator_task = asyncio.ensure_future(self._heartbeat_generator(), loop=self._loop)
         self._worker_status_task = asyncio.ensure_future(self._periodic_worker_state_request(), loop=self._loop)
 
-        self._plan_queue = PlanQueueOperations(redis_host=self._ip_redis_server)
+        self._plan_queue = PlanQueueOperations(
+            redis_host=self._ip_redis_server, name_prefix=self._redis_name_prefix
+        )
         await self._plan_queue.start()
 
         # Delete Redis entries (for testing and debugging)

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -75,6 +75,7 @@ class PlanQueueOperations:
         if not isinstance(name_prefix, str):
             raise TypeError(f"Parameter 'name_prefix' should be a string: {name_prefix}")
 
+        # The case of an empty string
         if name_prefix:
             name_prefix = name_prefix + "_"
 

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -20,12 +20,17 @@ class PlanQueueOperations:
     redis_host: str
         Address of Redis host.
 
+    name_prefix: str
+        Prefix for the names of the keys used in Redis. The prefix is used to avoid conflicts
+        with the keys used by other instances of Queue Server. For example, the prefix used
+        for unit tests should be different from the prefix used in production.
+
     Examples
     --------
 
     .. code-block:: python
 
-        pq = PlanQueueOperations()  # Redis located at `localhost`
+        pq = PlanQueueOperations(prefix="qs_unit_test")  # Redis located at `localhost`
         await pq.start()
 
         # Fill queue
@@ -61,23 +66,23 @@ class PlanQueueOperations:
         plan = await pq.set_processed_item_as_stopped(exit_status="stopped")
     """
 
-    def __init__(self, redis_host="localhost"):
+    def __init__(self, redis_host="localhost", name_prefix="qs_default"):
         self._redis_host = redis_host
         self._uid_dict = dict()
         self._r_pool = None
 
-        self._name_running_plan = "running_plan"
-        self._name_plan_queue = "plan_queue"
-        self._name_plan_history = "plan_history"
-        self._name_plan_queue_mode = "plan_queue_mode"
+        self._name_running_plan = name_prefix + "_running_plan"
+        self._name_plan_queue = name_prefix + "_plan_queue"
+        self._name_plan_history = name_prefix + "_plan_history"
+        self._name_plan_queue_mode = name_prefix + "_plan_queue_mode"
 
         # Redis is also used for storage of some additional information not related to the queue.
         #   The class contains only the functions for saving and retrieving the data, which is
         #   not used by other functions of the class.
-        self._name_user_group_permissions = "user_group_permissions"
-        self._name_lock_info = "lock_info"
-        self._name_autostart_mode_info = "autostart_mode_info"
-        self._name_stop_pending_info = "stop_pending_info"
+        self._name_user_group_permissions = name_prefix + "_user_group_permissions"
+        self._name_lock_info = name_prefix + "_lock_info"
+        self._name_autostart_mode_info = name_prefix + "_autostart_mode_info"
+        self._name_stop_pending_info = name_prefix + "_stop_pending_info"
 
         # The list of allowed item parameters used for parameter filtering. Filtering operation
         #   involves removing all parameters that are not in the list.

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -23,7 +23,8 @@ class PlanQueueOperations:
     name_prefix: str
         Prefix for the names of the keys used in Redis. The prefix is used to avoid conflicts
         with the keys used by other instances of Queue Server. For example, the prefix used
-        for unit tests should be different from the prefix used in production.
+        for unit tests should be different from the prefix used in production. If the prefix
+        is an empty string, then no prefix will be added (not recommended).
 
     Examples
     --------
@@ -71,18 +72,24 @@ class PlanQueueOperations:
         self._uid_dict = dict()
         self._r_pool = None
 
-        self._name_running_plan = name_prefix + "_running_plan"
-        self._name_plan_queue = name_prefix + "_plan_queue"
-        self._name_plan_history = name_prefix + "_plan_history"
-        self._name_plan_queue_mode = name_prefix + "_plan_queue_mode"
+        if not isinstance(name_prefix, str):
+            raise TypeError(f"Parameter 'name_prefix' should be a string: {name_prefix}")
+
+        if name_prefix:
+            name_prefix = name_prefix + "_"
+
+        self._name_running_plan = name_prefix + "running_plan"
+        self._name_plan_queue = name_prefix + "plan_queue"
+        self._name_plan_history = name_prefix + "plan_history"
+        self._name_plan_queue_mode = name_prefix + "plan_queue_mode"
 
         # Redis is also used for storage of some additional information not related to the queue.
         #   The class contains only the functions for saving and retrieving the data, which is
         #   not used by other functions of the class.
-        self._name_user_group_permissions = name_prefix + "_user_group_permissions"
-        self._name_lock_info = name_prefix + "_lock_info"
-        self._name_autostart_mode_info = name_prefix + "_autostart_mode_info"
-        self._name_stop_pending_info = name_prefix + "_stop_pending_info"
+        self._name_user_group_permissions = name_prefix + "user_group_permissions"
+        self._name_lock_info = name_prefix + "lock_info"
+        self._name_autostart_mode_info = name_prefix + "autostart_mode_info"
+        self._name_stop_pending_info = name_prefix + "stop_pending_info"
 
         # The list of allowed item parameters used for parameter filtering. Filtering operation
         #   involves removing all parameters that are not in the list.

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -1449,6 +1449,14 @@ def qserver_clear_lock():
         "(default: %(default)s). ",
     )
 
+    parser.add_argument(
+        "--redis-name-prefix",
+        dest="redis_name_prefix",
+        type=str,
+        default="qs_default",
+        help="The prefix for the names of Redis keys used by RE Manager (default: %(default)s). ",
+    )
+
     args = parser.parse_args()
 
     exit_code = 0
@@ -1456,7 +1464,7 @@ def qserver_clear_lock():
     async def remove_lock():
         nonlocal exit_code
         try:
-            pq = PlanQueueOperations(redis_host=args.redis_addr)
+            pq = PlanQueueOperations(redis_host=args.redis_addr, name_prefix=args.redis_name_prefix)
             await pq.start()
             lock_info = await pq.lock_info_retrieve()
             if lock_info is not None:

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -393,6 +393,14 @@ def start_manager():
         "(default: %(default)s). ",
     )
 
+    parser.add_argument(
+        "--redis-name-prefix",
+        dest="redis_name_prefix",
+        type=str,
+        default="qs_default",
+        help="The prefix for the names of Redis keys used by RE Manager (default: %(default)s). ",
+    )
+
     parser.add_argument("--kafka-topic", dest="kafka_topic", type=str, help="The kafka topic to publish to.")
     parser.add_argument(
         "--kafka-server",
@@ -772,6 +780,7 @@ def start_manager():
     config_manager["zmq_private_key"] = settings.zmq_private_key
 
     config_manager["redis_addr"] = settings.redis_addr
+    config_manager["redis_name_prefix"] = settings.redis_name_prefix
 
     config_manager["use_ipython_kernel"] = settings.use_ipython_kernel
 

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -23,7 +23,7 @@ logger = logging.Logger(__name__)
 # User name and user group name used throughout most of the tests.
 _user, _user_group = "Testing Script", "primary"
 
-_redis_name_prefix = "qs_unit_tests"
+_test_redis_name_prefix = "qs_unit_tests"
 
 
 def use_ipykernel_for_tests():

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -23,6 +23,8 @@ logger = logging.Logger(__name__)
 # User name and user group name used throughout most of the tests.
 _user, _user_group = "Testing Script", "primary"
 
+_redis_name_prefix = "qs_unit_tests"
+
 
 def use_ipykernel_for_tests():
     """

--- a/bluesky_queueserver/manager/tests/test_config.py
+++ b/bluesky_queueserver/manager/tests/test_config.py
@@ -164,6 +164,7 @@ network:
   zmq_info_addr: tcp://*:60625
   zmq_publish_console: true
   redis_addr: localhost:6379
+  redis_name_prefix: qs_test
 startup:
   keep_re: true
   startup_dir: ~/.ipython/profile_collection/startup
@@ -191,6 +192,7 @@ network:
   zmq_info_addr: tcp://*:60625
   zmq_publish_console: true
   redis_addr: localhost:6379
+  redis_name_prefix: qs_test
 """
 
 config_01b_success = """
@@ -227,6 +229,7 @@ config_01_dict = {
         "zmq_info_addr": "tcp://*:60625",
         "zmq_publish_console": True,
         "redis_addr": "localhost:6379",
+        "redis_name_prefix": "qs_test",
     },
     "startup": {
         "keep_re": True,

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -103,6 +103,9 @@ def test_running_plan_info():
 
 
 def test_redis_name_prefix():
+    """
+    Test that the prefix is correctly appended to the name of the redis key (test with one key).
+    """
     pq = PlanQueueOperations(name_prefix=_test_redis_name_prefix)
     assert pq._name_plan_queue == _test_redis_name_prefix + "_plan_queue"
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -11,6 +11,8 @@ from bluesky_queueserver.manager.plan_queue_ops import PlanQueueOperations
 
 errmsg_wrong_plan_type = "Parameter 'item' should be a dictionary"
 
+redis_prefix = "qs_unit_tests"
+
 
 class PQ:
     """

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -9,9 +9,9 @@ import pytest
 
 from bluesky_queueserver.manager.plan_queue_ops import PlanQueueOperations
 
-errmsg_wrong_plan_type = "Parameter 'item' should be a dictionary"
+from .common import _redis_name_prefix
 
-redis_prefix = "qs_unit_tests"
+errmsg_wrong_plan_type = "Parameter 'item' should be a dictionary"
 
 
 class PQ:
@@ -27,7 +27,7 @@ class PQ:
         """
         Returns initialized instance of plan queue.
         """
-        self._pq = PlanQueueOperations()
+        self._pq = PlanQueueOperations(name_prefix=_redis_name_prefix)
         await self._pq.start()
         # Clear any pool entries
         await self._pq.delete_pool_entries()
@@ -200,7 +200,7 @@ def test_set_plan_queue_mode_1():
             queue_mode = {"loop": True, "ignore_failures": True}
             await pq.set_plan_queue_mode(queue_mode, update=False)
 
-            pq2 = PlanQueueOperations()
+            pq2 = PlanQueueOperations(name_prefix=_redis_name_prefix)
             await pq2.start()
             assert pq2.plan_queue_mode == queue_mode
 

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -9,7 +9,7 @@ import pytest
 
 from bluesky_queueserver.manager.plan_queue_ops import PlanQueueOperations
 
-from .common import _redis_name_prefix
+from .common import _test_redis_name_prefix
 
 errmsg_wrong_plan_type = "Parameter 'item' should be a dictionary"
 
@@ -27,7 +27,7 @@ class PQ:
         """
         Returns initialized instance of plan queue.
         """
-        self._pq = PlanQueueOperations(name_prefix=_redis_name_prefix)
+        self._pq = PlanQueueOperations(name_prefix=_test_redis_name_prefix)
         await self._pq.start()
         # Clear any pool entries
         await self._pq.delete_pool_entries()
@@ -100,6 +100,14 @@ def test_running_plan_info():
             assert await pq.is_item_running() is False
 
     asyncio.run(testing())
+
+
+def test_redis_name_prefix():
+    pq = PlanQueueOperations(name_prefix=_test_redis_name_prefix)
+    assert pq._name_plan_queue == _test_redis_name_prefix + "_plan_queue"
+
+    pq = PlanQueueOperations(name_prefix="")
+    assert pq._name_plan_queue == "plan_queue"
 
 
 # fmt: off
@@ -200,7 +208,7 @@ def test_set_plan_queue_mode_1():
             queue_mode = {"loop": True, "ignore_failures": True}
             await pq.set_plan_queue_mode(queue_mode, update=False)
 
-            pq2 = PlanQueueOperations(name_prefix=_redis_name_prefix)
+            pq2 = PlanQueueOperations(name_prefix=_test_redis_name_prefix)
             await pq2.start()
             assert pq2.plan_queue_mode == queue_mode
 

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -198,8 +198,8 @@ Other Configuration Parameters
                             [--update-existing-plans-devices {NEVER,ENVIRONMENT_OPEN,ALWAYS}]
                             [--user-group-permissions USER_GROUP_PERMISSIONS_PATH]
                             [--user-group-permissions-reload {NEVER,ON_REQUEST,ON_STARTUP}]
-                            [--redis-addr REDIS_ADDR] [--kafka-topic KAFKA_TOPIC]
-                            [--kafka-server KAFKA_SERVER]
+                            [--redis-addr REDIS_ADDR] [--redis-name-prefix REDIS_NAME_PREFIX]
+                            [--kafka-topic KAFKA_TOPIC] [--kafka-server KAFKA_SERVER]
                             [--zmq-data-proxy-addr ZMQ_DATA_PROXY_ADDR] [--keep-re]
                             [--use-ipython-kernel {ON,OFF}] [--ipython-dir IPYTHON_DIR]
                             [--ipython-matplotlib IPYTHON_MATPLOTLIB]
@@ -212,7 +212,7 @@ Other Configuration Parameters
                             [--verbose | --quiet | --silent]
 
     Start Run Engine (RE) Manager
-    bluesky-queueserver version 0.0.19
+    bluesky-queueserver version 0.0.20
 
     Encryption for ZeroMQ communication server may be enabled by setting the value of
     'QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER' environment variable to a valid private key
@@ -309,6 +309,9 @@ Other Configuration Parameters
       --redis-addr REDIS_ADDR
                         The address of Redis server, e.g. 'localhost', '127.0.0.1',
                         'localhost:6379' (default: localhost).
+      --redis-name-prefix REDIS_NAME_PREFIX
+                        The prefix for the names of Redis keys used by RE Manager (default:
+                        qs_default).
       --kafka-topic KAFKA_TOPIC
                         The kafka topic to publish to.
       --kafka-server KAFKA_SERVER
@@ -418,7 +421,7 @@ periodically requests and displays the status of Queue Server.
                   command [command ...]
 
     Command-line tool for communicating with RE Monitor.
-    bluesky-queueserver version 0.0.18.
+    bluesky-queueserver version 0.0.20.
 
     positional arguments:
       command           a sequence of keywords and parameters that define the command
@@ -640,7 +643,7 @@ the path to the directory with startup files, the path to a startup script or mo
 
     Bluesky-QServer:
     CLI tool for generating the list of plans and devices from beamline startup scripts.
-    bluesky-queueserver version 0.0.19
+    bluesky-queueserver version 0.0.20
 
     options:
       -h, --help        show this help message and exit
@@ -723,7 +726,7 @@ key to ``qserver-zmq-keys`` using ``--zmq-private_key``.
 
     Bluesky-QServer:
     ZMQ security: Generate public-private key pair for ZeroMQ control communication channel.
-    bluesky-queueserver version 0.0.3.post61.dev0+g45f1afb.
+    bluesky-queueserver version 0.0.20.
 
     Generate new public-private key pair for secured 0MQ control connection between
     RE Manager and client applications. If private key is passed as ``--zmq-private-key``
@@ -769,7 +772,7 @@ to 0MQ socket by default. Publishing can be enabled by starting RE Manager with 
 
     Queue Server Console Monitor:
     CLI tool for remote monitoring of console output published by RE Manager.
-    bluesky-queueserver version 0.0.19
+    bluesky-queueserver version 0.0.20
 
     optional arguments:
       -h, --help        show this help message and exit
@@ -802,9 +805,10 @@ address is different from default, the correct address must be passed using the 
 
   $ qserver-clear-lock -h
   usage: qserver-clear-lock [-h] [--redis-addr REDIS_ADDR]
+                                 [--redis-name-prefix REDIS_NAME_PREFIX]
 
   Bluesky-QServer: Clear RE Manager lock.
-  bluesky-queueserver version 0.0.19.
+  bluesky-queueserver version 0.0.20.
 
   Recover locked RE Manager if the lock key is lost. The utility requires access to Redis
   used by RE Manager. Provide the address of Redis service using '--redis-addr' parameter.
@@ -815,6 +819,9 @@ address is different from default, the correct address must be passed using the 
     --redis-addr REDIS_ADDR
                       The address of Redis server, e.g. 'localhost', '127.0.0.1',
                       'localhost:6379' (default: localhost).
+    --redis-name-prefix REDIS_NAME_PREFIX
+                      The prefix for the names of Redis keys used by RE Manager (default:
+                      qs_default).
 
 
 .. _qserver_console_cli:

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -842,7 +842,7 @@ close the worker environment.
   usage: qserver-console [-h] [--zmq-control-addr ZMQ_CONTROL_ADDR]
 
   Bluesky-QServer: Start Jupyter console for IPython kernel running in the worker process.
-  bluesky-queueserver version 0.0.19.
+  bluesky-queueserver version 0.0.20.
 
   Requests IPython kernel connection info from RE Manager and starts Jupyter Console. The RE Worker
   must be running (environment opened) and using IPython kernel. The address of 0MQ control port of

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,6 @@ Bluesky-QueueServer Documentation
    using_queue_server
    features_and_config
    startup_code
-   ipython
    item_validation
    plan_annotation
    cli_tools

--- a/docs/source/ipython.rst
+++ b/docs/source/ipython.rst
@@ -1,5 +1,0 @@
-===========================
-Using IPython Startup Files
-===========================
-
-Documentation is coming soon ...

--- a/docs/source/manager_config.rst
+++ b/docs/source/manager_config.rst
@@ -70,6 +70,7 @@ most of the supported parameters:
       zmq_info_addr: tcp://*:60625
       zmq_publish_console: true
       redis_addr: localhost:6379
+      redis_name_prefix: qs_default
     startup:
       keep_re: true
       startup_dir: ~/.ipython/profile_collection/startup
@@ -131,6 +132,10 @@ Parameters that define for network settings used by RE Manager:
 
 - ``redis_addr`` - the address of Redis server, e.g. ``localhost``, ``127.0.0.1``, ``localhost:6379``.
   The value may also be passed using ``--redis-addr`` CLI parameter.
+
+- ``redis_name_prefix`` - the prefix is appended to the Redis keys to differentiate between keys
+  created by different instances of RE Manager. The value may also be passed using
+  ``--redis-name-prefix`` CLI parameter.
 
 startup
 +++++++
@@ -242,3 +247,24 @@ its subscriptions are fully defined in startup scripts and this section is skipp
 
 - ``databroker_config`` -  databroker configuration (e.g. ``'srx'``) used by Databroker
   callback. The value can also be set using ``--databroker-config`` CLI parameter.
+
+
+Using Redis
+-----------
+
+RE Manager is using Redis as a persistent storage for plan queue, plan history and a few other
+parameters, that are expected to be preserved between RE Manager restarts. Starting from version
+v0.0.20, RE Manager is appending a prefix to each Redis key. The prefix can be used to identify
+the keys created by different instances of RE Manager (not necessarily running simultaneously,
+but maintaining different plan queue and history). The prefixed keys can also be easily
+distinguished from keys created by other applications using the same Redis server. The default
+prefix is ``qs_default``. Custom prefix can be passed using ``--redis-name-prefix`` CLI parameter
+or set in the config file using ``redis_name_prefix`` parameter in the ``network`` section.
+
+.. note::
+
+  It is recommended that Redis server is installed locally on the machine running the Queue Server
+
+Prior to version v0.0.20, RE Manager did not append any prefix to the keys. If it is desirable
+to continue using RE Manager without prefix, e.g. to access the plan queue and history created
+by the older version of RE Manager, pass `""` (empty string) as the parameter value.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

After the code changes in this PR, RE Manager is adding an identical prefix to each Redis key. The default prefix is `qs_default` (the parameter name `plan_queue` becomes `qs_default_plan_queue`, etc.) A custom prefix can be passed using `--redis-name-prefix` CLI parameter or the `redis_name_prefix` parameter in the `network` section of the YML config file. A properly chosen prefix allows to easily distinguish between parameters created by the queue server and other applications using the same Redis server. Two instance of RE Manager using different prefix can share the same Redis server. (It is still recommended that the Redis server is running on the same machine as RE Manager).

RE Manager can still used old names without prefix. Do configure RE Manager to key names without prefix, pass `""` (empty string) to the `--redis-name-prefix` CLI parameter or set `network/redis_name_prefix` key in the YML config file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The motivations for the change:

- keep Redis keys better organized;
- provide an option to separate instances of RE Manager running on the same machine (not necessarily simultaneously), so that each instance could maintain it's own plan queue and history (and other parameters);
- treat RE Manager used in unit tests as a separate instance. All unit tests are now executed using `qs_unit_tests` key prefix, so running unit tests do not change the plan queue and history used for manual testing and development on the same machine (each unit test clears the plan queue and history before and after the test).

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- RE Manager is now adding a prefix to each Redis key name. The default prefix is `qs_default`. Custom prefix can be passed with `--redis-name-prefix` CLI parameter or set as `network/redis_name_prefix` parameter in YML config file.

### Changed

- By default, RE Manager is adding `qs_default` prefix to each Redis key. To access plan queue and history created by older versions of RE Manager, pass `""` (empty string) to `--redis-name-prefix` CLI parameter or `network/redis_name_prefix` parameter in the YML config file.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were added. The existing unit tests were modified.

<!--
## Screenshots (if appropriate):
-->
