### PR TITLE
Modify Redis address validation code to allow passing security credentials with the address

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -15,7 +15,7 @@ jobs:
           # installation problems if out of date.
           python -m pip install --upgrade pip setuptools numpy
 
-          pip install black
+          pip install black!=25.11.0
       - name: Run black
         run: |
           black . --check

--- a/bluesky_queueserver/manager/config.py
+++ b/bluesky_queueserver/manager/config.py
@@ -361,8 +361,6 @@ class Settings:
             value_config=self._get_value_from_config("redis_addr"),
             value_cli=self._args_existing("redis_addr"),
         )
-        if redis_addr.count(":") > 1:
-            raise ConfigError(f"Redis address is incorrectly formatted: {redis_addr}")
         self._settings["redis_addr"] = redis_addr
 
         redis_name_prefix = self._get_param(

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -257,7 +257,9 @@ class PlanQueueOperations:
             self._lock = asyncio.Lock()
             async with self._lock:
                 try:
-                    host = f"redis://{self._redis_host}"
+                    if "://" not in self._redis_host:
+                        host = f"redis://{self._redis_host}"
+                    logger.debug("Connecting to Redis host at'%s'", host)
                     self._r_pool = redis.asyncio.from_url(host, encoding="utf-8", decode_responses=True)
                     await self._r_pool.ping()
                 except Exception as ex:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
-black
+black!=25.11.0
 coverage
 flake8
 isort


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

In this PR the existing trivial validation code was removed. Instead it is checked if the address contains `://`,  and if not, then the prefix `redis://` is added to the address automatically.

The PR is expected to resolve the issue https://github.com/bluesky/bluesky-queueserver/issues/337
