### PR TITLE
Support for components (children) of ophyd-async devices

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,13 +9,11 @@ jobs:
     strategy:
       matrix:
         use-ipykernel: [false, true]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         zmq-encoding: ["json", "msgpack"]
         # pydantic-version: ["<2.0.0", ">=2.0.0"]
         group: [1, 2, 3]
         exclude:
-          - python-version: "3.9"
-            zmq-encoding: "msgpack"
           - python-version: "3.10"
             zmq-encoding: "msgpack"
           - python-version: "3.11"

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -677,9 +677,10 @@ def is_device(obj):
     """
     Returns ``True`` if the object is a device.
     """
-    from bluesky.protocols import Flyable, HasName, Readable
+    from bluesky.protocols import Flyable, Readable
 
-    return isinstance(obj, (HasName, Readable, Flyable)) and not inspect.isclass(obj)
+    # Detect ophyd-async devices, which are not readable nor flyable by checking existence of 'children' attribute
+    return (isinstance(obj, (Readable, Flyable)) or hasattr(obj, "children")) and not inspect.isclass(obj)
 
 
 def _process_registered_objects(*, nspace, reg_objs, validator, obj_type):

--- a/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
+++ b/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
@@ -2155,6 +2155,14 @@ existing_plans:
         name: KEYWORD_ONLY
         value: 3
       name: group
+    - annotation:
+        type: typing.Optional[float]
+      default: None
+      description: Specify a maximum time that the move(s) can be waited for.
+      kind:
+        name: KEYWORD_ONLY
+        value: 3
+      name: timeout
     - description: passed to obj.set()
       kind:
         name: VAR_KEYWORD
@@ -2184,6 +2192,14 @@ existing_plans:
         name: KEYWORD_ONLY
         value: 3
       name: group
+    - annotation:
+        type: typing.Optional[float]
+      default: None
+      description: Specify a maximum time that the move(s) can be waited for.
+      kind:
+        name: KEYWORD_ONLY
+        value: 3
+      name: timeout
     - description: passed to obj.set()
       kind:
         name: VAR_KEYWORD

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,3 +27,7 @@ pandas
 pyarrow
 matplotlib # Needed for BEC, should be factored out
 scikit-image # Needed for BEC/other stuff to run, factor out
+# Dependencies of ophyd-async
+h5py
+aioca
+ophyd-async


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The PR resolves the issues https://github.com/bluesky/bluesky-queueserver/issues/327 and https://github.com/bluesky/bluesky-queueserver/issues/328.

Now the Queue Server can properly handle children of Ophyd Async devices and include then in the lists of existing and allowed devices. Also, names of the children of the Ophyd Async devices can now be passed as plan parameters and Queue Server properly converts the names (strings) to the device objects from the namespace.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Added

- Support for children of Ophyd Async devices.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test cases with Ophyd Async devices are added to existing tests.
