### PR TITLE
Status streaming

### DIFF
--- a/bluesky_queueserver/__init__.py
+++ b/bluesky_queueserver/__init__.py
@@ -13,7 +13,12 @@ from .manager.comms import (  # noqa: E402, F401
     validate_zmq_key,
 )
 from .manager.gen_lists import gen_list_of_plans_and_devices  # noqa: E402, F401
-from .manager.output_streaming import ReceiveConsoleOutput, ReceiveConsoleOutputAsync  # noqa: E402, F401
+from .manager.output_streaming import (  # noqa: E402, F401
+    ReceiveConsoleOutput,
+    ReceiveConsoleOutputAsync,
+    ReceiveSystemInfo,
+    ReceiveSystemInfoAsync,
+)
 from .manager.profile_ops import bind_plan_arguments  # noqa: E402, F401
 from .manager.profile_ops import construct_parameters  # noqa: E402, F401
 from .manager.profile_ops import format_text_descriptions  # noqa: E402, F401

--- a/bluesky_queueserver/manager/logging_setup.py
+++ b/bluesky_queueserver/manager/logging_setup.py
@@ -25,7 +25,7 @@ def setup_loggers(*, log_level, name="bluesky_queueserver"):
         or (log_level == "DEBUG")
         or (isinstance(log_level, int) and (log_level <= 10))
     ):
-        log_stream_format = "[%(levelname)1.1s %(asctime)s.%(msecs)03d %(name)s %(module)s:%(lineno)d] %(message)s"
+        log_stream_format = "[%(levelname)1.1s %(asctime)s %(name)s %(module)s:%(lineno)d] %(message)s"
     else:
         log_stream_format = "[%(levelname)1.1s %(asctime)s %(name)s] %(message)s"
 

--- a/bluesky_queueserver/manager/logging_setup.py
+++ b/bluesky_queueserver/manager/logging_setup.py
@@ -68,7 +68,7 @@ class PPrintForLogging:
         Formatted object ``msg``.
     """
 
-    def __init__(self, msg, *, max_list_size=10, max_dict_size=25, max_chars_in_str=1024):
+    def __init__(self, msg, *, max_list_size=10, max_dict_size=30, max_chars_in_str=1024):
         self._msg = msg
         self._max_list_size = max_list_size
         self._max_dict_size = max_dict_size

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1804,8 +1804,7 @@ class RunEngineManager(Process):
         #   used to access status. On the other hand the reference can be used to store the current status.
         self._status = {
             "msg": response_msg,
-            "status_uid": status_uid,
-            "timestamp": timestamp,
+            "time": timestamp,
             "items_in_queue": items_in_queue,
             "items_in_history": items_in_history,
             "running_item_uid": running_item_uid,
@@ -1821,6 +1820,7 @@ class RunEngineManager(Process):
             "pause_pending": deferred_pause_pending,  # True/False - Cleared once pause processed
             # If Run List UID change, download the list of runs for the current plan.
             # Run List UID is updated when the list is cleared as well.
+            "status_uid": status_uid,
             "run_list_uid": run_list_uid,
             "plan_queue_uid": plan_queue_uid,
             "plan_history_uid": plan_history_uid,

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -350,6 +350,7 @@ class RunEngineManager(Process):
         self.__queue_autostart_enabled = enabled
         if self._plan_queue:
             await self._plan_queue.autostart_mode_save({"enabled": enabled})
+        await self._status_update()
 
     async def _heartbeat_generator(self):
         """
@@ -1214,6 +1215,8 @@ class RunEngineManager(Process):
         else:
             success, err_msg = await self._worker_command_pause_plan(option)
 
+        await self._status_update()
+
         if not success:
             logger.error("Failed to pause Run Engine: %s", err_msg)
 
@@ -1259,6 +1262,8 @@ class RunEngineManager(Process):
                 False,
                 "Environment does not exist. Can not pause Run Engine.",
             )
+
+        await self._status_update()
 
         return success, err_msg
 
@@ -1546,6 +1551,7 @@ class RunEngineManager(Process):
         except Exception as ex:
             success, msg = False, f"Failed to interrupt IPython kernel: {str(ex)}"
 
+        await self._status_update()
         return success, msg
 
     # ===============================================================================

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -397,6 +397,9 @@ class RunEngineManager(Process):
         """
         return datetime.now().isoformat()
 
+    def _compute_re_state(self):
+        return self._worker_state_info["re_state"] if self._worker_state_info else None
+
     async def _status_update(self):
         """
         Compute the updated status
@@ -1885,9 +1888,6 @@ class RunEngineManager(Process):
         """
         return await self._status_handler(request)
 
-    def _compute_re_state(self):
-        return self._worker_state_info["re_state"] if self._worker_state_info else None
-
     async def _status_handler(self, request):
         """
         Returns status of the manager.
@@ -1895,7 +1895,7 @@ class RunEngineManager(Process):
         # Status is expected to be requested very often. Print the message only in the debug mode.
         logger.debug("Processing 'status' request ...")
 
-        await self._status_update()
+        # await self._status_update()
         return self._status
 
     async def _config_get_handler(self, request):
@@ -2074,6 +2074,8 @@ class RunEngineManager(Process):
         except Exception as ex:
             success = False
             msg = f"Error: {str(ex)}"
+
+        await self._status_update()
         return {"success": success, "msg": msg}
 
     async def _permissions_set_handler(self, request):
@@ -2106,6 +2108,7 @@ class RunEngineManager(Process):
             success = False
             msg = f"Error: {str(ex)}"
 
+        await self._status_update()
         return {"success": success, "msg": msg}
 
     async def _permissions_get_handler(self, request):
@@ -2402,6 +2405,7 @@ class RunEngineManager(Process):
 
         logger.info(self._generate_item_log_msg("Item added", success, item_type, item, qsize))
 
+        await self._status_update()
         rdict = {"success": success, "msg": msg, "qsize": qsize, "item": item}
         return rdict
 
@@ -2517,6 +2521,7 @@ class RunEngineManager(Process):
             pass
 
         logger.info(self._generate_item_log_msg("Batch of items added", success, None, None, qsize))
+        await self._status_update()
 
         # Note, that 'item_list' may be an empty list []
         rdict = {"success": success, "msg": msg, "qsize": qsize, "items": item_list, "results": results}
@@ -2567,6 +2572,7 @@ class RunEngineManager(Process):
             msg = f"Failed to add an item: {str(ex)}"
 
         logger.info(self._generate_item_log_msg("Item updated", success, item_type, item, qsize))
+        await self._status_update()
 
         rdict = {"success": success, "msg": msg, "qsize": qsize, "item": item}
 
@@ -2618,6 +2624,7 @@ class RunEngineManager(Process):
             success = False
             msg = f"Failed to remove an item: {str(ex)}"
 
+        await self._status_update()
         return {"success": success, "msg": msg, "item": item, "qsize": qsize}
 
     async def _queue_item_remove_batch_handler(self, request):
@@ -2651,6 +2658,7 @@ class RunEngineManager(Process):
             success = False
             msg = f"Failed to remove a batch of items: {str(ex)}"
 
+        await self._status_update()
         return {"success": success, "msg": msg, "items": items, "qsize": qsize}
 
     async def _queue_item_move_handler(self, request):
@@ -2682,6 +2690,7 @@ class RunEngineManager(Process):
             success = False
             msg = f"Failed to move the item: {str(ex)}"
 
+        await self._status_update()
         return {"success": success, "msg": msg, "item": item, "qsize": qsize}
 
     async def _queue_item_move_batch_handler(self, request):
@@ -2724,6 +2733,7 @@ class RunEngineManager(Process):
             success = False
             msg = f"Failed to move the batch of items: {str(ex)}"
 
+        await self._status_update()
         return {"success": success, "msg": msg, "qsize": qsize, "items": items}
 
     async def _queue_item_execute_handler(self, request):
@@ -2799,6 +2809,8 @@ class RunEngineManager(Process):
             success, msg = True, ""
         except Exception as ex:
             success, msg = False, f"Error: {ex}"
+
+        await self._status_update()
         return {"success": success, "msg": msg}
 
     async def _history_get_handler(self, request):
@@ -2848,6 +2860,7 @@ class RunEngineManager(Process):
         except Exception as ex:
             success, msg = False, f"Error: {ex}"
 
+        await self._status_update()
         return {"success": success, "msg": msg}
 
     async def _environment_open_handler(self, request):
@@ -3452,6 +3465,7 @@ class RunEngineManager(Process):
                     queue,
                     note,
                 )
+                await self._status_update()
             else:
                 raise ValueError(f"RE Manager was locked with a different key: \n{self._lock_info.to_str()}")
 
@@ -3518,6 +3532,7 @@ class RunEngineManager(Process):
                 lock_info = self._format_lock_info()
                 lock_info_uid = self._lock_info.uid
                 await self._save_lock_info_to_redis()
+                await self._status_update()
                 logger.info("RE Manager is successfully unlocked.")
             else:
                 lock_info = self._format_lock_info()

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1755,6 +1755,12 @@ class RunEngineManager(Process):
     def _compute_re_state(self):
         return self._worker_state_info["re_state"] if self._worker_state_info else None
 
