### PR TITLE
Disable JSON encoding for interprocess communication

### DIFF
--- a/bluesky_queueserver/manager/json_rpc.py
+++ b/bluesky_queueserver/manager/json_rpc.py
@@ -98,7 +98,7 @@ class JSONRPCResponseManager:
         """
         msgs = {
             -32700: "Parse error",
-            -32600: "Invalid Request",
+            -32600: "Invalid request",
             -32601: "Method not found",
             -32602: "Invalid params",
             -32603: "Internal error",
@@ -174,11 +174,12 @@ class JSONRPCResponseManager:
         (*list(dict)*). Messages in the batch are executed one by one. The response is also a single
         message if input message is *dict* or a batch of messages if the input message is *list(dict)*.
 
-        If a message can not be decoded (invalid JSON), then the response is *None* and should not be
-        sent. The response is also *None* if the input message is a notification or all messages in
-        the batch are notifications. Responses to notifications are not included in the batch of the
-        response messages, so the response batch may contain less messages than the input batch.
-        In any case, if the response is *None*, it should not be sent.
+        If the response value returned by the function is *None*, it should not be sent to client.
+        It happens when the input message is a notification ('id' is missing) or all messages in
+        the batch are notifications. Responses to notifications are not included in the batch of
+        the response messages, so the response batch may contain less messages than the input batch.
+
+        If an input message can not be decoded (invalid JSON), then the response has 'id' set to *None*.
 
         Parameters
         ----------
@@ -199,7 +200,7 @@ class JSONRPCResponseManager:
             try:
                 msg_full = self._decode(msg_full)
             except Exception as ex:
-                raise TypeError(f"Failed to parse the message {msg_full!r}: {ex}") from ex
+                raise TypeError(f"Failed to parse the message '{msg_full}': {ex}") from ex
 
             is_batch = isinstance(msg_full, list)
             if not is_batch:

--- a/bluesky_queueserver/manager/json_rpc.py
+++ b/bluesky_queueserver/manager/json_rpc.py
@@ -1,0 +1,122 @@
+import inspect
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class JSONRPCResponseManager:
+    def __init__(self, *, use_json=True):
+        self._methods = {}
+        self._use_json = use_json
+
+    def add_method(self, handler, method):
+        self._methods[method] = handler
+
+    def _decode(self, msg):
+        if self._use_json:
+            return json.loads(msg)
+        else:
+            return msg
+
+    def _encode(self, msg):
+        if self._use_json:
+            return json.dumps(msg)
+        else:
+            return msg
+
+    def _get_error_msg(self, error_code):
+        msgs = {
+            -32700: "Parse error",
+            -32600: "Invalid Request",
+            -32601: "Method not found",
+            -32602: "Invalid params",
+            -32603: "Internal error",
+            -32000: "Server error",
+        }
+        return msgs.get(error_code, "Unknown error")
+
+    def _handle_single_msg(self, msg):
+        error_code, is_notification, msg_id, response = 0, "id" not in msg, None, None
+
+        try:
+            if not isinstance(msg, dict) or "method" not in msg or "jsonrpc" not in msg or msg["jsonrpc"] != "2.0":
+                error_code = -32600
+                raise TypeError(f"Invalid message format: {msg!r}")
+
+            method = msg["method"]
+            params = msg.get("params", {})
+            msg_id = msg.get("id", None)
+
+            if not isinstance(params, (tuple, list, dict)):
+                error_code = -32602
+                raise TypeError(f"Invalid params in the message {msg!r}")
+
+            handler = self._methods.get(method)
+            if handler is None:
+                error_code = -32601
+                raise TypeError(f"Unknown method: {method}")
+
+            try:
+                if isinstance(params, dict):
+                    inspect.getcallargs(handler, **params)
+                else:
+                    inspect.getcallargs(handler, *params)
+            except Exception as ex:
+                error_code = -32602
+                raise TypeError(f"Invalid params in the message {msg!r}: {ex}") from ex
+
+            try:
+                if isinstance(params, dict):
+                    result = handler(**params)
+                else:  # Tuple or list
+                    result = handler(*params)
+                if not is_notification:
+                    response = {"jsonrpc": "2.0", "id": msg_id, "result": result}
+            except Exception:
+                error_code = -32000
+                raise
+
+        except Exception as ex:
+            if not is_notification:
+                data = {"type": ex.__class__.__name__, "message": str(ex)}
+                error = {"code": error_code, "message": self._get_error_msg(error_code), "data": data}
+                response = {"jsonrpc": "2.0", "id": msg_id, "error": error}
+
+        return response
+
+    def handle(self, msg_full):
+        response, is_batch = [], False
+
+        try:
+            try:
+                msg_full = self._decode(msg_full)
+            except Exception as ex:
+                raise TypeError(f"Failed to parse the message {msg_full!r}: {ex}") from ex
+
+            is_batch = isinstance(msg_full, list)
+            if not is_batch:
+                msg_full = [msg_full]
+
+            for msg in msg_full:
+                single_response = self._handle_single_msg(msg)
+                if single_response:
+                    response.append(single_response)
+
+            if not response:
+                response = None
+            elif not is_batch:
+                response = response[0]
+
+            if response:
+                response = self._encode(response)
+        except Exception as ex:
+            data = {"type": ex.__class__.__name__, "message": str(ex)}
+            response = {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": self._get_error_msg(-32700), "data": data},
+            }
+            response = self._encode(response)
+
+        return response

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -3816,6 +3816,7 @@ class RunEngineManager(Process):
                 self._heartbeat_generator_task.cancel()
                 self._comm_to_watchdog.stop()
                 self._comm_to_worker.stop()
+                await self._plan_queue.stop()
                 self._zmq_socket.close()
                 logger.info("RE Manager was stopped by ZMQ command.")
                 break

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -3634,10 +3634,12 @@ class RunEngineManager(Process):
 
         self._comm_to_watchdog = PipeJsonRpcSendAsync(
             conn=self._watchdog_conn,
+            use_json=False,
             name="RE Manager-Watchdog Comm",
         )
         self._comm_to_worker = PipeJsonRpcSendAsync(
             conn=self._worker_conn,
+            use_json=False,
             name="RE Manager-Worker Comm",
             timeout=self._comm_to_worker_timeout,
         )

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -273,6 +273,14 @@ class PlanQueueOperations:
                 self._plan_queue_uid = self.new_item_uid()
                 self._plan_history_uid = self.new_item_uid()
 
+    async def stop(self):
+        """
+        Close all connections in the pool.
+        """
+        if self._r_pool:
+            await self._r_pool.aclose()
+            self._r_pool = None
+
     async def _queue_clean(self):
         """
         Delete all the invalid queue entries (there could be some entries from failed unit tests).

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -65,6 +65,9 @@ class PlanQueueOperations:
         # Assume that we paused and then stopped the plan. Clear the running plan and
         #   push it back to the queue. Also create the respective history entry.
         plan = await pq.set_processed_item_as_stopped(exit_status="stopped")
