### PR TITLE
Use is_plan from bluesky utils

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -24,6 +24,8 @@ import yaml
 from numpydoc.docscrape import NumpyDocString
 from packaging import version
 
+from bluesky.utils import is_plan
+
 import bluesky_queueserver
 
 from .logging_setup import PPrintForLogging as ppfl
@@ -687,13 +689,6 @@ def load_script_into_existing_nspace(
                     del sys.modules[key]
 
             sys.path.remove(script_root_path)
-
-
-def is_plan(obj):
-    """
-    Returns ``True`` if the object is a plan.
-    """
-    return inspect.isgeneratorfunction(obj)
 
 
 def is_device(obj):

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -697,6 +697,7 @@ def is_plan(obj):
     try:
         # If available, use is_plan from bs utils to catch plans with new decorator.
         from bluesky.utils import is_plan as bs_utils_is_plan
+
         return bs_utils_is_plan(obj)
     except ImportError:
         return inspect.isgeneratorfunction(obj)

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -21,10 +21,9 @@ from collections.abc import Iterable, Mapping
 import jsonschema
 import pydantic
 import yaml
+from bluesky.utils import is_plan
 from numpydoc.docscrape import NumpyDocString
 from packaging import version
-
-from bluesky.utils import is_plan
 
 import bluesky_queueserver
 

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -21,7 +21,6 @@ from collections.abc import Iterable, Mapping
 import jsonschema
 import pydantic
 import yaml
-from bluesky.utils import is_plan
 from numpydoc.docscrape import NumpyDocString
 from packaging import version
 
@@ -688,6 +687,19 @@ def load_script_into_existing_nspace(
                     del sys.modules[key]
 
             sys.path.remove(script_root_path)
+
+
+def is_plan(obj):
+    """
+    Returns ``True`` if the object is a plan.
+    """
+
+    try:
+        # If available, use is_plan from bs utils to catch plans with new decorator.
+        from bluesky.utils import is_plan as bs_utils_is_plan
+        return bs_utils_is_plan(obj)
+    except ImportError:
+        return inspect.isgeneratorfunction(obj)
 
 
 def is_device(obj):

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -3760,7 +3760,7 @@ def test_construct_parameters_1(testmode, success, errmsg):
 # ---------------------------------------------------------------------------------
 
 
-def test_plans_from_nspace():
+def test_plans_from_nspace_1():
     """
     Function 'plans_from_nspace' is extracting a subset of callable items from the namespace
     """
@@ -3769,6 +3769,18 @@ def test_plans_from_nspace():
     plans = plans_from_nspace(nspace)
     for name, plan in plans.items():
         assert callable(plan), f"Plan '{name}' is not callable"
+
+
+def test_plans_from_nspace_2():
+    """
+    Function 'plans_from_nspace' is extracting a subset of callable items from the namespace
+    """
+    pc_path = get_default_startup_dir()
+    nspace = load_profile_collection(pc_path)
+    plans = plans_from_nspace(nspace)
+    assert "mv" in plans
+    assert "mvr" in plans
+    assert "null" in plans
 
 
 def test_devices_from_nspace():

--- a/bluesky_queueserver/profile_collection_sim/00-ophyd.py
+++ b/bluesky_queueserver/profile_collection_sim/00-ophyd.py
@@ -1,6 +1,8 @@
 # flake8: noqa
 print(f"Loading file {__file__!r}")
 
+# Import some built-in plans
+from bluesky.plan_stubs import mv, mvr, null
 from ophyd.sim import hw
 
 # Import ALL simulated Ophyd objects in global namespace (borrowed from ophyd.sim)

--- a/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
+++ b/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
@@ -2049,6 +2049,60 @@ existing_plans:
       step: '0.01'
     properties:
       is_generator: true
+  mv:
+    description: Move one or more devices to a setpoint. Wait for all to complete.
+    module: bluesky.plan_stubs
+    name: mv
+    parameters:
+    - description: device1, value1, device2, value2, ...
+      kind:
+        name: VAR_POSITIONAL
+        value: 2
+      name: args
+    - default: None
+      description: Used to mark these as a unit to be waited on.
+      kind:
+        name: KEYWORD_ONLY
+        value: 3
+      name: group
+    - description: passed to obj.set()
+      kind:
+        name: VAR_KEYWORD
+        value: 4
+      name: kwargs
+    properties:
+      is_generator: true
+  mvr:
+    description: Move one or more devices to a relative setpoint. Wait for all to
+      complete.
+    module: bluesky.plan_stubs
+    name: mvr
+    parameters:
+    - description: device1, value1, device2, value2, ...
+      kind:
+        name: VAR_POSITIONAL
+        value: 2
+      name: args
+    - default: None
+      description: Used to mark these as a unit to be waited on.
+      kind:
+        name: KEYWORD_ONLY
+        value: 3
+      name: group
+    - description: passed to obj.set()
+      kind:
+        name: VAR_KEYWORD
+        value: 4
+      name: kwargs
+    properties:
+      is_generator: true
+  'null':
+    description: Yield a no-op Message. (Primarily for debugging and testing.)
+    module: bluesky.plan_stubs
+    name: 'null'
+    parameters: []
+    properties:
+      is_generator: true
   plan_test_progress_bars:
     description: Test visualization of progress bars.
     module: __main__


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Switch to use new `is_plan` function from bluesky utils.

## Motivation and Context
Solves #305 . Requires https://github.com/bluesky/bluesky/pull/1780 to be released, and pinned in the `requirements` file.

## Summary of Changes for Release Notes
Remove `is_plan` function, use instead the equivalent from bluesky utils that can handle the decorated functions.

### Fixed
Bluesky builtin plans that use the `@plan` decorator are now correctly identified by queueserver.