+    def _get_timestamp_iso8601(self):
+        """
+        Returns current timestamp in ISO 8601 format.
+        """
+        return datetime.now().isoformat()
+
     async def _status_update(self):
         """
         Compute the updated status
@@ -1767,6 +1773,7 @@ class RunEngineManager(Process):
         # Prepared output data
         response_msg = f"RE Manager v{qserver_version}"
         status_uid = _generate_uid()  # Generate the new status UID each time the status is updated
+        timestamp = self._get_timestamp_iso8601()
         items_in_queue = n_pending_items
         items_in_history = n_items_in_history
         running_item_uid = running_item_info["item_uid"] if running_item_info else None
@@ -1798,6 +1805,7 @@ class RunEngineManager(Process):
         self._status = {
             "msg": response_msg,
             "status_uid": status_uid,
+            "timestamp": timestamp,
             "items_in_queue": items_in_queue,
             "items_in_history": items_in_history,
             "running_item_uid": running_item_uid,

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -407,9 +407,9 @@ class RunEngineManager(Process):
         """
         # Computed/retrieved data
         logger.info("==== 4 ====")  ##
-        n_pending_items = await self._plan_queue.get_queue_size()
-        running_item_info = await self._plan_queue.get_running_item_info()
-        n_items_in_history = await self._plan_queue.get_history_size()
+        n_pending_items = self._plan_queue.get_queue_size()
+        running_item_info = self._plan_queue.get_running_item_info()
+        n_items_in_history = self._plan_queue.get_history_size()
         logger.info("==== 5 ====")  ##
 
         # Prepared output data
@@ -853,7 +853,7 @@ class RunEngineManager(Process):
 
             if plan_state in ("completed", "unknown") or continue_failed:
                 # Check if the plan was running in the 'immediate_execution' mode.
-                item = await self._plan_queue.get_running_item_info()
+                item = self._plan_queue.get_running_item_info()
                 immediate_execution = item.get("properties", {}).get("immediate_execution", False)
 
                 # Executed plan is removed from the queue only after it is successfully completed.
@@ -1065,7 +1065,7 @@ class RunEngineManager(Process):
                 await self._status_update()
 
                 item = self._plan_queue.set_new_item_uuid(item)
-                qsize = await self._plan_queue.get_queue_size()
+                qsize = self._plan_queue.get_queue_size()
 
                 asyncio.ensure_future(self._execute_background_task(self._start_plan_task(single_item=item)))
 
@@ -1091,7 +1091,7 @@ class RunEngineManager(Process):
 
         # Check if the queue should be stopped and stop the queue
         if not immediate_execution:
-            n_pending_plans = await self._plan_queue.get_queue_size()
+            n_pending_plans = self._plan_queue.get_queue_size()
             if n_pending_plans:
                 logger.info("Processing the next queue item: %d plans are left in the queue.", n_pending_plans)
             else:
@@ -1295,7 +1295,7 @@ class RunEngineManager(Process):
         """
         self._queue_autostart_event.clear()
         while True:
-            queue_size = await self._plan_queue.get_queue_size()
+            queue_size = self._plan_queue.get_queue_size()
             if not self.queue_autostart_enabled:
                 break
             if queue_size and self._manager_state == MState.IDLE and self._compute_re_state() is not None:
@@ -2536,7 +2536,7 @@ class RunEngineManager(Process):
             msg = f"Failed to add an item: {str(ex)}"
 
         try:
-            qsize = await self._plan_queue.get_queue_size()
+            qsize = self._plan_queue.get_queue_size()
         except Exception:
             pass
 
@@ -3887,7 +3887,7 @@ class RunEngineManager(Process):
                     #   the queue is not running.
                     self._re_pause_pending = re_deferred_pause_requested
                     # Plan is running. Check if it is the same plan as in redis.
-                    plan_stored = await self._plan_queue.get_running_item_info()
+                    plan_stored = self._plan_queue.get_running_item_info()
                     if "item_uid" in plan_stored:
                         item_uid_stored = plan_stored["item_uid"]
                         if re_state in ("paused", "pausing"):

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -390,6 +390,87 @@ class RunEngineManager(Process):
         if self._status:
             push_info_to_msg_queue(key="status", msg=self._status, msg_queue=self._msg_queue)
 
+    def _get_timestamp_iso8601(self):
+        """
+        Returns current timestamp in ISO 8601 format.
+        """
+        return datetime.now().isoformat()
+
+    async def _status_update(self):
+        """
+        Compute the updated status
+        """
+        # Computed/retrieved data
+        n_pending_items = await self._plan_queue.get_queue_size()
+        running_item_info = await self._plan_queue.get_running_item_info()
+        n_items_in_history = await self._plan_queue.get_history_size()
+
+        # Prepared output data
+        response_msg = f"RE Manager v{qserver_version}"
+        status_uid = _generate_uid()  # Generate the new status UID each time the status is updated
+        timestamp = self._get_timestamp_iso8601()
+        items_in_queue = n_pending_items
+        items_in_history = n_items_in_history
+        running_item_uid = running_item_info["item_uid"] if running_item_info else None
+        manager_state = self._manager_state.value
+        queue_stop_pending = self.queue_stop_pending
+        queue_autostart_enabled = self.queue_autostart_enabled
+        worker_environment_exists = self._environment_exists
+        re_state = self._compute_re_state()
+        ip_kernel_state = self._worker_state_info["ip_kernel_state"] if self._worker_state_info else None
+        ip_kernel_captured = self._worker_state_info["ip_kernel_captured"] if self._worker_state_info else None
+        env_state = self._worker_state_info["environment_state"] if self._worker_state_info else "closed"
+        background_tasks = self._worker_state_info["background_tasks_num"] if self._worker_state_info else 0
+        deferred_pause_pending = self._re_pause_pending
+        run_list_uid = self._re_run_list_uid
+        plan_queue_uid = self._plan_queue.plan_queue_uid
+        plan_history_uid = self._plan_queue.plan_history_uid
+        devices_existing_uid = self._existing_devices_uid
+        plans_existing_uid = self._existing_plans_uid
+        devices_allowed_uid = self._allowed_devices_uid
+        plans_allowed_uid = self._allowed_plans_uid
+        plan_queue_mode = self._plan_queue.plan_queue_mode
+        task_results_uid = self._task_results.task_results_uid
+        lock_info_uid = self._lock_info.uid
+        locked_environment = self._lock_info.environment
+        locked_queue = self._lock_info.queue
+
+        # The status reference is replaced each time status is updated, i.e. stored reference should not be
+        #   used to access status. On the other hand the reference can be used to store the current status.
+        self._status = {
+            "msg": response_msg,
+            "time": timestamp,
+            "items_in_queue": items_in_queue,
+            "items_in_history": items_in_history,
+            "running_item_uid": running_item_uid,
+            "manager_state": manager_state,
+            "queue_stop_pending": queue_stop_pending,
+            "queue_autostart_enabled": queue_autostart_enabled,
+            "worker_environment_exists": worker_environment_exists,
+            "worker_environment_state": env_state,  # State of the worker environment
+            "worker_background_tasks": background_tasks,  # The number of background tasks
+            "re_state": re_state,  # State of Run Engine
+            "ip_kernel_state": ip_kernel_state,  # State of IPython kernel
+            "ip_kernel_captured": ip_kernel_captured,
+            "pause_pending": deferred_pause_pending,  # True/False - Cleared once pause processed
+            # If Run List UID change, download the list of runs for the current plan.
+            # Run List UID is updated when the list is cleared as well.
+            "status_uid": status_uid,
+            "run_list_uid": run_list_uid,
+            "plan_queue_uid": plan_queue_uid,
+            "plan_history_uid": plan_history_uid,
+            "devices_existing_uid": devices_existing_uid,
+            "plans_existing_uid": plans_existing_uid,
+            "devices_allowed_uid": devices_allowed_uid,
+            "plans_allowed_uid": plans_allowed_uid,
+            "plan_queue_mode": plan_queue_mode,
+            "task_results_uid": task_results_uid,
+            "lock_info_uid": lock_info_uid,
+            "lock": {"environment": locked_environment, "queue": locked_queue},
+        }
+
+        self._status_publish()  # Add the updated status to 'msg_queue'
+
     # ======================================================================
     #          Functions that implement functionality of the server
 
@@ -1777,87 +1858,6 @@ class RunEngineManager(Process):
 
     def _compute_re_state(self):
         return self._worker_state_info["re_state"] if self._worker_state_info else None
-
-    def _get_timestamp_iso8601(self):
-        """
-        Returns current timestamp in ISO 8601 format.
-        """
-        return datetime.now().isoformat()
-
-    async def _status_update(self):
-        """
-        Compute the updated status
-        """
-        # Computed/retrieved data
-        n_pending_items = await self._plan_queue.get_queue_size()
-        running_item_info = await self._plan_queue.get_running_item_info()
-        n_items_in_history = await self._plan_queue.get_history_size()
-
-        # Prepared output data
-        response_msg = f"RE Manager v{qserver_version}"
-        status_uid = _generate_uid()  # Generate the new status UID each time the status is updated
-        timestamp = self._get_timestamp_iso8601()
-        items_in_queue = n_pending_items
-        items_in_history = n_items_in_history
-        running_item_uid = running_item_info["item_uid"] if running_item_info else None
-        manager_state = self._manager_state.value
-        queue_stop_pending = self.queue_stop_pending
-        queue_autostart_enabled = self.queue_autostart_enabled
-        worker_environment_exists = self._environment_exists
-        re_state = self._compute_re_state()
-        ip_kernel_state = self._worker_state_info["ip_kernel_state"] if self._worker_state_info else None
-        ip_kernel_captured = self._worker_state_info["ip_kernel_captured"] if self._worker_state_info else None
-        env_state = self._worker_state_info["environment_state"] if self._worker_state_info else "closed"
-        background_tasks = self._worker_state_info["background_tasks_num"] if self._worker_state_info else 0
-        deferred_pause_pending = self._re_pause_pending
-        run_list_uid = self._re_run_list_uid
-        plan_queue_uid = self._plan_queue.plan_queue_uid
-        plan_history_uid = self._plan_queue.plan_history_uid
-        devices_existing_uid = self._existing_devices_uid
-        plans_existing_uid = self._existing_plans_uid
-        devices_allowed_uid = self._allowed_devices_uid
-        plans_allowed_uid = self._allowed_plans_uid
-        plan_queue_mode = self._plan_queue.plan_queue_mode
-        task_results_uid = self._task_results.task_results_uid
-        lock_info_uid = self._lock_info.uid
-        locked_environment = self._lock_info.environment
-        locked_queue = self._lock_info.queue
-
-        # The status reference is replaced each time status is updated, i.e. stored reference should not be
-        #   used to access status. On the other hand the reference can be used to store the current status.
-        self._status = {
-            "msg": response_msg,
-            "time": timestamp,
-            "items_in_queue": items_in_queue,
-            "items_in_history": items_in_history,
-            "running_item_uid": running_item_uid,
-            "manager_state": manager_state,
-            "queue_stop_pending": queue_stop_pending,
-            "queue_autostart_enabled": queue_autostart_enabled,
-            "worker_environment_exists": worker_environment_exists,
-            "worker_environment_state": env_state,  # State of the worker environment
-            "worker_background_tasks": background_tasks,  # The number of background tasks
-            "re_state": re_state,  # State of Run Engine
-            "ip_kernel_state": ip_kernel_state,  # State of IPython kernel
-            "ip_kernel_captured": ip_kernel_captured,
-            "pause_pending": deferred_pause_pending,  # True/False - Cleared once pause processed
-            # If Run List UID change, download the list of runs for the current plan.
-            # Run List UID is updated when the list is cleared as well.
-            "status_uid": status_uid,
-            "run_list_uid": run_list_uid,
-            "plan_queue_uid": plan_queue_uid,
-            "plan_history_uid": plan_history_uid,
-            "devices_existing_uid": devices_existing_uid,
-            "plans_existing_uid": plans_existing_uid,
-            "devices_allowed_uid": devices_allowed_uid,
-            "plans_allowed_uid": plans_allowed_uid,
-            "plan_queue_mode": plan_queue_mode,
-            "task_results_uid": task_results_uid,
-            "lock_info_uid": lock_info_uid,
-            "lock": {"environment": locked_environment, "queue": locked_queue},
-        }
-
-        self._status_publish()  # Add the updated status to 'msg_queue'
 
     async def _status_handler(self, request):
         """

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1824,7 +1824,7 @@ class RunEngineManager(Process):
         # Status is expected to be requested very often. Print the message only in the debug mode.
         logger.debug("Processing 'status' request ...")
 