+
+        # 'stopping' disconnects all connections. This step is not required in normal use.
+        await pq.stop()
     """
 
     def __init__(self, redis_host="localhost", name_prefix="qs_default"):

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -56,7 +56,7 @@ class WatchdogProcess:
 
         # Class that supports communication over the pipe
         self._comm_to_manager = PipeJsonRpcReceive(
-            conn=self._watchdog_to_manager_conn, name="RE Watchdog-Manager Comm"
+            conn=self._watchdog_to_manager_conn, use_json=False, name="RE Watchdog-Manager Comm"
         )
 
         self._watchdog_state = 0  # State is currently just time since last notification

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -3,6 +3,8 @@ import atexit
 import logging
 import os
 import re
+import signal
+import sys
 import threading
 import time as ttime
 from multiprocessing import Pipe, Queue
@@ -222,7 +224,58 @@ class WatchdogProcess:
         logger.info("RE Watchdog is stopped")
 
 
+class AtTerm:
+    def __init__(self):
+        """
+        Replaces the standard handler for SIGTERM (not SIGKILL). Executes the list of
+        registered functions before calling the standard handler.
+
+        Examples
+        --------
+
+        .. code-block::
+
+            # Configuring the AtTerm object
+            atterm = AtTerm()
+
+            # Somewhere at the beginning of the program
+            atterm.replace_sigterm_handler()
+
+            # Register functions to be executed at SIGTERM
+            def cleanup():
+                # <some code>
+
+            atterm.register(cleanup)
+        """
+        self._sigterm_standard_handler = None
+        self._registered_funcs = []
+
+    def _sigterm_custom_handler(self, signum, frame):
+        logger.info("Terminating the process ...")
+        for func in reversed(self._registered_funcs):
+            func()
+        signal.signal(signal.SIGTERM, self._sigterm_standard_handler)
+        sys.exit(1)
+
+    def replace_sigterm_handler(self):
+        """
+        Replaces standard handler for SIGTERM with the custom handler. The custom
+        handler calls the standard handler after calling all registered functions
+        in the reverse order.
+        """
+        self._sigterm_standard_handler = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGTERM, self._sigterm_custom_handler)
+
+    def register(self, func):
+        """
+        Register a function (signature has no parameters and returns no values).
+        Registered functions are executed in reverse order when processing 'SIGTERM'.
+        """
+        self._registered_funcs.append(func)
+
+
 def start_manager():
+
     s_enc = (
         "Encryption for ZeroMQ communication server may be enabled by setting the value of\n"
         "'QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER' environment variable to a valid private key\n"
@@ -236,6 +289,9 @@ def start_manager():
     def formatter(prog):
         # Set maximum width such that printed help mostly fits in the RTD theme code block (documentation).
         return argparse.RawDescriptionHelpFormatter(prog, max_help_position=20, width=90)
+
+    atterm = AtTerm()
+    atterm.replace_sigterm_handler()
 
     parser = argparse.ArgumentParser(
         description=f"Start Run Engine (RE) Manager\nbluesky-queueserver version {__version__}\n\n{s_enc}",
@@ -799,6 +855,7 @@ def start_manager():
 
         # Make sure that all processes are killed before exit
         atexit.register(kill_all_processes)
+        atterm.register(kill_all_processes)
 
         wp.run()
     except KeyboardInterrupt:

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -513,7 +513,7 @@ class ReManager:
             except Exception as ex:
                 # The manager is not responsive, so just kill the process.
                 if self._p:
-                    self._p.kill()
+                    self._p.terminate()
                     self._p.wait(timeout)
                 assert False, f"RE Manager failed to stop: {str(ex)}"
 
@@ -533,7 +533,7 @@ class ReManager:
             Timeout in seconds.
         """
         if self._p:
