### PR TITLE
Fix IPKernel config handling

### DIFF
--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1797,10 +1797,10 @@ class RunEngineWorker(Process):
                 """Find the IP address to use for the IPython kernel."""
                 if ip_str == "localhost":
                     return "127.0.0.1"
-                    
+
                 if ip_str != "auto":
                     return ip_str
-                    
+
                 # Try to determine IP automatically
                 try:
                     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -1808,7 +1808,7 @@ class RunEngineWorker(Process):
                     ip_address = sock.getsockname()[0]
                     sock.close()
                     return str(ip_address)
-                    
+
                 except Exception as e:
                     logger.error("Error determining IP automatically: %s", str(e))
                     return "127.0.0.1"  # Fallback to localhost
@@ -1837,7 +1837,6 @@ class RunEngineWorker(Process):
 
                 self._ip_kernel_monitor_always_allow_types = ["error"]
                 self._ip_kernel_monitor_collected_tracebacks = []
-
 
                 logger.info("Initializing IPython kernel ...")
                 self._ip_kernel_app.initialize([])

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1826,10 +1826,11 @@ class RunEngineWorker(Process):
             if self._success_startup:
 
                 def start_jupyter_client():
-                    from jupyter_client import BlockingKernelClient
+                    # from jupyter_client import BlockingKernelClient
 
-                    self._ip_kernel_client = BlockingKernelClient()
-                    self._ip_kernel_client.load_connection_info(self._ip_connect_info)
+                    # self._ip_kernel_client = BlockingKernelClient()
+                    # self._ip_kernel_client.load_connection_info(self._ip_connect_info)
+                    self._ip_kernel_client = self._ip_kernel_app.blocking_client()
                     logger.info(
                         "Session ID for communication with IP kernel: %s", self._ip_kernel_client.session.session
                     )
@@ -1842,8 +1843,6 @@ class RunEngineWorker(Process):
                     )
                     ip_kernel_iopub_monitor_thread.start()
 
-                start_jupyter_client()
-
                 self._ip_kernel_monitor_always_allow_types = ["error"]
                 self._ip_kernel_monitor_collected_tracebacks = []
 
@@ -1853,7 +1852,11 @@ class RunEngineWorker(Process):
                 self._ip_kernel_app.initialize([])
                 logger.info("IPython kernel initialization is complete.")
 
+                self._ip_connect_info = self._ip_kernel_app.get_connection_info()
+
                 ttime.sleep(0.2)  # Wait until the error message are delivered (if startup fails)
+
+                start_jupyter_client()
 
                 self._ip_kernel_monitor_always_allow_types = ["stream", "error", "execute_result"]
                 collected_tracebacks = self._ip_kernel_monitor_collected_tracebacks

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1822,6 +1822,7 @@ class RunEngineWorker(Process):
             if self._success_startup:
 
                 def start_jupyter_client():