-        await self._status_update(self)
+        await self._status_update()
         return self._status
 
     async def _config_get_handler(self, request):

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1834,6 +1834,8 @@ class RunEngineManager(Process):
             "lock": {"environment": locked_environment, "queue": locked_queue},
         }
 
+        self._status_publish()  # Add the updated status to 'msg_queue'
+
     async def _status_handler(self, request):
         """
         Returns status of the manager.
@@ -1842,7 +1844,6 @@ class RunEngineManager(Process):
         logger.debug("Processing 'status' request ...")
 
         await self._status_update()
-        self._status_publish()
         return self._status
 
     async def _config_get_handler(self, request):

--- a/bluesky_queueserver/manager/output_streaming.py
+++ b/bluesky_queueserver/manager/output_streaming.py
@@ -46,7 +46,7 @@ class ConsoleOutputStream(io.TextIOBase):
         """
         s = str(s)
 
-        msg = {"time": ttime.time(), "msg": s}
+        msg = {"channel": "console", "time": ttime.time(), "msg": s}
         self._msg_queue.put(msg)
         return len(s)
 
@@ -92,6 +92,7 @@ def setup_console_output_redirection(msg_queue):
 
 
 _default_zmq_console_topic = "QS_Console"
+_default_zmq_info_topic = "QS_Info"
 
 
 class PublishConsoleOutput:
@@ -117,8 +118,10 @@ class PublishConsoleOutput:
         the default address ``tcp://*:60625`` is used.
     encoding : str or ZMQEncoding
         Encoding of used for 0MQ messages. Supported values: "json" or "msgpack".
-    zmq_topic : str
-        Name of the 0MQ topic where the messages are published.
+    zmq_topic_console : str
+        Name of the 0MQ topic where the console messages are published.
+    zmq_topic_info : str
+        Name of the 0MQ topic where the system information messages are published.
     name : str
         Name of the thread where the messages are published.
     """
@@ -131,7 +134,8 @@ class PublishConsoleOutput:
         zmq_publish_on=True,
         zmq_publish_addr=None,
         encoding="json",
-        zmq_topic=_default_zmq_console_topic,
+        zmq_topic_console=_default_zmq_console_topic,
+        zmq_topic_info=_default_zmq_info_topic,
         name="RE Console Output Publisher",
     ):
         self._thread_running = False  # Set True to exit the thread
@@ -147,7 +151,8 @@ class PublishConsoleOutput:
         zmq_publish_addr = zmq_publish_addr or default_zmq_info_address_for_server
 
         self._zmq_publish_addr = zmq_publish_addr
-        self._zmq_topic = zmq_topic
+        self._zmq_topic_console = zmq_topic_console
+        self._zmq_topic_info = zmq_topic_info
 
         self._socket = None
         if self._zmq_publish_on:
@@ -208,7 +213,14 @@ class PublishConsoleOutput:
             sys.__stdout__.flush()
 
         if self._zmq_publish_on and self._socket:
-            topic = self._zmq_topic
+            channel = payload["channel"]
+            if channel == "console":
+                topic = self._zmq_topic_console
+            elif channel == "info":
+                topic = self._zmq_topic_info
+            else:
+                logger.error("Failed to publish the message: unsupported 0MQ channel %s.")
+            payload = {k: payload[k] for k in ("time", "msg")}
             if self._encoding == ZMQEncoding.JSON:
                 payload_json = json.dumps(payload)
                 self._socket.send_multipart([topic.encode("ascii"), payload_json.encode("utf8")])
@@ -217,7 +229,7 @@ class PublishConsoleOutput:
                 self._socket.send_multipart([topic.encode("ascii"), payload_pickle])
 
 
-class ReceiveConsoleOutput:
+class _ReceiveZMQStreamOutput:
     """
     The class allows to subscribe to published 0MQ messages and read the messages one by
     one as they arrive. Subscription is performed using the remote 0MQ address and topic.
@@ -261,16 +273,16 @@ class ReceiveConsoleOutput:
         ``tcp://localhost:60625`` is used.
     encoding : str or ZMQEncoding
         Encoding of used for 0MQ messages. Supported values: "json" or "msgpack".
-    zmq_topic : str
+    zmq_topic_console : str
         0MQ topic for console output. Only messages from this topic are going to be received.
+    zmq_topic_info : str
+        0MQ topic for info output. Only messages from this topic are going to be received.
     timeout : int, float or None
         Timeout for the receive operation in milliseconds. If `None`, then wait
         for the message indefinitely.
     """
 
-    def __init__(
-        self, *, zmq_subscribe_addr=None, encoding="json", zmq_topic=_default_zmq_console_topic, timeout=1000
-    ):
+    def __init__(self, *, zmq_subscribe_addr, encoding, zmq_topic, timeout):
         self._timeout = timeout  # Timeout for 'recv' operation (ms)
 
         zmq_subscribe_addr = zmq_subscribe_addr or default_zmq_info_address
@@ -356,9 +368,41 @@ class ReceiveConsoleOutput:
         self._socket.close()
 
 
-class ReceiveConsoleOutputAsync:
+class ReceiveConsoleOutput(_ReceiveZMQStreamOutput):
     """