-            self._p.kill()
+            self._p.terminate()
             self._p.wait(timeout)
             clear_redis_pool(redis_name_prefix=self._used_redis_name_prefix)
 
@@ -569,6 +569,7 @@ def re_manager_cmd():
         # Wait until RE Manager is started. Raise exception if the server failed to start.
         if not wait_for_condition(time=10, condition=condition_manager_idle):
             failed_to_start = True
+            re["re"].kill_manager()
             raise TimeoutError("Timeout: RE Manager failed to start.")
 
         _reset_queue_mode()
@@ -606,6 +607,7 @@ def re_manager():
     # Wait until RE Manager is started. Raise exception if the server failed to start.
     if not wait_for_condition(time=10, condition=condition_manager_idle):
         failed_to_start = True
+        re.kill_manager()
         raise TimeoutError("Timeout: RE Manager failed to start.")
 
     _reset_queue_mode()
@@ -630,6 +632,7 @@ def re_manager_pc_copy(tmp_path):
     # Wait until RE Manager is started. Raise exception if the server failed to start.
     if not wait_for_condition(time=10, condition=condition_manager_idle):
         failed_to_start = True
+        re.kill_manager()
         raise TimeoutError("Timeout: RE Manager failed to start.")
 
     _reset_queue_mode()

--- a/bluesky_queueserver/manager/tests/common.py
+++ b/bluesky_queueserver/manager/tests/common.py
@@ -362,6 +362,7 @@ def clear_redis_pool(redis_name_prefix=_test_redis_name_prefix):
         await pq.lock_info_clear()
         await pq.autostart_mode_clear()
         await pq.stop_pending_clear()
+        await pq.stop()
 
     asyncio.run(run())
 

--- a/bluesky_queueserver/manager/tests/test_json_rpc.py
+++ b/bluesky_queueserver/manager/tests/test_json_rpc.py
@@ -1,0 +1,18 @@
+import pytest
+
+from ..json_rpc import JSONRPCResponseManager
+
+
+# fmt: off
+@pytest.mark.parametrize("use_json", [None, True, False])
+# fmt: on
+def test_json_rpc_init(use_json):
+    if use_json is None:
+        params = {}
+    elif use_json in (True, False):
+        params = {"use_json": use_json}
+    else:
+        assert False, f"Unknown value of 'use_json': {use_json}"
+
+    rm = JSONRPCResponseManager(**params)
+    assert rm._use_json == (use_json if use_json is not None else True)

