### PR TITLE
Added `_uid_dict_remove` for loop mode

### DIFF
--- a/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/bluesky_queueserver/manager/plan_queue_ops.py
@@ -1764,6 +1764,7 @@ class PlanQueueOperations:
                 item_to_add = item_cleaned.copy()
                 item_to_add = self.set_new_item_uuid(item_to_add)
                 await self._r_pool.rpush(self._name_plan_queue, json.dumps(item_to_add))
+                self._uid_dict_remove(item["item_uid"])
                 self._uid_dict_add(item_to_add)
             item_cleaned.setdefault("result", {})
             item_cleaned["result"]["exit_status"] = exit_status


### PR DESCRIPTION
## Description
We observed a constant increase in memory consumption when using the loop mode of the queue server.

## Motivation and Context

Issue #349 describes the observed behaviour.

## Summary of Changes for Release Notes
I added a call to `_uid_dict_remove` in loop mode, to replicate the behaviour found in standard mode.

### Fixed
The change fixes the observed memory leak.

## How Has This Been Tested?
A `count` plan was executed in loop mode, for approximately 100k times, after the fix was applied.


## Screenshots (if appropriate):

before:
<img width="2560" height="1049" alt="image" src="https://github.com/user-attachments/assets/ddc852d1-ac8f-401e-afd2-20f7350c49c7" />

after:
<img width="2560" height="1047" alt="image" src="https://github.com/user-attachments/assets/3fa8139e-fad6-4888-8b3a-8fb53fa1d7a7" />