-    Async version of ``ReceiveConsoleOutput`` class. There are two ways to use the class:
+    The class defaults are set to receive 0MQ messages with console output.
+    """
+
+    def __init__(
+        self, *, zmq_subscribe_addr=None, encoding="json", zmq_topic=_default_zmq_console_topic, timeout=1000
+    ):
+        super().__init__(
+            zmq_subscribe_addr=zmq_subscribe_addr,
+            encoding=encoding,
+            zmq_topic=zmq_topic,
+            timeout=timeout,
+        )
+
+
+class ReceiveSystemInfo(_ReceiveZMQStreamOutput):
+    """
+    The class defaults are set to receive 0MQ messages with system information.
+    """
+
+    def __init__(
+        self, *, zmq_subscribe_addr=None, encoding="json", zmq_topic=_default_zmq_info_topic, timeout=1000
+    ):
+        super().__init__(
+            zmq_subscribe_addr=zmq_subscribe_addr,
+            encoding=encoding,
+            zmq_topic=zmq_topic,
+            timeout=timeout,
+        )
+
+
+class _ReceiveZMQStreamOutputAsync:
+    """
+    Async version of ``_ReceiveZMQStreamOutput`` class. There are two ways to use the class:
     explicitly awaiting for the ``recv`` function (same as in ``ReceiveConsoleOutput``)
     or setting up a callback function (plain function or coroutine).
 
@@ -452,9 +496,7 @@ class ReceiveConsoleOutputAsync:
         for the message indefinitely.
     """
 
-    def __init__(
-        self, *, zmq_subscribe_addr=None, encoding="json", zmq_topic=_default_zmq_console_topic, timeout=1000
-    ):
+    def __init__(self, *, zmq_subscribe_addr, encoding, zmq_topic, timeout):
         self._timeout = timeout  # Timeout for 'recv' operation (ms)
 
         zmq_subscribe_addr = zmq_subscribe_addr or "tcp://localhost:60625"
@@ -610,6 +652,38 @@ class ReceiveConsoleOutputAsync:
         self.stop()
         if self._socket:
             self._socket.close()
+
+
+class ReceiveConsoleOutputAsync(_ReceiveZMQStreamOutputAsync):
+    """
+    The class defaults are set to receive 0MQ messages with console output.
+    """
+
+    def __init__(
+        self, *, zmq_subscribe_addr=None, encoding="json", zmq_topic=_default_zmq_console_topic, timeout=1000
+    ):
+        super().__init__(
+            zmq_subscribe_addr=zmq_subscribe_addr,
+            encoding=encoding,
+            zmq_topic=zmq_topic,
+            timeout=timeout,
+        )
+
+
+class ReceiveSystemInfoAsync(_ReceiveZMQStreamOutputAsync):
+    """
+    The class defaults are set to receive 0MQ messages with system information.
+    """
+
+    def __init__(
+        self, *, zmq_subscribe_addr=None, encoding="json", zmq_topic=_default_zmq_info_topic, timeout=1000
+    ):
+        super().__init__(
+            zmq_subscribe_addr=zmq_subscribe_addr,
+            encoding=encoding,
+            zmq_topic=zmq_topic,
+            timeout=timeout,
+        )
 
 
 def qserver_console_monitor_cli():

--- a/bluesky_queueserver/manager/output_streaming.py
+++ b/bluesky_queueserver/manager/output_streaming.py
@@ -91,6 +91,30 @@ def setup_console_output_redirection(msg_queue):
             pass
 
 
+def push_info_to_msg_queue(*, key, msg, msg_queue):
+    """
+    Format the message and put it into the message queue. The message is published to
+    the ``info`` socket in the ``"info"`` channel.
+
+    Parameters
+    ----------
+    key : str
+        The key used for the message. The message is formatted as a dictionary:
+        ``{"channel": "info", "time": ttime.time(), "msg": {key: msg}}``.
+        The key is used to identify the information in the message. E.g. ``"status"``.
+    msg : dict
+        The message is a dictionary with useful information (actual payload).
+    msg_queue : multiprocessing.Queue
+        Reference to the queue used for collecting messages.
+
+    Returns
+    -------
+    None
+    """
+    msg = {"channel": "info", "time": ttime.time(), "msg": {key: msg}}
+    msg_queue.put(msg)
+
+
 _default_zmq_console_topic = "QS_Console"
 _default_zmq_info_topic = "QS_Info"
 

--- a/bluesky_queueserver/manager/output_streaming.py
+++ b/bluesky_queueserver/manager/output_streaming.py
@@ -232,7 +232,7 @@ class PublishZMQStreamOutput:
                 break
 
     def _publish(self, payload):
-        if self._console_output_on:
+        if self._console_output_on and payload["channel"] == "console":
             sys.__stdout__.write(payload["msg"])
             sys.__stdout__.flush()
 

--- a/bluesky_queueserver/manager/output_streaming.py
+++ b/bluesky_queueserver/manager/output_streaming.py
@@ -232,12 +232,12 @@ class PublishZMQStreamOutput:
                 break
 
     def _publish(self, payload):
-        if self._console_output_on and payload["channel"] == "console":
+        channel = payload["channel"]
+        if self._console_output_on and channel == "console":
             sys.__stdout__.write(payload["msg"])
             sys.__stdout__.flush()
 
         if self._zmq_publish_on and self._socket:
-            channel = payload["channel"]
             if channel == "console":
                 topic = self._zmq_topic_console
             elif channel == "info":

--- a/bluesky_queueserver/manager/output_streaming.py
+++ b/bluesky_queueserver/manager/output_streaming.py
@@ -331,7 +331,7 @@ class _ReceiveZMQStreamOutput:
 
     def subscribe(self):
         """
-        Subscribe 0MQ socket to the console output topic. Once the socket is subscribed,
+        Subscribe 0MQ socket to the topic. Once the socket is subscribed,
         the published messages are cached by 0MQ and could be loaded with ``recv()`` method.
         The function does nothing if the socket is already subscribed.
         """
@@ -341,7 +341,7 @@ class _ReceiveZMQStreamOutput:
 
     def unsubscribe(self):
         """
-        Unsubscribe 0MQ socket from the console output topic. Once the socket is unsubscribed,
+        Unsubscribe 0MQ socket from the topic. Once the socket is unsubscribed,
         all published messages are discarded.
         """
         if self._socket and self._socket_subscribed:
@@ -425,6 +425,10 @@ class ReceiveSystemInfo(_ReceiveZMQStreamOutput):
             zmq_topic=zmq_topic,
             timeout=timeout,
         )
+
+
+ReceiveConsoleOutput.__doc__ += _ReceiveZMQStreamOutput.__doc__
+ReceiveSystemInfo.__doc__ += _ReceiveZMQStreamOutput.__doc__
 
 
 class _ReceiveZMQStreamOutputAsync:
@@ -550,7 +554,7 @@ class _ReceiveZMQStreamOutputAsync:
 
     def subscribe(self):
         """
-        Subscribe 0MQ socket to the console output topic. Once the socket is subscribed,
+        Subscribe 0MQ socket to the topic. Once the socket is subscribed,
         the published messages are cached by 0MQ and could be loaded with ``recv()`` method.
         The function does nothing if the socket is already subscribed.
         """
@@ -560,7 +564,7 @@ class _ReceiveZMQStreamOutputAsync:
 
     def unsubscribe(self):
         """
-        Unsubscribe 0MQ socket from the console output topic. Once the socket is unsubscribed,
+        Unsubscribe 0MQ socket from the topic. Once the socket is unsubscribed,
         all published messages are discarded.
         """
         if self._socket and self._socket_subscribed:
@@ -711,6 +715,10 @@ class ReceiveSystemInfoAsync(_ReceiveZMQStreamOutputAsync):
             zmq_topic=zmq_topic,
             timeout=timeout,
         )
+
+
+ReceiveConsoleOutputAsync.__doc__ += _ReceiveZMQStreamOutputAsync.__doc__
+ReceiveSystemInfoAsync.__doc__ += _ReceiveZMQStreamOutputAsync.__doc__
 
 
 def qserver_console_monitor_cli():

--- a/bluesky_queueserver/manager/output_streaming.py
+++ b/bluesky_queueserver/manager/output_streaming.py
@@ -95,7 +95,7 @@ _default_zmq_console_topic = "QS_Console"
 _default_zmq_info_topic = "QS_Info"
 
 
-class PublishConsoleOutput:
+class PublishZMQStreamOutput:
     """
     The class that is publishing the collected console output messages to 0MQ socket.
     The queue is expected to be filled with messages in the format
@@ -242,6 +242,9 @@ class _ReceiveZMQStreamOutput:
     The ``subscribe()`` and ``unsubscribe()`` methods allow to explicitly subscribe and
     unsubscribe the socket to the topic. The messages published while the socket is unsubscribed
     are discarded. First call to ``recv()`` method automatically subscribes the socket.
+
+    The following code is an example of using the ``ReceiveConsoleOutput`` subclass,
+    which is configured to receive console output:
 
     .. code-block:: python
 
@@ -403,7 +406,7 @@ class ReceiveSystemInfo(_ReceiveZMQStreamOutput):
 class _ReceiveZMQStreamOutputAsync:
     """
     Async version of ``_ReceiveZMQStreamOutput`` class. There are two ways to use the class:
-    explicitly awaiting for the ``recv`` function (same as in ``ReceiveConsoleOutput``)
+    explicitly awaiting for the ``recv`` function (same as in ``_ReceiveZMQStreamOutput``)
     or setting up a callback function (plain function or coroutine).
 
     The ``subscribe()`` and ``unsubscribe()`` methods allow to explicitly subscribe and
@@ -411,7 +414,7 @@ class _ReceiveZMQStreamOutputAsync:
     are discarded. Calls to ``recv()`` and ``start()`` methods always subscribe the socket,
     ``stop()`` method unsubscribes the socket unless called with ``unsubscribe=False``.
 
-    Explicitly awaiting ``recv`` function:
+    Explicitly awaiting ``recv`` function (``ReceiveConsoleOutputAsync`` is a subclass):
 
     .. code-block:: python
 

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -524,21 +524,22 @@ class PlanQueueOperations:
 
     async def _is_item_running(self):
         """
