### PR TITLE
MNT: pass callbacks directly to _RE.__call__

### DIFF
--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -463,8 +463,6 @@ class RunEngineWorker(Process):
         plan_info = parameters
 
         try:
-            from bluesky.preprocessors import subs_wrapper
-
             with self._allowed_items_lock:
                 allowed_plans, allowed_devices = self._allowed_plans, self._allowed_devices
 
@@ -492,8 +490,11 @@ class RunEngineWorker(Process):
 
             def get_start_plan_func(plan_func, plan_args, plan_kwargs, plan_meta):
                 def start_plan_func():
-                    g = subs_wrapper(plan_func(*plan_args, **plan_kwargs), {"all": [self._run_reg_cb]})
-                    return self._RE(g, **plan_meta)
+                    return self._RE(
+                        plan_func(*plan_args, **plan_kwargs),
+                        {"all": [self._run_reg_cb]},
+                        **plan_meta
+                    )
 
                 return start_plan_func
 

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -490,11 +490,7 @@ class RunEngineWorker(Process):
 
             def get_start_plan_func(plan_func, plan_args, plan_kwargs, plan_meta):
                 def start_plan_func():
-                    return self._RE(
-                        plan_func(*plan_args, **plan_kwargs),
-                        {"all": [self._run_reg_cb]},
-                        **plan_meta
-                    )
+                    return self._RE(plan_func(*plan_args, **plan_kwargs), {"all": [self._run_reg_cb]}, **plan_meta)
 
                 return start_plan_func
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -106,9 +106,6 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
-import sphinx_rtd_theme
-
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The second positional argument to RE() is subscriptions to processed for that invocation.  This avoids adding one more layer to the callstack and a possible confusion with plans that do not set their own name being reported as having the `'plan_name'` of `'subs_wrapper'` in the start document.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This caused some confusion at HEX.  The ultimate fix is that plans that generate start documents should insert their own name into the meta-data of the `open_run` plan so that when used from inside of a bigger plan the name is stable.  This change will not fix the ultimate problem, but it will change what the user sees to be the name of the plan they wrote so it will be clearer what is going on and what they have to do to fix it.

## Summary of Changes for Release Notes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Expect all tests to pass after this change and there to be no meaningful user-facing change.