+                    logger.info("Starting IPython kernel client ...")
                     self._ip_kernel_client = self._ip_kernel_app.blocking_client()
                     logger.info(
                         "Session ID for communication with IP kernel: %s", self._ip_kernel_client.session.session
@@ -1838,7 +1839,6 @@ class RunEngineWorker(Process):
                 self._ip_kernel_monitor_always_allow_types = ["error"]
                 self._ip_kernel_monitor_collected_tracebacks = []
 
-                ttime.sleep(0.5)  # Wait unitl 0MQ monitor is connected to the kernel ports
 
                 logger.info("Initializing IPython kernel ...")
                 self._ip_kernel_app.initialize([])
@@ -1847,6 +1847,8 @@ class RunEngineWorker(Process):
                 ttime.sleep(0.2)  # Wait until the error message are delivered (if startup fails)
 
                 start_jupyter_client()
+                # TODO: are those sleeps still relevant?
+                ttime.sleep(0.5)  # Wait unitl 0MQ monitor is connected to the kernel ports
 
                 self._ip_kernel_monitor_always_allow_types = ["stream", "error", "execute_result"]
                 collected_tracebacks = self._ip_kernel_monitor_collected_tracebacks

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1794,7 +1794,7 @@ class RunEngineWorker(Process):
             # Echo all the output to sys.__stdout__ and sys.__stderr__ during kernel initialization
             self._ip_kernel_app.quiet = False
 
-            # TODO: add type hints and check for exceptions for the socket connection ... not every host hast access to 8.8.8.8
+            # TODO: add type hints and check for exceptions for the socket connection
             def find_kernel_ip(ip_str):
                 if ip_str == "localhost":
                     ip = "127.0.0.1"
@@ -1859,7 +1859,10 @@ class RunEngineWorker(Process):
                 self._ip_kernel_app.quiet = True
 
                 # Print connect info for the kernel (after kernel initialization)
-                logger.info("IPython kernel connection info:\n %r", ppfl(self._request_ip_connect_info().get("ip_connect_info")))
+                logger.info(
+                    "IPython kernel connection info:\n %r",
+                    ppfl(self._request_ip_connect_info().get("ip_connect_info")),
+                )
 
                 th_abandoned_plans = threading.Thread(target=self._monitor_abandoned_plans_thread, daemon=True)
                 th_abandoned_plans.start()

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -185,7 +185,6 @@ class RunEngineWorker(Process):
         self._use_ipython_kernel = self._config_dict["use_ipython_kernel"]
         self._ip_kernel_app = None  # Reference to IPKernelApp, None if IPython is not used
         self._ip_connect_file = ""  # Filename with connection info for the running IP kernel
-        self._ip_connect_info = {}  # Connection info for the running IP Kernel
         self._ip_kernel_client = None  # Kernel client for communication with IP kernel.
         self._ip_kernel_state = IPKernelState.DISABLED
         self._ip_kernel_monitor_stop = False
@@ -934,7 +933,7 @@ class RunEngineWorker(Process):
         Return IP connect info obtained from IPython kernel. Returns ``{}`` if
         worker is using pure Python.
         """
-        connect_info = copy.deepcopy(self._ip_connect_info)
+        connect_info = copy.deepcopy(self._ip_kernel_app.get_connection_info())
         connect_info["key"] = connect_info["key"].decode("utf-8")
         return {"ip_connect_info": connect_info}
 
@@ -1837,8 +1836,6 @@ class RunEngineWorker(Process):
                 self._ip_kernel_app.initialize([])
                 logger.info("IPython kernel initialization is complete.")
 
-                self._ip_connect_info = self._ip_kernel_app.get_connection_info()
-
                 ttime.sleep(0.2)  # Wait until the error message are delivered (if startup fails)
 
                 start_jupyter_client()
@@ -1860,6 +1857,7 @@ class RunEngineWorker(Process):
 
                 # Disable echoing, since startup code is already loaded
                 self._ip_kernel_app.quiet = True
+                # TODO: check whether this this call is required. `self._ip_kernel_app.initialize([])` calls `init_io` internally. 
                 self._ip_kernel_app.init_io()
 
                 # Print connect info for the kernel (after kernel initialization)

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1857,8 +1857,6 @@ class RunEngineWorker(Process):
 
                 # Disable echoing, since startup code is already loaded
                 self._ip_kernel_app.quiet = True
-                # TODO: check whether this this call is required. `self._ip_kernel_app.initialize([])` calls `init_io` internally. 
-                self._ip_kernel_app.init_io()
 
                 # Print connect info for the kernel (after kernel initialization)
                 logger.info("IPython kernel connection info:\n %r", ppfl(self._request_ip_connect_info().get("ip_connect_info")))

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1797,6 +1797,7 @@ class RunEngineWorker(Process):
             # Echo all the output to sys.__stdout__ and sys.__stderr__ during kernel initialization
             self._ip_kernel_app.quiet = False
 
+            # TODO: add type hints and check for exceptions for the socket connection ... not every host hast access to 8.8.8.8
             def find_kernel_ip(ip_str):
                 if ip_str == "localhost":
                     ip = "127.0.0.1"
@@ -1826,10 +1827,6 @@ class RunEngineWorker(Process):
             if self._success_startup:
 
                 def start_jupyter_client():
-                    # from jupyter_client import BlockingKernelClient
-
-                    # self._ip_kernel_client = BlockingKernelClient()
-                    # self._ip_kernel_client.load_connection_info(self._ip_connect_info)
                     self._ip_kernel_client = self._ip_kernel_app.blocking_client()
                     logger.info(
                         "Session ID for communication with IP kernel: %s", self._ip_kernel_client.session.session
@@ -1878,9 +1875,7 @@ class RunEngineWorker(Process):
                 self._ip_kernel_app.init_io()
 
                 # Print connect info for the kernel (after kernel initialization)
-                cinfo = copy.deepcopy(self._ip_connect_info)
-                cinfo["key"] = cinfo["key"].decode("utf-8")
-                logger.info("IPython kernel connection info:\n %r", ppfl(cinfo))
+                logger.info("IPython kernel connection info:\n %r", ppfl(self._request_ip_connect_info().get("ip_connect_info")))
 
                 th_abandoned_plans = threading.Thread(target=self._monitor_abandoned_plans_thread, daemon=True)
                 th_abandoned_plans.start()

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -184,7 +184,6 @@ class RunEngineWorker(Process):
 
         self._use_ipython_kernel = self._config_dict["use_ipython_kernel"]
         self._ip_kernel_app = None  # Reference to IPKernelApp, None if IPython is not used
-        self._ip_connect_file = ""  # Filename with connection info for the running IP kernel
         self._ip_kernel_client = None  # Kernel client for communication with IP kernel.
         self._ip_kernel_state = IPKernelState.DISABLED
         self._ip_kernel_monitor_stop = False
@@ -1853,8 +1852,6 @@ class RunEngineWorker(Process):
                 self._ip_kernel_monitor_always_allow_types = ["stream", "error", "execute_result"]
                 collected_tracebacks = self._ip_kernel_monitor_collected_tracebacks
                 self._ip_kernel_monitor_collected_tracebacks = None
-
-                self._ip_connect_file = self._ip_kernel_app.connection_file
 
                 # This is a very naive idea: if no exceptions were raised during kernel initialization
                 #   the we consider that startup code was loaded and the environment is fully functional

--- a/bluesky_queueserver/manager/worker.py
+++ b/bluesky_queueserver/manager/worker.py
@@ -1762,8 +1762,6 @@ class RunEngineWorker(Process):
 
             from ipykernel.kernelapp import IPKernelApp
 
-            from .utils import generate_random_port
-
             self._re_namespace["___ip_execution_loop_start___"] = self._run_loop_ipython
             self._re_namespace["___ip_kernel_startup_init___"] = self._ip_kernel_startup_init
             self._ip_kernel_app = IPKernelApp.instance(user_ns=self._re_namespace)
@@ -1811,18 +1809,8 @@ class RunEngineWorker(Process):
 
             logger.info("Generating random port numbers for IPython kernel ...")
             kernel_ip = self._config_dict["ipython_kernel_ip"]
-            try:
-                kernel_ip = find_kernel_ip(kernel_ip)
-                self._ip_kernel_app.ip = kernel_ip
-                self._ip_kernel_app.shell_port = generate_random_port(kernel_ip)
-                self._ip_kernel_app.iopub_port = generate_random_port(kernel_ip)
-                self._ip_kernel_app.stdin_port = generate_random_port(kernel_ip)
-                self._ip_kernel_app.hb_port = generate_random_port(kernel_ip)
-                self._ip_kernel_app.control_port = generate_random_port(kernel_ip)
-                self._ip_connect_info = self._ip_kernel_app.get_connection_info()
-            except Exception as ex:
-                self._success_startup = False
-                logger.error("Failed to generates kernel ports for IP %r: %s", kernel_ip, ex)
+            kernel_ip = find_kernel_ip(kernel_ip)
+            self._ip_kernel_app.ip = kernel_ip
 
             if self._success_startup:
 


### PR DESCRIPTION
# Fix errors arising from disregarding the `ipython-kernel-config.py`

## Description
Providing a kernel configuration makes the re-manager fail to load the environment with an ipython kernel.
See #314 for details.

## Motivation and Context
When using an ipython kernel, users will expect the provided configuration for the kernel in the profile directory to be obeyed.
The bug resulted from explicitly defining a kernel-client with connection information produced in scope, rather than providing the IPKernelApp with the respective overwrites and creating the client from the KernelApp.

## Summary of Changes for Release Notes
### Fixed
No direct fixes as the expected behavior can be achieved by arranging the code.

### Added
- the `find_kernel_ip` function is made a little more robust in case the socket calls are failing

### Changed
- the sequence in which the `IPKernelApp` and the `BlockingKernelClient` are created are reversed.
- the `BlockingKernelClient` is obtained via the provided method from IPKernelApp `self._ip_kernel_client = self._ip_kernel_app.blocking_client()`

### Removed
- `self._ip_connect_file` removed because is was never used.
- `self._ip_connect_info` was removed because there is no real reason to keep this state, the info can be obtained from by calling `self._ip_kernel_app.get_connection_info()`
- the calles to `generate_random_port(kernel_ip)` have been removed, as the IPKernelApp will used random ports be default, or read the ports from the config or an existing connection file.


## How Has This Been Tested?
The configurations for two different profile setups are provided in issue #314.
Both cases work as expected.
Additionally, invoking `start-re-manager --use-ipython-kernel=ON` with a profile that doesn't bear a configuration, will behave identically to the existing implementation.
