### PR TITLE
Add support for NamedMovable protocol

### DIFF
--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2938,9 +2938,16 @@ def _process_plan(plan, *, existing_devices, existing_plans):
             Triggerable,
         )
 
+        # TODO: remove try-except block when 'bluesky.protocols.NamedMovable' is
+        # available in every Bluesky deployment
+        try:
+            from bluesky.protocols import NamedMovable
+        except ImportError:
+            NamedMovable = Movable
+
         protocols_mapping = {
             "__READABLE__": [Readable],
-            "__MOVABLE__": [Movable],
+            "__MOVABLE__": [Movable, NamedMovable],
             "__FLYABLE__": [Flyable],
             "__DEVICE__": [
                 Configurable,
@@ -3301,9 +3308,14 @@ def _prepare_devices(devices, *, max_depth=0, ignore_all_subdevices_if_one_fails
     from ophyd.areadetector import ADBase
 
     def get_device_params(device):
+        movable_protocols = [protocols.Movable]
+        # TODO: remove this check when NamedMovable is available in every Bluesky deployment
+        if hasattr(protocols, "NamedMovable"):
+            movable_protocols.append(protocols.NamedMovable)
+
         return {
             "is_readable": isinstance(device, protocols.Readable),
-            "is_movable": isinstance(device, protocols.Movable),
+            "is_movable": isinstance(device, movable_protocols),
             "is_flyable": isinstance(device, protocols.Flyable),
             "classname": type(device).__name__,
             "module": type(device).__module__,

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -2938,11 +2938,10 @@ def _process_plan(plan, *, existing_devices, existing_plans):
             Triggerable,
         )
 
-        # TODO: remove try-except block when 'bluesky.protocols.NamedMovable' is
-        # available in every Bluesky deployment
-        try:
+        # TODO: remove this check once NameMovable becomes standard
+        if hasattr(bluesky.protocols, "NamedMovable"):
             from bluesky.protocols import NamedMovable
-        except ImportError:
+        else:
             NamedMovable = Movable
 
         protocols_mapping = {
@@ -3308,10 +3307,10 @@ def _prepare_devices(devices, *, max_depth=0, ignore_all_subdevices_if_one_fails
     from ophyd.areadetector import ADBase
 
     def get_device_params(device):
-        movable_protocols = [protocols.Movable]
+        movable_protocols = (protocols.Movable,)
         # TODO: remove this check when NamedMovable is available in every Bluesky deployment
         if hasattr(protocols, "NamedMovable"):
-            movable_protocols.append(protocols.NamedMovable)
+            movable_protocols = (*movable_protocols, protocols.NamedMovable)
 
         return {
             "is_readable": isinstance(device, protocols.Readable),

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -2028,7 +2028,8 @@ _pf2h_processed = {
 def _pf2i(
     val1: bluesky.protocols.Readable,
     val2: bluesky.protocols.Movable,
-    val3: bluesky.protocols.Flyable,
+    val3: bluesky.protocols.Movable,
+    val4: bluesky.protocols.Flyable,
 ):
     yield from [val1, val2, val3]
 
@@ -2048,10 +2049,16 @@ _pf2i_processed = {
             "name": "val2",
         },
         {
-            "annotation": {"type": "__FLYABLE__"},
+            "annotation": {"type": "__MOVABLE__"},
             "convert_device_names": True,
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "name": "val3",
+        },
+        {
+            "annotation": {"type": "__FLYABLE__"},
+            "convert_device_names": True,
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "name": "val4",
         },
     ],
     "properties": {"is_generator": True},

--- a/docs/source/plan_annotation.rst
+++ b/docs/source/plan_annotation.rst
@@ -294,6 +294,7 @@ The server can recognize and properly handle the following types used in the pla
 
 * ``bluesky.protocols.Readable`` (replaced by ``__READABLE__`` built-in type);
 * ``bluesky.protocols.Movable`` (replaced by ``__MOVABLE__`` built-in type);
+* ``bluesky.protocols.NamedMovable`` (replaced by ``__MOVABLE__`` built-in type);
 * ``bluesky.protocols.Flyable`` (replaced by ``__FLYABLE__`` built-in type);
 * ``bluesky.protocols.Configurable`` (replaced by ``__DEVICE__`` built-in type);
 * ``bluesky.protocols.Triggerable`` (replaced by ``__DEVICE__`` built-in type);
@@ -394,8 +395,9 @@ of plans with type hints:
       <code implementing the plan>
 
 The server can process the annotations containing Bluesky protocols such as
-``bluesky.protocols.Readable``, ```bluesky.protocols.Movable`` and ``bluesky.protocols.Flyable``
-and callable types ``collections.abc.Callable`` and ``typing.Callable`` with or without type parameters.
+``bluesky.protocols.Readable``, ``bluesky.protocols.Movable``, ``bluesky.protocols.NamedMovable``
+and ``bluesky.protocols.Flyable`` and callable types ``collections.abc.Callable`` and
+``typing.Callable`` with or without type parameters.
 Those types are replaced with ``__READABLE__``, ``__MOVABLE__``, ``__FLYABLE__``
 and ``__CALLABLE__`` built-in types respectively. See the details on built-in types in
 :ref:`parameter_annotation_decorator_parameter_types`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add support for `bluesky.protocols.NamedMovable` to resolve https://github.com/bluesky/bluesky-queueserver/issues/310
Queue server handles the protocol identically to `bluesky.protocols.Movable`.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Added

- Support for `bluesky.protocols.NamedMovable` protocol.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test case is added to unit tests.