--- a/bluesky_queueserver/manager/tests/test_json_rpc.py
+++ b/bluesky_queueserver/manager/tests/test_json_rpc.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from ..json_rpc import JSONRPCResponseManager
@@ -16,3 +18,146 @@ def test_json_rpc_init(use_json):
 
     rm = JSONRPCResponseManager(**params)
     assert rm._use_json == (use_json if use_json is not None else True)
+
+
+def _method1():
+    return 1
+
+
+def _method2(a):
+    return a
+
+
+def _method3():
+    pass
+
+
+def _method4():
+    raise RuntimeError("Error in 'method4'")
+
+
+methods = {
+    "method1": _method1,
+    "method2": _method2,
+    "method3": _method3,
+    "method4": _method4,
+}
+
+
+# fmt: off
+@pytest.mark.parametrize("use_json", [True, False])
+@pytest.mark.parametrize("msg_in, msg_resp", [
+    ([], None),  # Empty batch
+    ({"jsonrpc": "2.0", "method": "method1", "id": 1}, {'id': 1, 'jsonrpc': '2.0', 'result': 1}),
+    ({"jsonrpc": "2.0", "method": "method1"}, None),  # Notification
+    ({"jsonrpc": "2.0", "method": "method1", "params": [], "id": 1}, {'id': 1, 'jsonrpc': '2.0', 'result': 1}),
+    ({"jsonrpc": "2.0", "method": "method1", "params": {}, "id": 1}, {'id': 1, 'jsonrpc': '2.0', 'result': 1}),
+    ({"jsonrpc": "2.0", "method": "method2", "params": [10], "id": 1},
+     {'id': 1, 'jsonrpc': '2.0', 'result': 10}),
+    ({"jsonrpc": "2.0", "method": "method2", "params": {"a": 10}, "id": 1},
+     {'id': 1, 'jsonrpc': '2.0', 'result': 10}),
+
+    # Batch
+    ([{"jsonrpc": "2.0", "method": "method2", "params": [10], "id": 1}],
+     [{'id': 1, 'jsonrpc': '2.0', 'result': 10}]),
+    ([{"jsonrpc": "2.0", "method": "method2", "params": [10]}], None),  # Notification
+    ([{"jsonrpc": "2.0", "method": "method2", "params": [10], "id": 1},
+      {"jsonrpc": "2.0", "method": "method2", "params": [5]}],  # Notification
+     [{'id': 1, 'jsonrpc': '2.0', 'result': 10}]),
+
+    # Method returns None
+    ({"jsonrpc": "2.0", "method": "method3", "id": 1}, {'id': 1, 'jsonrpc': '2.0', 'result': None}),
+
+    # Invalid request
+    ({"method": "method1", "id": 1},  # Missing 'jsonrpc'
+     {"jsonrpc": "2.0", "id": None, "error":  # ID is None
+      {"code": -32600, "message": "Invalid request", "data":
+       {"type": "TypeError", "message": "Invalid message format: {'method': 'method1', 'id': 1}"}}}),
+    ({"json_rpc": "1.0", "method": "method1", "id": 1},  # Incorrect version of 'jsonrpc'
+     {"jsonrpc": "2.0", "id": None, "error":  # ID is None
+      {"code": -32600, "message": "Invalid request", "data":
+       {"type": "TypeError",
+        "message": "Invalid message format: {'json_rpc': '1.0', 'method': 'method1', 'id': 1}"}}}),
+    ({"json_rpc": "2.0", "id": 1},  # 'method' is missing
+     {"jsonrpc": "2.0", "id": None, "error":  # ID is None
+      {"code": -32600, "message": "Invalid request", "data":
+       {"type": "TypeError", "message": "Invalid message format: {'json_rpc': '2.0', 'id': 1}"}}}),
+
+    # Unknown method
+    ({"jsonrpc": "2.0", "method": "unknown", "id": 1},
+     {'jsonrpc': '2.0', 'id': 1, 'error':
+      {'code': -32601, 'message': 'Method not found', 'data':
+       {'type': 'TypeError', 'message': 'Unknown method: unknown'}}}),
+
+    # Invalid params
+    ({"jsonrpc": "2.0", "method": "method2", "params": 10, "id": 1},  # Params should be list or dict
+     {"jsonrpc": "2.0", "id": 1, "error":
+      {"code": -32602, "message": "Invalid params", "data":
+       {"type": "TypeError",
+        "message": "Invalid params in the message {'jsonrpc': '2.0', 'method': 'method2', 'params': 10, 'id': 1}"
+        }}}),
+    ({"jsonrpc": "2.0", "method": "method2", "params": {"b": 10}, "id": 1},  # No param 'b'
+     {"jsonrpc": "2.0", "id": 1, "error":
+      {"code": -32602, "message": "Invalid params", "data":
+       {"type": "TypeError",
+        "message": (
+            "Invalid params in the message {'jsonrpc': '2.0', 'method': 'method2', 'params': "
+            "{'b': 10}, 'id': 1}: _method2() got an unexpected keyword argument 'b'")
+        }}}),
+
+    # Server error
+    ({"jsonrpc": "2.0", "method": "method4", "id": 1},
+     {"jsonrpc": "2.0", "id": 1, "error":
+      {"code": -32000, "message": "Server error", "data":
+       {"type": "RuntimeError", "message": "Error in 'method4'"}}}),
+
+    # Errors in batches of messages
+    ([{"jsonrpc": "2.0", "method": "unknown", "id": 2},
+      {"jsonrpc": "2.0", "method": "method2", "params": [10], "id": 1},
+      {"jsonrpc": "2.0", "method": "method4", "id": 3}],
+     [{'id': 2, 'jsonrpc': '2.0', 'error':
+       {'code': -32601, 'message': 'Method not found', 'data':
+        {'type': 'TypeError', 'message': 'Unknown method: unknown'}}},
+      {'id': 1, 'jsonrpc': '2.0', 'result': 10},
+      {"jsonrpc": "2.0", "id": 3, "error":
+       {"code": -32000, "message": "Server error", "data":
+        {"type": "RuntimeError", "message": "Error in 'method4'"}}}
+      ]),
+])
+# fmt: on
+def test_json_rpc_handle(use_json, msg_in, msg_resp):
+    rm = JSONRPCResponseManager(use_json=use_json)
+    for k, v in methods.items():
+        rm.add_method(v, k)
+
+    if use_json:
+        msg_in = json.dumps(msg_in)
+    resp = rm.handle(msg_in)
+    if use_json and resp is not None:
+        resp = json.loads(resp)
+    assert resp == msg_resp
+
+
+def test_json_rpc_corrupt_message():
+    """
+    Test the case when the handler fails to decode JSON message.
+    """
+    rm = JSONRPCResponseManager(use_json=True)
+    msg = "{'json_rpc}"
+    resp = rm.handle(msg)
+    resp = json.loads(resp)
+    assert resp == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {
+            "code": -32700,
+            "message": "Parse error",
+            "data": {
+                "type": "TypeError",
+                "message": (
+                    "Failed to parse the message '{'json_rpc}': Expecting property name "
+                    "enclosed in double quotes: line 1 column 2 (char 1)"
+                ),
+            },
+        },
+    }

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -49,6 +49,26 @@ class PQ:
         await self._pq.stop_pending_clear()
 
 