-        See ``self.is_item_running()`` method.
+        Check if an item is set as running. True does not indicate that the plan is actually running.
+        Reads data from Redis.
         """
         return bool(await self._get_running_item_info())
 
-    async def is_item_running(self):
+    def is_item_running(self):
         """
         Check if an item is set as running. True does not indicate that the plan is actually running.
+        Result based on cached data.
 
         Returns
         -------
         boolean
             True - an item is set as running, False otherwise.
         """
-        async with self._lock:
-            return await self._is_item_running()
+        return bool(self._running_item_info)
 
     async def _get_running_item_info(self):
         """

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -1529,8 +1529,8 @@ class PlanQueueOperations:
         See ``self.clear_history()`` method.
         """
         self._plan_history_uid = self.new_item_uid()
-        self._history_size = await self._get_history_size()
         await self._r_pool.delete(self._name_plan_history)
+        self._history_size = await self._get_history_size()
 
     async def clear_history(self):
         """

--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -41,7 +41,7 @@ class PlanQueueOperations:
         await pq.add_item_to_queue(<plan3>)
 
         # Number of plans in the queue
-        qsize = await pq.get_queue_size()
+        qsize = pq.get_queue_size()
 
         # Read the queue (as a list)
         queue, _ = await pq.get_queue()
@@ -53,7 +53,7 @@ class PlanQueueOperations:
 
         # Again this only shows whether a plan was set as running. Expected to be True in
         #   this example.
-        is_running = await pq.is_item_running()
+        is_running = pq.is_item_running()
 
         # Assume that plan execution is completed, so move the plan to history
         #   This also clears the currently processed plan.

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -1282,7 +1282,7 @@ def prepare_qserver_output(msg):
             d = msg[dict_name]
             for k in d.keys():
                 d[k] = "{...}"
-    return ppfl(msg, max_dict_size=30)
+    return ppfl(msg)
 
 
 def qserver():

--- a/bluesky_queueserver/manager/qserver_cli.py
+++ b/bluesky_queueserver/manager/qserver_cli.py
@@ -1282,7 +1282,7 @@ def prepare_qserver_output(msg):
             d = msg[dict_name]
             for k in d.keys():
                 d[k] = "{...}"
-    return ppfl(msg)
+    return ppfl(msg, max_dict_size=30)
 
 
 def qserver():

--- a/bluesky_queueserver/manager/start_manager.py
+++ b/bluesky_queueserver/manager/start_manager.py
@@ -15,7 +15,7 @@ from .config import Settings, profile_name_to_startup_dir, save_settings_to_file
 from .logging_setup import setup_loggers
 from .manager import RunEngineManager
 from .output_streaming import (
-    PublishConsoleOutput,
+    PublishZMQStreamOutput,
     default_zmq_info_address_for_server,
     setup_console_output_redirection,
 )
@@ -689,7 +689,7 @@ def start_manager():
     # Optionally save settings to a YAML file (used for testing)
     save_settings_to_file(settings)
 
