### PR TITLE
shift requirements to dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,3 +22,5 @@ sphinx
 sphinx_rtd_theme
 # Extra dependencies for development
 fastapi[all]
+pandas
+pyarrow

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,5 +22,8 @@ sphinx
 sphinx_rtd_theme
 # Extra dependencies for development
 fastapi[all]
+# moved from requirements.txt
 pandas
 pyarrow
+matplotlib # Needed for BEC, should be factored out
+scikit-image # Needed for BEC/other stuff to run, factor out

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,6 @@ numpydoc
 openpyxl
 ophyd
 packaging
-pandas
-pyarrow
 pydantic
 python-multipart
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@ ipykernel
 jsonschema
 jupyter-client>=7.4.2
 jupyter-console
-matplotlib # Needed for BEC, should be factored out
-scikit-image # Needed for BEC/other stuff to run, factor out
 msgpack>=1.0.0
 msgpack_numpy
 numpydoc


### PR DESCRIPTION
Both pyarrow and pandas were added as package requirements in commit  672f579 as part of PR#301.  Neither of these are imported by this package.  Shift the both of them to `requirements-dev.txt`.

## Motivation and Context
We ran into an installation dependency in https://github.com/prjemian/model_instrument/pull/5#issuecomment-2408085385.  On inspection, this seems not to be a real requirement of this package.