+def test_pq_start_stop():
+    """
+    Test for the ``PlanQueueOperations.start()`` and ``PlanQueueOperations.stop()``
+    """
+
+    async def testing():
+        pq = PlanQueueOperations(name_prefix=_test_redis_name_prefix)
+        await pq.start()
+        await pq._r_pool.ping()
+        await pq.stop()
+        assert pq._r_pool is None
+
+        await pq.start()
+        await pq._r_pool.ping()
+        await pq.stop()
+        assert pq._r_pool is None
+
+    asyncio.run(testing())
+
+
 # fmt: off
 @pytest.mark.parametrize("item_in, item_out", [
     ({"name": "plan1", "item_uid": "abcde"}, {"name": "plan1", "item_uid": "abcde"}),

--- a/bluesky_queueserver/manager/tests/test_scenarios.py
+++ b/bluesky_queueserver/manager/tests/test_scenarios.py
@@ -486,7 +486,7 @@ def unit_test_download_data():
 # fmt: off
 @pytest.mark.parametrize("background", [False, True])
 # fmt: on
-@pytest.mark.xfail(reason="Test is unreliable on CI, but expected to pass locally")
+# @pytest.mark.xfail(reason="Test is unreliable on CI, but expected to pass locally")
 def test_large_datasets_01(re_manager, background):  # noqa: F811
     """
     Submit large array as a function parameter. When running functions on background
@@ -555,7 +555,7 @@ def plan_large_array(vlist, n):
 """
 
 
-@pytest.mark.xfail(reason="Test is unreliable on CI, but expected to pass locally")
+# @pytest.mark.xfail(reason="Test is unreliable on CI, but expected to pass locally")
 def test_large_datasets_02(re_manager):  # noqa: F811
     """
     Submit large array as a plan parameter. Then download the queue that contains the plan.
@@ -619,7 +619,7 @@ _plan_move_then_count = {
     (_plan_move_then_count, 10000, 60000),
 ])
 # fmt: on
-@pytest.mark.xfail(reason="Test is unreliable on CI, but expected to pass locally")
+# @pytest.mark.xfail(reason="Test is unreliable on CI, but expected to pass locally")
 def test_large_datasets_03(re_manager, plan, n_plans, timeout_ms):  # noqa: F811
     """
     Submit large number of plans to the queue as a batch.

--- a/bluesky_queueserver/manager/tests/test_scenarios.py
+++ b/bluesky_queueserver/manager/tests/test_scenarios.py
@@ -486,7 +486,6 @@ def unit_test_download_data():
 # fmt: off
 @pytest.mark.parametrize("background", [False, True])
 # fmt: on
-# @pytest.mark.xfail(reason="Test is unreliable on CI, but expected to pass locally")
 def test_large_datasets_01(re_manager, background):  # noqa: F811
     """
     Submit large array as a function parameter. When running functions on background
@@ -555,7 +554,6 @@ def plan_large_array(vlist, n):
 """
 
 
-# @pytest.mark.xfail(reason="Test is unreliable on CI, but expected to pass locally")
 def test_large_datasets_02(re_manager):  # noqa: F811
     """
     Submit large array as a plan parameter. Then download the queue that contains the plan.
@@ -619,7 +617,6 @@ _plan_move_then_count = {
     (_plan_move_then_count, 10000, 60000),
 ])
 # fmt: on
-# @pytest.mark.xfail(reason="Test is unreliable on CI, but expected to pass locally")
 def test_large_datasets_03(re_manager, plan, n_plans, timeout_ms):  # noqa: F811
     """
     Submit large number of plans to the queue as a batch.

--- a/bluesky_queueserver/manager/tests/test_start_manager.py
+++ b/bluesky_queueserver/manager/tests/test_start_manager.py
@@ -1,10 +1,13 @@
-# import json
+import json
 import logging
 import threading
 import time as ttime
 
 from bluesky_queueserver.manager.start_manager import WatchdogProcess
 from bluesky_queueserver.tests.common import format_jsonrpc_msg
+
+# Must match the settings in WatchdogProcess class
+_use_json = False
 
 
 class ReManagerEmulation(threading.Thread):
@@ -41,7 +44,7 @@ class ReManagerEmulation(threading.Thread):
         hb_period, dt = 0.5, 0.01
         n_wait = round(hb_period / dt)
         msg = format_jsonrpc_msg("heartbeat", {"value": "alive"}, notification=True)
-        msg_json = msg  # json.dumps(msg)
+        msg_json = json.dumps(msg) if _use_json else msg
         while True:
             # Since we are emulating 'kill' method, we want the function to
             #   react to 'exit' quickly.
@@ -74,13 +77,13 @@ class ReManagerEmulation(threading.Thread):
         #   this is acceptable for testing. Timeout would typically indicate an error.
         msg = format_jsonrpc_msg(method, params, notification=notification)
         with self._lock:
-            msg_json = msg  # json.dumps(msg)
+            msg_json = json.dumps(msg) if _use_json else msg
             self._conn_watchdog.send(msg_json)
             if notification:
                 return
             if self._conn_watchdog.poll(timeout):
                 response_json = self._conn_watchdog.recv()
-                response = response_json  # json.loads(response_json)
+                response = json.loads(response_json) if _use_json else response_json
                 result = response["result"]
             else:
                 result = None
@@ -102,7 +105,7 @@ class ReManagerEmulation(threading.Thread):
 
         if not self._restart:
             msg = format_jsonrpc_msg("manager_stopping", notification=True)
-            msg_json = msg  # json.dumps(msg)
+            msg_json = json.dumps(msg) if _use_json else msg
             with self._lock:
                 self._conn_watchdog.send(msg_json)
 

--- a/bluesky_queueserver/manager/tests/test_start_manager.py
+++ b/bluesky_queueserver/manager/tests/test_start_manager.py
@@ -1,4 +1,4 @@
-import json
+# import json
 import logging
 import threading
 import time as ttime
@@ -41,7 +41,7 @@ class ReManagerEmulation(threading.Thread):
         hb_period, dt = 0.5, 0.01
         n_wait = round(hb_period / dt)
         msg = format_jsonrpc_msg("heartbeat", {"value": "alive"}, notification=True)
-        msg_json = json.dumps(msg)
+        msg_json = msg  # json.dumps(msg)
         while True:
             # Since we are emulating 'kill' method, we want the function to
             #   react to 'exit' quickly.
@@ -74,12 +74,13 @@ class ReManagerEmulation(threading.Thread):
         #   this is acceptable for testing. Timeout would typically indicate an error.
         msg = format_jsonrpc_msg(method, params, notification=notification)
         with self._lock:
-            self._conn_watchdog.send(json.dumps(msg))
+            msg_json = msg  # json.dumps(msg)
+            self._conn_watchdog.send(msg_json)
             if notification:
                 return
             if self._conn_watchdog.poll(timeout):
                 response_json = self._conn_watchdog.recv()
-                response = json.loads(response_json)
+                response = response_json  # json.loads(response_json)
                 result = response["result"]
             else:
                 result = None
@@ -101,8 +102,9 @@ class ReManagerEmulation(threading.Thread):
 
         if not self._restart:
             msg = format_jsonrpc_msg("manager_stopping", notification=True)
+            msg_json = msg  # json.dumps(msg)
             with self._lock:
-                self._conn_watchdog.send(json.dumps(msg))
+                self._conn_watchdog.send(msg_json)
 
         th_hb.join()
 

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1346,7 +1346,7 @@ class RunEngineWorker(Process):
         self._run_reg_cb = CallbackRegisterRun(run_list=self._active_run_list)
 
         # Class that supports communication over the pipe
-        self._comm_to_manager = PipeJsonRpcReceive(conn=self._conn, name="RE Worker-Manager Comm")
+        self._comm_to_manager = PipeJsonRpcReceive(conn=self._conn, use_json=False, name="RE Worker-Manager Comm")
 
         self._comm_to_manager.add_method(self._request_state_handler, "request_state")
         self._comm_to_manager.add_method(self._request_ip_connect_info, "request_ip_connect_info")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ numpydoc
 openpyxl
 ophyd
 packaging
+pandas
+pyarrow
 pydantic
 python-multipart
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ bluesky-kafka
 databroker
 event-model
 ipykernel
-json-rpc
 jsonschema
 jupyter-client>=7.4.2
 jupyter-console


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Queue Server is using JSON RPC protocol for communication between the manager process and other processes. In this PR the communication code is modified so that the messages are not encoded as JSON string by the process sending the message and the decoded by the receiving process. Conversion data (e.g. a large array) to and from a JSON string is slow and completely unnecessary for interprocess communication within one application. Instead, the JSON RPC message is sent as a dictionary via `multiprocessing.Pipe`, which automatically pickles the outgoing message and then unpickles it at the receiving end. The change does not affect user-facing API, but is expected to make Queue Server more stable due to shorter  interprocess communication delays.

Other changes: `json-rpc` package is replaced with custom implementation of JSON RPC handler, which supports the option to enable/disable JSON encoding (`json-rpc` is no longer a dependency); new parameter `use_json` in the constructors of `PipeJsonRpcReceive` and `PipeJsonRpcSendAsync` classes; better processing of `SIGTERM` by the watchdog process, which is now reliably closes the manager and the worker processes (e.g. if `kill <pid>` is called on the watchdog process, it does not work with `kill -9 <pid>`)