-    stream_publisher = PublishConsoleOutput(
+    stream_publisher = PublishZMQStreamOutput(
         msg_queue=msg_queue,
         console_output_on=settings.print_console_output,
         zmq_publish_on=settings.zmq_publish_console,

--- a/bluesky_queueserver/manager/tests/test_info_streaming.py
+++ b/bluesky_queueserver/manager/tests/test_info_streaming.py
@@ -1,0 +1,115 @@
+import threading
+import time as ttime
+
+import pytest
+
+from bluesky_queueserver.manager.output_streaming import ReceiveSystemInfo, _default_zmq_info_topic
+
+from .common import re_manager_cmd  # noqa: F401
+from .common import (
+    condition_environment_closed,
+    condition_environment_created,
+    use_zmq_encoding_for_tests,
+    wait_for_condition,
+    zmq_request,
+)
+
+timeout_env_open = 10
+
+
+class ReceiveMessages(threading.Thread):
+    def __init__(self, *, receiver_class, zmq_subscribe_addr, zmq_topic, encoding, timeout=0.1):
+        super().__init__()
+        self._rco = receiver_class(zmq_subscribe_addr=zmq_subscribe_addr, zmq_topic=zmq_topic, encoding=encoding)
+        self._exit = False
+        self.received_msgs = []
+        self._timeout = timeout
+        self.n_timeouts = 0
+
+    def run(self):
+        while True:
+            try:
+                _ = {} if (self._timeout is None) else {"timeout": self._timeout}
+                msg = self._rco.recv(**_)
+                self.received_msgs.append(msg)
+            except TimeoutError:
+                self.n_timeouts += 1
+            if self._exit:
+                break
+
+    def stop(self):
+        self._exit = True
+
+    def subscribe(self):
+        self._rco.subscribe()
+
+    def unsubscribe(self):
+        self._rco.unsubscribe()
+
+
+# fmt: off
+@pytest.mark.parametrize("stream_enabled", [True, False, None])
+# fmt: on
+def test_zmq_info_streaming_1(monkeypatch, re_manager_cmd, stream_enabled):  # noqa: F811
+    """
+    Test 0MQ streaming functionality: streaming of status messages.
+    Test periodic streaming (once per second).
+    Test that streamed status reflect current state of RE Manager.
+    Test that streaming can be disabled.
+    """
+    address_info_server = "tcp://*:60621"
+    address_info_client = "tcp://localhost:60621"
+
+    params_server = [f"--zmq-info-addr={address_info_server}"]
+    if stream_enabled is not None:
+        params_server.append(f"--zmq-publish-console={'ON' if stream_enabled else 'OFF'}")
+
+    zmq_encoding = use_zmq_encoding_for_tests()
+
+    rm_info = ReceiveMessages(
+        receiver_class=ReceiveSystemInfo,
+        zmq_subscribe_addr=address_info_client,
+        zmq_topic=_default_zmq_info_topic,
+        encoding=zmq_encoding,
+    )
+
+    rm_info.start()
+
+    re_manager_cmd(params_server)
+
+    # Test periodic streaming of status messages (once per second)
+    if stream_enabled is True:
+        ttime.sleep(6)
+        assert len(rm_info.received_msgs) > 5
+
+        msg_prev = rm_info.received_msgs[-2]
+        msg_last = rm_info.received_msgs[-1]
+        assert msg_last["time"] > msg_prev["time"]
+        status_prev = msg_prev["msg"]["status"]
+        status_last = msg_last["msg"]["status"]
+        assert status_last["status_uid"] == status_prev["status_uid"]
+        assert status_last["manager_state"] == "idle"
+        assert status_last["worker_environment_exists"] is False
+
+    zmq_request("environment_open")
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    # The assumption is that only 'status' messages are streamed.
+    # If other messages are streamed, then the test needs to be adjusted.
+    if stream_enabled is True:
+        status_1 = rm_info.received_msgs[-1]["msg"]["status"]
+        assert status_1["worker_environment_exists"] is True
+
+    zmq_request("environment_close")
+    assert wait_for_condition(time=3, condition=condition_environment_closed)
+
+    if stream_enabled is True:
+        status_2 = rm_info.received_msgs[-1]["msg"]["status"]
+        assert status_2["worker_environment_exists"] is False
+        assert status_2["status_uid"] != status_1["status_uid"]
+
+    if stream_enabled is not True:
+        assert len(rm_info.received_msgs) == 0
+
+    rm_info.stop()
+    rm_info.join()

--- a/bluesky_queueserver/manager/tests/test_output_streaming.py
+++ b/bluesky_queueserver/manager/tests/test_output_streaming.py
@@ -9,7 +9,7 @@ import pytest
 from bluesky_queueserver.manager.comms import ZMQEncoding, process_zmq_encoding_name
 from bluesky_queueserver.manager.output_streaming import (
     ConsoleOutputStream,
-    PublishConsoleOutput,
+    PublishZMQStreamOutput,
     ReceiveConsoleOutput,
     ReceiveConsoleOutputAsync,
     ReceiveSystemInfo,
@@ -102,7 +102,7 @@ def test_ReceiveConsoleOutput_1(
     capfd, console_output_on, zmq_publish_on, sub, unsub, period, timeout, n_timeouts, zmq_encoding, channel
 ):
     """
-    Tests for ``ReceiveConsoleOutput`` and ``PublishConsoleOutput``.
+    Tests for ``ReceiveConsoleOutput``, ``ReceiveSystemInfo`` and ``PublishZMQStreamOutput``.
     """
     zmq_port = 61223  # Arbitrary port
     zmq_topic_console = "testing_topic_console"
@@ -113,7 +113,7 @@ def test_ReceiveConsoleOutput_1(
 
     queue = multiprocessing.Queue()
 
-    pco = PublishConsoleOutput(
+    pco = PublishZMQStreamOutput(
         msg_queue=queue,
         console_output_on=console_output_on,
         zmq_publish_on=zmq_publish_on,
@@ -238,7 +238,8 @@ def test_ReceiveConsoleOutput_1(
 @pytest.mark.xfail(reason="Test often fails when run on CI, but expected to pass locally")
 def test_ReceiveConsoleOutputAsync_1(period, cb_type, zmq_encoding, channel):
     """
-    Basic test for ``ReceiveConsoleOutputAsync``: send and receive 3 messages over 0MQ.
+    Basic test for ``ReceiveConsoleOutputAsync`` and ``ReceiveSystemInfoAsync``:
+    send and receive 3 messages over 0MQ.
     Send messages with different period (to check if timeout is handled correctly) and
     tests with callbacks in the form of plain function and coroutine.
     """
@@ -253,7 +254,7 @@ def test_ReceiveConsoleOutputAsync_1(period, cb_type, zmq_encoding, channel):
 
     queue = multiprocessing.Queue()
 
-    pco = PublishConsoleOutput(
+    pco = PublishZMQStreamOutput(
         msg_queue=queue,
         console_output_on=True,
         zmq_publish_on=True,
@@ -405,7 +406,7 @@ def test_ConsoleOutput_zmq_encoding_1(zmq_encoding):
 
     queue = multiprocessing.Queue()
 
-    pco = PublishConsoleOutput(msg_queue=queue, **params)
+    pco = PublishZMQStreamOutput(msg_queue=queue, **params)
     assert pco._encoding == encoding
 
     rco1 = ReceiveConsoleOutput(**params)

--- a/bluesky_queueserver/manager/tests/test_output_streaming.py
+++ b/bluesky_queueserver/manager/tests/test_output_streaming.py
@@ -12,6 +12,8 @@ from bluesky_queueserver.manager.output_streaming import (
     PublishConsoleOutput,
     ReceiveConsoleOutput,
     ReceiveConsoleOutputAsync,
+    ReceiveSystemInfo,
+    ReceiveSystemInfoAsync,
     setup_console_output_redirection,
 )
 
@@ -79,6 +81,7 @@ def test_setup_console_output_redirection_1(sys_stdout_stderr_restore):
 
 
 # fmt: off
+@pytest.mark.parametrize("channel", ["console", "info"])
 @pytest.mark.parametrize("zmq_encoding", ["json", "msgpack"])
 @pytest.mark.parametrize("console_output_on, zmq_publish_on, sub, unsub, period, timeout, n_timeouts", [
     (True, True, False, False, 0, None, 0),
@@ -96,13 +99,14 @@ def test_setup_console_output_redirection_1(sys_stdout_stderr_restore):
 # TODO: this test may need to be changed to run more reliably on CI
 @pytest.mark.xfail(reason="Test often fails when run on CI, but expected to pass locally")
 def test_ReceiveConsoleOutput_1(
-    capfd, console_output_on, zmq_publish_on, sub, unsub, period, timeout, n_timeouts, zmq_encoding
+    capfd, console_output_on, zmq_publish_on, sub, unsub, period, timeout, n_timeouts, zmq_encoding, channel
 ):
     """
     Tests for ``ReceiveConsoleOutput`` and ``PublishConsoleOutput``.
     """
     zmq_port = 61223  # Arbitrary port
-    zmq_topic = "testing_topic"
+    zmq_topic_console = "testing_topic_console"
+    zmq_topic_info = "testing_topic_info"
 
     zmq_publish_addr = f"tcp://*:{zmq_port}"
     zmq_subscribe_addr = f"tcp://localhost:{zmq_port}"
@@ -114,14 +118,15 @@ def test_ReceiveConsoleOutput_1(
         console_output_on=console_output_on,
         zmq_publish_on=zmq_publish_on,
         zmq_publish_addr=zmq_publish_addr,
-        zmq_topic=zmq_topic,
+        zmq_topic_console=zmq_topic_console,
+        zmq_topic_info=zmq_topic_info,
         encoding=zmq_encoding,
     )
 
     class ReceiveMessages(threading.Thread):
-        def __init__(self, *, zmq_subscribe_addr, zmq_topic, encoding):
+        def __init__(self, *, receiver_class, zmq_subscribe_addr, zmq_topic, encoding):
             super().__init__()
-            self._rco = ReceiveConsoleOutput(
+            self._rco = receiver_class(
                 zmq_subscribe_addr=zmq_subscribe_addr, zmq_topic=zmq_topic, encoding=encoding
             )
             self._exit = False
@@ -148,20 +153,35 @@ def test_ReceiveConsoleOutput_1(
         def unsubscribe(self):
             self._rco.unsubscribe()
 
-    rm = ReceiveMessages(zmq_subscribe_addr=zmq_subscribe_addr, zmq_topic=zmq_topic, encoding=zmq_encoding)
+    rm_console = ReceiveMessages(
+        receiver_class=ReceiveConsoleOutput,
+        zmq_subscribe_addr=zmq_subscribe_addr,
+        zmq_topic=zmq_topic_console,
+        encoding=zmq_encoding,
+    )
+
+    rm_info = ReceiveMessages(
+        receiver_class=ReceiveSystemInfo,
+        zmq_subscribe_addr=zmq_subscribe_addr,
+        zmq_topic=zmq_topic_info,
+        encoding=zmq_encoding,
+    )
 
     pco.start()
 
     if sub:
-        rm.subscribe()
+        rm_console.subscribe()
+        rm_info.subscribe()
     if unsub:
-        rm.unsubscribe()
+        rm_console.unsubscribe()
+        rm_info.unsubscribe()
     if not sub and not unsub:
-        rm.start()
+        rm_console.start()
+        rm_info.start()
 
     msgs = ["message-one\n", "message-two\n", "message-three\n"]
     for msg in msgs:
-        queue.put({"time": ttime.time(), "msg": msg})
+        queue.put({"channel": channel, "time": ttime.time(), "msg": msg})
         ttime.sleep(period)
 
     # Wait for all messages to be sent
@@ -171,19 +191,31 @@ def test_ReceiveConsoleOutput_1(
     ttime.sleep(pco._polling_timeout * 2)
 
     if sub or unsub:
-        rm.start()
+        rm_console.start()
+        rm_info.start()
         ttime.sleep(pco._polling_timeout * 2)
 
-    rm.stop()
-    rm.join()
+    rm_console.stop()
+    rm_info.stop()
+    rm_console.join()
+    rm_info.join()
+
+    if channel == "console":
+        rm = rm_console
+        rm_no_msg = rm_info
+    elif channel == "info":
+        rm = rm_info
+        rm_no_msg = rm_console
 
     if zmq_publish_on and not unsub:
         assert len(rm.received_msgs) == 3
+        assert len(rm_no_msg.received_msgs) == 0
         for msg_received, msg in zip(rm.received_msgs, msgs):
             assert isinstance(msg_received["time"], float)
             assert msg_received["msg"] == msg
     else:
-        assert len(rm.received_msgs) == 0
+        assert len(rm_console.received_msgs) == 0
+        assert len(rm_info.received_msgs) == 0
 
     captured = capfd.readouterr()
     if console_output_on:
@@ -197,13 +229,14 @@ def test_ReceiveConsoleOutput_1(
 
 
 # fmt: off
+@pytest.mark.parametrize("channel", ["console", "info"])
 @pytest.mark.parametrize("zmq_encoding", ["json", "msgpack"])
 @pytest.mark.parametrize("period", [0.5, 1, 1.5])
 @pytest.mark.parametrize("cb_type", ["func", "coro"])
 # fmt: on
 # TODO: this test may need to be changed to run more reliably on CI
 @pytest.mark.xfail(reason="Test often fails when run on CI, but expected to pass locally")
-def test_ReceiveConsoleOutputAsync_1(period, cb_type, zmq_encoding):
+def test_ReceiveConsoleOutputAsync_1(period, cb_type, zmq_encoding, channel):
     """
     Basic test for ``ReceiveConsoleOutputAsync``: send and receive 3 messages over 0MQ.
     Send messages with different period (to check if timeout is handled correctly) and
@@ -212,7 +245,8 @@ def test_ReceiveConsoleOutputAsync_1(period, cb_type, zmq_encoding):
     timeout = 1000  # Timeout used for waiting for incoming messages
 
     zmq_port = 61223  # Arbitrary port
-    zmq_topic = "testing_topic"
+    zmq_topic_console = "testing_topic_console"
+    zmq_topic_info = "testing_topic_info"
 
     zmq_publish_addr = f"tcp://*:{zmq_port}"
     zmq_subscribe_addr = f"tcp://localhost:{zmq_port}"
@@ -224,7 +258,8 @@ def test_ReceiveConsoleOutputAsync_1(period, cb_type, zmq_encoding):
         console_output_on=True,
         zmq_publish_on=True,
         zmq_publish_addr=zmq_publish_addr,
-        zmq_topic=zmq_topic,
+        zmq_topic_console=zmq_topic_console,
+        zmq_topic_info=zmq_topic_info,
         encoding=zmq_encoding,
     )
 
@@ -232,40 +267,59 @@ def test_ReceiveConsoleOutputAsync_1(period, cb_type, zmq_encoding):
 
     msgs = ["message-one\n", "message-two\n", "message-three\n"]
 
-    rm = ReceiveConsoleOutputAsync(
-        zmq_subscribe_addr=zmq_subscribe_addr, zmq_topic=zmq_topic, timeout=timeout, encoding=zmq_encoding
+    rm_console = ReceiveConsoleOutputAsync(
+        zmq_subscribe_addr=zmq_subscribe_addr, zmq_topic=zmq_topic_console, timeout=timeout, encoding=zmq_encoding
+    )
+    rm_info = ReceiveSystemInfoAsync(
+        zmq_subscribe_addr=zmq_subscribe_addr, zmq_topic=zmq_topic_info, timeout=timeout, encoding=zmq_encoding
     )
     ttime.sleep(1)  # Important when executed on CI
 
     async def testing():
-        msgs_received = []
+        msgs_received_console, msgs_received_info = [], []
 
-        def cb_func(msg):
-            msgs_received.append(msg)
+        def cb_func_console(msg):
+            msgs_received_console.append(msg)
 
-        async def cb_coro(msg):
-            msgs_received.append(msg)
+        def cb_func_info(msg):
+            msgs_received_info.append(msg)
+
+        async def cb_coro_console(msg):
+            msgs_received_console.append(msg)
+
+        async def cb_coro_info(msg):
+            msgs_received_info.append(msg)
 
         if cb_type == "func":
-            cb = cb_func
+            cb_console, cb_info = cb_func_console, cb_func_info
         elif cb_type == "coro":
-            cb = cb_coro
+            cb_console, cb_info = cb_coro_console, cb_coro_info
         else:
             raise RuntimeError(f"Unknown callback type: {cb_type!r}")
 
-        rm.set_callback(cb=cb)
+        rm_console.set_callback(cb=cb_console)
+        rm_info.set_callback(cb=cb_info)
 
         for n in range(2):
             # ReceiveConsoleOutputAsync is expected to allow to start and stop acquisition multiple times.
-            msgs_received.clear()
-            rm.start()
-            rm.start()  # Repeated attempts to start should have no effect
+            msgs_received_console.clear()
+            msgs_received_info.clear()
+            rm_console.start()
+            rm_info.start()
+            rm_console.start()  # Repeated attempts to start should have no effect
+            rm_info.start()
 
             for msg in msgs:
-                queue.put({"time": ttime.time(), "msg": msg})
+                queue.put({"channel": channel, "time": ttime.time(), "msg": msg})
                 await asyncio.sleep(1)
 
-            rm.stop()
+            rm_console.stop()
+            rm_info.stop()
+
+            if channel == "console":
+                msgs_received, msgs_received_empty = msgs_received_console, msgs_received_info
+            elif channel == "info":
+                msgs_received, msgs_received_empty = msgs_received_info, msgs_received_console
 
             # Wait for all messages to be sent. It happens almost instantly when tests are run
             #   locally, but there could be delays when running on CI.
@@ -275,12 +329,13 @@ def test_ReceiveConsoleOutputAsync_1(period, cb_type, zmq_encoding):
                     break
 
             assert len(msgs_received) == 3, f"Attempt #{n + 1}"
+            assert len(msgs_received_empty) == 0
             for msg_received, msg in zip(msgs_received, msgs):
                 assert isinstance(msg_received["time"], float)
                 assert msg_received["msg"] == msg
 
             # Send an extra message. Acquisition is stopped at this point
-            queue.put({"time": ttime.time(), "msg": "Message is expected to be discarded"})
+            queue.put({"channel": channel, "time": ttime.time(), "msg": "Message is expected to be discarded"})
             await asyncio.sleep(1)
 
     asyncio.run(testing())

--- a/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -94,6 +94,7 @@ def test_filter_item_parameters(item_in, item_out):
 def test_running_plan_info():
     """
     Basic test for the following methods:
+    `PlanQueueOperations._is_item_running()`
     `PlanQueueOperations.is_item_running()`
     `PlanQueueOperations.get_running_item_info()`
     `PlanQueueOperations.delete_pool_entries()`
@@ -102,22 +103,26 @@ def test_running_plan_info():
     async def testing():
         async with PQ() as pq:
             assert pq.get_running_item_info() == {}
-            assert await pq.is_item_running() is False
+            assert await pq._is_item_running() is False
+            assert pq.is_item_running() is False
 
             some_plan = {"some_key": "some_value"}
             await pq._set_running_item_info(some_plan)
             assert pq.get_running_item_info() == some_plan
 
-            assert await pq.is_item_running() is True
+            assert await pq._is_item_running() is True
+            assert pq.is_item_running() is True
 
             await pq._clear_running_item_info()
             assert pq.get_running_item_info() == {}
-            assert await pq.is_item_running() is False
+            assert await pq._is_item_running() is False
+            assert pq.is_item_running() is False
 
             await pq._set_running_item_info(some_plan)
             await pq.delete_pool_entries()
             assert pq.get_running_item_info() == {}
-            assert await pq.is_item_running() is False
+            assert await pq._is_item_running() is False
+            assert pq.is_item_running() is False
 
     asyncio.run(testing())
 
@@ -294,7 +299,8 @@ def test_verify_item(plan, f_kwargs, result, errmsg):
                 await pq.set_next_item_as_running()
 
                 # Verify that setup is correct
-                assert await pq.is_item_running() is True
+                assert await pq._is_item_running() is True
+                assert pq.is_item_running() is True
                 assert pq.get_queue_size() == 1
 
             await set_plans()
@@ -1809,10 +1815,12 @@ def test_process_next_item_1(func, loop_mode, immediate_execution):
 
             # Apply to empty queue
             assert pq.get_queue_size() == 0
-            assert await pq.is_item_running() is False
+            assert await pq._is_item_running() is False
+            assert pq.is_item_running() is False
             assert await pq.set_next_item_as_running() == {}
             assert pq.get_queue_size() == 0
-            assert await pq.is_item_running() is False
+            assert await pq._is_item_running() is False
+            assert pq.is_item_running() is False
 
             # Apply to a queue with several plans
             p1, _ = await pq.add_item_to_queue({"item_type": "plan", "name": "a"})
@@ -1883,10 +1891,12 @@ def test_process_next_item_2(loop_mode, immediate_execution):
 
             # Apply to empty queue
             assert pq.get_queue_size() == 0
-            assert await pq.is_item_running() is False
+            assert await pq._is_item_running() is False
+            assert pq.is_item_running() is False
             assert await pq.set_next_item_as_running() == {}
             assert pq.get_queue_size() == 0
-            assert await pq.is_item_running() is False
+            assert await pq._is_item_running() is False
+            assert pq.is_item_running() is False
 
             # Apply to a queue with several plans
             p0, _ = await pq.add_item_to_queue({"item_type": "instruction", "name": "a"})

--- a/bluesky_queueserver/manager/tests/test_zmq_api_base.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api_base.py
@@ -1235,6 +1235,7 @@ def test_zmq_api_queue_item_execute_1(re_manager):  # noqa: F811
     resp2a, _ = zmq_request("status")
     assert resp2a["items_in_queue"] == 1
     assert resp2a["items_in_history"] == 0
+    assert resp2a["manager_state"] == "idle"
     assert resp2a["worker_environment_state"] == "idle"
     plan_queue_uid1 = resp2a["plan_queue_uid"]
     running_item_uid1 = resp2a["running_item_uid"]
@@ -1249,9 +1250,7 @@ def test_zmq_api_queue_item_execute_1(re_manager):  # noqa: F811
 
     # Check status immediately
     status, _ = zmq_request("status")
-    ttime.sleep(1) ##
-    assert status["plan_queue_uid"] != plan_queue_uid1
-    assert status["running_item_uid"] != running_item_uid1
+    assert status["manager_state"] != "idle"
 
     ttime.sleep(1)
     status, _ = zmq_request("status")
@@ -2087,7 +2086,7 @@ def test_zmq_api_script_upload_01(re_manager, update_lists, run_in_background): 
     assert isinstance(result, dict)
     assert isinstance(result["time_start"], float)
     assert result["task_uid"] == task_uid
-    assert result["run_in_background"] is run_in_background
+    assert result["run_in_background"] == run_in_background
 
     def condition_new_task_result_uid(msg):
         return msg["task_results_uid"] != task_results_uid

--- a/bluesky_queueserver/manager/tests/test_zmq_api_base.py
+++ b/bluesky_queueserver/manager/tests/test_zmq_api_base.py
@@ -1249,6 +1249,7 @@ def test_zmq_api_queue_item_execute_1(re_manager):  # noqa: F811
 
     # Check status immediately
     status, _ = zmq_request("status")
+    ttime.sleep(1) ##
     assert status["plan_queue_uid"] != plan_queue_uid1
     assert status["running_item_uid"] != running_item_uid1
 

--- a/docs/source/features_and_config.rst
+++ b/docs/source/features_and_config.rst
@@ -156,7 +156,7 @@ Remote Monitoring of Console Output
 -----------------------------------
 
 RE Manager is capable of capturing and publishing console output to 0MQ socket.
-0MQ publishing is disabled by default and must be enabled using ``--zmq-publish``
+0MQ publishing is disabled by default and must be enabled using ``--zmq-publish-console``
 parameter of ``start-re-manager``. A simple monitoring application (``qserver-console-monitor``)
 allows to visualize the published output. See :ref:`tutorial_remote_monitoring` for a brief
 tutorial.
@@ -164,3 +164,11 @@ tutorial.
 ``bluesky_queueserver`` package provides ``ReceiveConsoleOutput`` and ``ReceiveConsoleOutputAsync``
 class, which can be helpful in implementing remote monitoring features in client applications. See
 :ref:`subscribing_to_console_output` for more details.
+
+Remote Monitoring of System Info
+--------------------------------
+
+In addition to streaming console output, RE Manager is streaming system information over the
+same 0MQ socket. Currently only RE Manager status is streamed. The convenience classes
+``ReceiveSystemInfo`` and ``ReceiveSystemInfoAsync`` can be used to implement remote monitoring
+features in client applications. See :ref:`subscribing_to_system_info` for more details.

--- a/docs/source/interacting_with_qs.rst
+++ b/docs/source/interacting_with_qs.rst
@@ -9,7 +9,7 @@ Interacting with Queue Server
 Subscribing to Published Console Output
 ---------------------------------------
 
-If console output publishing is enabled at RE Manager (parameter ``--zmq-publish``), the output
+If console output publishing is enabled at RE Manager (parameter ``--zmq-publish-console``), the output
 is published to 0MQ socket. Client applications may subscribe to the messages and use them
 for processing, display them to users or forward to other applications.
 
@@ -59,6 +59,50 @@ and starting and then stopping acquisition with ``start()`` and ``stop()`` metho
     ReceiveConsoleOutputAsync.set_callback
     ReceiveConsoleOutputAsync.start
     ReceiveConsoleOutputAsync.stop
+
+.. _subscribing_to_system_info:
+
+Subscribing to Published System Info
+------------------------------------
+
+In addition to streaming of console output, RE Manager is publishing status information to
+the same 0MQ PUB socket. The status information published using a different topic and can
+be easily separated from console output messages. The messages are published once per
+second or each time status is changed by RE Manager. Periodically published status can be
+used as 'heartbeat' to detect that RE Manager is running properly.
+
+The message format used for streaming is similar to the message format for console output.
+The ``status`` key indicates that the message contains status information. Messages with
+other information may be added to the stream in the future::
+
+  {"time": <timestamp>, "msg": {"status": <status-info>}}
+
+
+The ``ReceiveSystemInfo`` class can be used in synchronous or thread-based applications to
+receive the streamed messages:
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated
+
+    ReceiveSystemInfo
+    ReceiveSystemInfo.subscribe
+    ReceiveSystemInfo.unsubscribe
+    ReceiveSystemInfo.recv
+
+``ReceiveSystemInfoAsync`` is the asyncio-based version of the class:
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated
+
+    ReceiveSystemInfoAsync
+    ReceiveSystemInfoAsync.subscribe
+    ReceiveSystemInfoAsync.unsubscribe
+    ReceiveSystemInfoAsync.recv
+    ReceiveSystemInfoAsync.set_callback
+    ReceiveSystemInfoAsync.start
+    ReceiveSystemInfoAsync.stop
 
 
 Formatting Descriptions of Plans and Plan Parameters

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -192,11 +192,19 @@ Parameters    ---
 Returns       **msg**: *str*
                  application name and version, e.g. 'RE Manager v0.0.10'
 
+              **time**: *str*
+                 timestamp of the last status update. Time is formatted accoring to iso8601,
+                 e.g. '2025-11-24T15:25:54.956818'.
+
               **items_in_queue**: *int*
                  the number of items in the plan queue
 
               **items_in_history**: *int*
                  the number of items in the plan history
+
+              **status_uid**: *str*
+                 status UID is changed each time status is updated at the server. The UID can
+                 be used to detect changes in other status parameters.
 
               **running_item_uid**: *str* or *None*
                  item UID of the currently running plan or *None* if no plan is currently running.

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -112,28 +112,33 @@ Monitoring of Status of RE Manager
 Status of RE Manager may be loaded at any time using :ref:`method_status` API. The API returns
 a dictionary with status parameters::
 
-  {'devices_allowed_uid': '0639bc7a-15c1-4bc2-bfeb-41f58a08a8b9',
-  'devices_existing_uid': '2fe9df70-5f0f-4c17-bb7b-cda8a0aa80b0',
-  'items_in_history': 0,
+  {'msg': 'RE Manager v0.0.24',
+  'time': '2025-11-24T15:25:54.956818',
   'items_in_queue': 0,
-  'lock': {'environment': False, 'queue': False},
-  'lock_info_uid': '2b438226-f715-4ed3-a057-400a42717bb0',
-  'manager_state': 'idle',
-  'msg': 'RE Manager v0.0.16.post28.dev0+ge2491ae',
-  'pause_pending': False,
-  'plan_history_uid': '5894c896-b2ea-42c1-9dd0-f4faaa52cb39',
-  'plan_queue_mode': {'loop': False},
-  'plan_queue_uid': '5589b7ac-01b9-4f51-a7f2-8e883c352053',
-  'plans_allowed_uid': '835a998a-e01e-439f-bb3a-b65817904f7a',
-  'plans_existing_uid': '609ec025-2552-4e06-aa54-5e9ae7b7ed2c',
-  'queue_stop_pending': False,
-  're_state': 'idle',
-  'run_list_uid': '0b088775-1cc3-46de-9563-b83e04c0e243',
+  'items_in_history': 10,
   'running_item_uid': None,
-  'task_results_uid': '846b6dd3-d9c2-4a12-bd03-b82580b8f742',
+  'manager_state': 'idle',
+  'queue_stop_pending': False,
+  'queue_autostart_enabled': False,
+  'worker_environment_exists': False,
+  'worker_environment_state': 'closed',
   'worker_background_tasks': 0,
-  'worker_environment_exists': True,
-  'worker_environment_state': 'idle'}
+  're_state': None,
+  'ip_kernel_state': None,
+  'ip_kernel_captured': None,
+  'pause_pending': False,
+  'status_uid': 'bff85f14-1385-4bd2-b6c1-ca10ce6e9fb7',
+  'run_list_uid': 'df43e1f9-897c-42a3-886b-a74cca92b9a5',
+  'plan_queue_uid': '8480de4e-1ce7-4ca4-a1dc-a70c217f4d70',
+  'plan_history_uid': 'd87aa9df-317d-4633-8773-a6acdb0cd0d3',
+  'devices_existing_uid': '129a3100-4719-4f6a-8994-78cd58391ece',
+  'plans_existing_uid': 'eed0604d-8f6e-4c80-b41b-fe724947c177',
+  'devices_allowed_uid': '2bab7afe-57ac-4fd7-8ff1-cb3c100a8679',
+  'plans_allowed_uid': 'eb253deb-a7f4-434a-bc57-448d83e1f077',
+  'plan_queue_mode': {'loop': False, 'ignore_failures': False},
+  'task_results_uid': '4378acb7-fd66-46a4-9ee6-61eae87fef66',
+  'lock_info_uid': '026b0a83-4de0-4974-b8c7-1db0031bb91b',
+  'lock': {'environment': False, 'queue': False}}
 
 The parameter *msg* contains the version information on currently running RE Manager. The states
 of RE Manager and Run Engine are returned using parameters *manager_state* and *re_state*.
@@ -146,6 +151,12 @@ objects that are changed each time the objects are updated. For example, *plan_q
 each time the queue is updated either in response to API request from a client or due to internal
 processes. Tracking changes in UIDs and downloading the respective objects only when the UIDs
 change is more efficient than continuously polling the objects themselves.
+
+The *status_uid* parameter is updated each time the status is changed and can be used for detecting
+changes of other status parameters. The parameter *time* is the timestamp of last updated of
+status. In some conditions status may not update for long period of time. For example,
+as long as RE Manager remains idle and no operations are performed on the queue or history,
+then *status_uid* and *time* remains unchanged.
 
 See documentation on :ref:`method_status` API for detailed description of the status parameters.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Implement streaming of status message over the 0MQ PUB socket ('info' socket that is currently used for streaming console output). The status messages are published to a separate topic, so they are easy to separate from console output messages. The message format is:

```
{"time": <timestamp>, "msg": {"status": <RE-Manager-status>}}
```

Other messages may be added to the stream in the future. The clients receiving the stream are responsible for separating status message from other messages. Support for system info streaming is added to `bluesky-queueserver-api` and `bluesky-httpserver` packages.

Additional fields were added to RE Manager status:

- `time` - time when the status was last updated, e.g. `'2025-12-03T11:10:07.686340'`.
- `status_uid` - UID of the status message, a new UID is generated each time the status is updated. The UID is not changed if the same status message is resent multiple times.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Added

- Additional fields in RE Manager status: `time` and `status_uid`.
- Implemented streaming of RE Manager status over `info` 0MQ socket.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Additional unit tests were implemented.

<!--
## Screenshots (if appropriate):
-->
