### PR TITLE
Mention Redis database number in documentation

### DIFF
--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -1445,7 +1445,7 @@ def qserver_clear_lock():
         dest="redis_addr",
         type=str,
         default="localhost",
-        help="The address of Redis server, e.g. 'localhost', '127.0.0.1', 'localhost:6379' "
+        help="The address of Redis server, e.g. 'localhost', '127.0.0.1', 'localhost:6379', 'localhost:6379/0'"
         "(default: %(default)s). ",
     )
 

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -445,7 +445,7 @@ def start_manager():
         dest="redis_addr",
         type=str,
         default="localhost",
-        help="The address of Redis server, e.g. 'localhost', '127.0.0.1', 'localhost:6379' "
+        help="The address of Redis server, e.g. 'localhost', '127.0.0.1', 'localhost:6379', 'localhost:6379/0'."
         "(default: %(default)s). ",
     )
 

--- a/bluesky_queueserver/manager/tests/test_manager_options.py
+++ b/bluesky_queueserver/manager/tests/test_manager_options.py
@@ -190,6 +190,7 @@ def test_manager_acq_with_0MQ_proxy(re_manager_cmd, zmq_proxy, zmq_dispatcher): 
 @pytest.mark.parametrize("redis_addr, success", [
     ("localhost", True),
     ("localhost:6379", True),
+    ("localhost:6379/0", True),
     ("localhost:6378", False)])  # Incorrect port.
 # fmt: on
 def test_manager_redis_addr_parameter(re_manager_cmd, redis_addr, success):  # noqa: F811

--- a/docs/source/cli_tools.rst
+++ b/docs/source/cli_tools.rst
@@ -339,7 +339,7 @@ Other Configuration Parameters
                       API request is received (default: ON_STARTUP)
     --redis-addr REDIS_ADDR
                       The address of Redis server, e.g. 'localhost', '127.0.0.1',
-                      'localhost:6379' (default: localhost).
+                      'localhost:6379', 'localhost:6379/0' (default: localhost).
     --redis-name-prefix REDIS_NAME_PREFIX
                       The prefix for the names of Redis keys used by RE Manager (default:
                       qs_default).
@@ -891,7 +891,7 @@ address is different from default, the correct address must be passed using the 
     -h, --help        show this help message and exit
     --redis-addr REDIS_ADDR
                       The address of Redis server, e.g. 'localhost', '127.0.0.1',
-                      'localhost:6379' (default: localhost).
+                      'localhost:6379', 'localhost:6379/0' (default: localhost).
     --redis-name-prefix REDIS_NAME_PREFIX
                       The prefix for the names of Redis keys used by RE Manager (default:
                       qs_default).

--- a/docs/source/manager_config.rst
+++ b/docs/source/manager_config.rst
@@ -166,7 +166,8 @@ Parameters that define for network settings used by RE Manager:
   ``--zmq-publish-console`` CLI parameter.
 
 - ``redis_addr`` - the address of Redis server, e.g. ``localhost``, ``127.0.0.1``, ``localhost:6379``.
-  The value may also be passed using ``--redis-addr`` CLI parameter.
+  The address may also contain a Redis database number, e.g. ``localhost:6379/0``.
+  Redis address may also be passed using ``--redis-addr`` CLI parameter.
 
 - ``redis_name_prefix`` - the prefix is appended to the Redis keys to differentiate between keys
   created by different instances of RE Manager. The value may also be passed using


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Redis database number may be specified as part of Redis address, e.g. `localhost:6379/0` and passed with `network/redis_addr` parameter in the config file or with `--redis-addr` CLI parameter. 

PR contains no code changes. Test case was added to one of the unit tests.

Related issue: https://github.com/bluesky/bluesky-queueserver/issues/316

