### PR TITLE
Fix for the failing unit tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,14 +13,14 @@ jobs:
     strategy:
       matrix:
         use-ipykernel: [false, true]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         zmq-encoding: ["json", "msgpack"]
         # pydantic-version: ["<2.0.0", ">=2.0.0"]
         group: [1, 2, 3]
         exclude:
-          - python-version: "3.10"
-            zmq-encoding: "msgpack"
           - python-version: "3.11"
+            zmq-encoding: "msgpack"
+          - python-version: "3.12"
             zmq-encoding: "msgpack"
           - python-version: "3.13"
             zmq-encoding: "msgpack"

--- a/bluesky_queueserver/manager/manager.py
+++ b/bluesky_queueserver/manager/manager.py
@@ -1763,6 +1763,7 @@ class RunEngineManager(Process):
             )
             success = response["status"] == "accepted"
             err_msg = response["err_msg"]
+
         except CommTimeoutError:
             success, err_msg = (None, "Timeout occurred while processing the request")
         return success, err_msg

--- a/bluesky_queueserver/manager/profile_ops.py
+++ b/bluesky_queueserver/manager/profile_ops.py
@@ -453,8 +453,12 @@ def load_startup_script(script_path, *, enable_local_imports=True, nspace=None):
             #   the script is executed again.
             for key in list(sys.modules.keys()):
                 if key not in sm_keys:
-                    # print(f"Deleting the key '{key}'")
-                    del sys.modules[key]
+                    # Make sure the module is local before deleting it.
+                    # Do not delete common library modules.
+                    fl = getattr(sys.modules[key], "__file__", None)
+                    if fl and fl.startswith(p):
+                        # print(f"Deleting the key '{key}'")
+                        del sys.modules[key]
 
             sys.path.remove(p)
 
@@ -653,8 +657,12 @@ def load_script_into_existing_nspace(
             #   the script is executed again.
             for key in list(sys.modules.keys()):
                 if key not in sm_keys:
-                    print(f"Deleting the key '{key}'")
-                    del sys.modules[key]
+                    # Make sure the module is local before deleting it.
+                    # Do not delete common library modules.
+                    fl = getattr(sys.modules[key], "__file__", None)
+                    if fl and fl.startswith(script_root_path):
+                        # print(f"Deleting the key '{key}'")
+                        del sys.modules[key]
 
             sys.path.remove(script_root_path)
 

--- a/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
+++ b/bluesky_queueserver/manager/tests/test_ip_kernel_func.py
@@ -1343,6 +1343,7 @@ def test_ip_kernel_interrupt_03(
     elif pause_option == "immediate":
         resp, _ = zmq_request("kernel_interrupt", params=params_interrupt)
         assert resp["success"] is True, pprint.pformat(resp)
+        ttime.sleep(0.2)  # Short pause between consecutive interrupt requests
         resp, _ = zmq_request("kernel_interrupt", params=params_interrupt)
         assert resp["success"] is True, pprint.pformat(resp)
     else:

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -1931,11 +1931,11 @@ _pf2f_processed = {
 
 
 def _pf2g(
-    val1: typing.Tuple[typing.Union[float, int]] = (50,),
-    val2: typing.Union[typing.List[str], str] = "some_str",
+    val1: typing.Tuple[float | int] = (50,),
+    val2: typing.List[str] | str = "some_str",
     val3: typing.Dict[str, int] = {"ab": 10, "cd": 50},
     val4: Dict[str, int] = {"ab": 10, "cd": 50},  # No module name 'typing'
-    val5: Optional[float] = None,  # typing.Optional[float] == typing.Union[float, NoneType]
+    val5: float | None = None,  # typing.Optional[float] == typing.Union[float, NoneType]
 ):
     yield from [val1, val2, val3, val4, val5]
 
@@ -1946,13 +1946,13 @@ _pf2g_processed = {
             "name": "val1",
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "default": "(50,)",
-            "annotation": {"type": "typing.Tuple[typing.Union[float, int]]"},
+            "annotation": {"type": "typing.Tuple[float | int]"},
         },
         {
             "name": "val2",
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "default": "'some_str'",
-            "annotation": {"type": "typing.Union[typing.List[str], str]"},
+            "annotation": {"type": "typing.List[str] | str"},
         },
         {
             "name": "val3",
@@ -1970,9 +1970,7 @@ _pf2g_processed = {
             "name": "val5",
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "default": "None",
-            "annotation": {
-                "type": "typing.Optional[float]" if python_version >= (3, 9) else "typing.Union[float, NoneType]"
-            },
+            "annotation": {"type": "float | None"},
         },
     ],
     "properties": {"is_generator": True},
@@ -2118,13 +2116,13 @@ _pf2j_processed = {
             "name": "val8",
         },
         {
-            "annotation": {"type": "typing.Optional[__DEVICE__]"},
+            "annotation": {"type": "__DEVICE__ | None"},
             "convert_device_names": True,
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "name": "val9",
         },
         {
-            "annotation": {"type": "typing.Union[__DEVICE__, list[__DEVICE__]]"},
+            "annotation": {"type": "__DEVICE__ | list[__DEVICE__]"},
             "convert_device_names": True,
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "name": "val10",
@@ -2137,17 +2135,15 @@ _pf2j_processed = {
 def _pf2k(
     val1: typing.Callable,
     val2: typing.Callable[[int, float], str],
-    val3: typing.Union[
-        typing.Callable[[int, float], typing.Tuple[str, str]], typing.List[typing.Callable[[int, float], str]]
-    ],
-    val4: typing.Union[
-        collections.abc.Callable[[int, float], typing.Tuple[str, str]],
-        list[collections.abc.Callable[[int, float], str]],
-    ],
-    val5: typing.Union[
-        collections.abc.Callable[[int, typing.Callable[[int], int]], typing.Tuple[str, str]],
-        list[collections.abc.Callable[[int, float], str]],
-    ],
+    val3: typing.Callable[[int, float], typing.Tuple[str, str]] | typing.List[typing.Callable[[int, float], str]],
+    val4: (
+        collections.abc.Callable[[int, float], typing.Tuple[str, str]]
+        | list[collections.abc.Callable[[int, float], str]]
+    ),
+    val5: (
+        collections.abc.Callable[[int, typing.Callable[[int], int]], typing.Tuple[str, str]]
+        | list[collections.abc.Callable[[int, float], str]]
+    ),
 ):
     yield from [val1, val2, val3, val4, val5]
 
@@ -2167,19 +2163,19 @@ _pf2k_processed = {
             "name": "val2",
         },
         {
-            "annotation": {"type": "typing.Union[__CALLABLE__, typing.List[__CALLABLE__]]"},
+            "annotation": {"type": "__CALLABLE__ | typing.List[__CALLABLE__]"},
             "eval_expressions": True,
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "name": "val3",
         },
         {
-            "annotation": {"type": "typing.Union[__CALLABLE__, list[__CALLABLE__]]"},
+            "annotation": {"type": "__CALLABLE__ | list[__CALLABLE__]"},
             "eval_expressions": True,
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "name": "val4",
         },
         {
-            "annotation": {"type": "typing.Union[__CALLABLE__, list[__CALLABLE__]]"},
+            "annotation": {"type": "__CALLABLE__ | list[__CALLABLE__]"},
             "eval_expressions": True,
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "name": "val5",
@@ -2192,7 +2188,7 @@ _pf2k_processed = {
 def _pf2l(
     val1: collections.abc.Iterable,
     val2: collections.abc.Iterable[int],
-    val3: Optional[typing.Union[collections.abc.Iterable, bool]],
+    val3: collections.abc.Iterable | bool | None,
 ):
     yield from [val1, val2, val3]
 
@@ -2210,7 +2206,7 @@ _pf2l_processed = {
             "name": "val2",
         },
         {
-            "annotation": {"type": "typing.Union[collections.abc.Iterable[typing.Any], bool, NoneType]"},
+            "annotation": {"type": "collections.abc.Iterable[typing.Any] | bool | None"},
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "name": "val3",
         },

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -5201,8 +5201,12 @@ def test_prepare_plan_5(plan, from_nspace):
 # fmt: off
 _det_components = {
     "components": {
-        "Imax": {}, "center": {}, "noise": {},
-        "noise_multiplier": {}, "sigma": {}, "val": {},
+        "Imax": {},
+        "center": {},
+        "noise": {},
+        "noise_multiplier": {},
+        "sigma": {},
+        "val": {},
     }
 }
 
@@ -5233,7 +5237,10 @@ _stg_components = {
 
 _mtr_async_components = {
     "components": {
-        "acceleration_time": {}, "units": {}, "user_readback": {}, "user_setpoint": {}, "velocity": {}
+        "acceleration_time": {},
+        "user_readback": {},
+        "user_setpoint": {},
+        "velocity": {},
     }
 }
 
@@ -5365,6 +5372,8 @@ def test_prepare_devices_1(max_depth, registered_devices, expected_devices):
 
     clean_devices(existing_devices)
 
+    print(f"existing_devices: {pprint.pformat(existing_devices)}")
+    print(f"expected_devices: {pprint.pformat(expected_devices)}")
     assert existing_devices == expected_devices, pprint.pformat(existing_devices)
 
 

--- a/bluesky_queueserver/manager/tests/test_profile_ops.py
+++ b/bluesky_queueserver/manager/tests/test_profile_ops.py
@@ -1931,11 +1931,11 @@ _pf2f_processed = {
 
 
 def _pf2g(
-    val1: typing.Tuple[float | int] = (50,),
-    val2: typing.List[str] | str = "some_str",
-    val3: typing.Dict[str, int] = {"ab": 10, "cd": 50},
-    val4: Dict[str, int] = {"ab": 10, "cd": 50},  # No module name 'typing'
-    val5: float | None = None,  # typing.Optional[float] == typing.Union[float, NoneType]
+    val1: tuple[float | int] = (50,),
+    val2: list[str] | str = "some_str",
+    val3: dict[str, int] = {"ab": 10, "cd": 50},
+    val4: dict[str, int] = {"ab": 10, "cd": 50},
+    val5: float | None = None,
 ):
     yield from [val1, val2, val3, val4, val5]
 
@@ -1946,13 +1946,68 @@ _pf2g_processed = {
             "name": "val1",
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "default": "(50,)",
-            "annotation": {"type": "typing.Tuple[float | int]"},
+            "annotation": {"type": "tuple[float | int]"},
         },
         {
             "name": "val2",
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "default": "'some_str'",
-            "annotation": {"type": "typing.List[str] | str"},
+            "annotation": {"type": "list[str] | str"},
+        },
+        {
+            "name": "val3",
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "default": "{'ab': 10, 'cd': 50}",
+            "annotation": {"type": "dict[str, int]"},
+        },
+        {
+            "name": "val4",
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "default": "{'ab': 10, 'cd': 50}",
+            "annotation": {"type": "dict[str, int]"},
+        },
+        {
+            "name": "val5",
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "default": "None",
+            "annotation": {"type": "float | None"},
+        },
+    ],
+    "properties": {"is_generator": True},
+}
+
+
+def _pf2g2(
+    val1: typing.Tuple[typing.Union[float, int]] = (50,),
+    val2: typing.Union[typing.List[str], str] = "some_str",
+    val3: typing.Dict[str, int] = {"ab": 10, "cd": 50},
+    val4: Dict[str, int] = {"ab": 10, "cd": 50},  # No module name 'typing'
+    val5: typing.Optional[float] = None,  # typing.Optional[float] == typing.Union[float, NoneType]
+):
+    yield from [val1, val2, val3, val4, val5]
+
+
+_pf2g2_processed = {
+    "parameters": [
+        {
+            "name": "val1",
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "default": "(50,)",
+            "annotation": (
+                {"type": "typing.Tuple[float | int]"}
+                if sys.version_info >= (3, 14)
+                else {"type": "typing.Tuple[typing.Union[float, int]]"}
+            ),
+        },
+        {
+            "name": "val2",
+            "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
+            "default": "'some_str'",
+            "annotation": (
+                {"type": "typing.List[str] | str"}
+                if sys.version_info >= (3, 14)
+                else {"type": "typing.Union[typing.List[str], str]"}
+            ),
         },
         {
             "name": "val3",
@@ -1970,7 +2025,9 @@ _pf2g_processed = {
             "name": "val5",
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "default": "None",
-            "annotation": {"type": "float | None"},
+            "annotation": (
+                {"type": "float | None"} if sys.version_info >= (3, 14) else {"type": "typing.Optional[float]"}
+            ),
         },
     ],
     "properties": {"is_generator": True},
@@ -2116,13 +2173,21 @@ _pf2j_processed = {
             "name": "val8",
         },
         {
-            "annotation": {"type": "__DEVICE__ | None"},
+            "annotation": (
+                {"type": "__DEVICE__ | None"}
+                if sys.version_info >= (3, 14)
+                else {"type": "typing.Optional[__DEVICE__]"}
+            ),
             "convert_device_names": True,
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "name": "val9",
         },
         {
-            "annotation": {"type": "__DEVICE__ | list[__DEVICE__]"},
+            "annotation": (
+                {"type": "__DEVICE__ | list[__DEVICE__]"}
+                if sys.version_info >= (3, 14)
+                else {"type": "typing.Union[__DEVICE__, list[__DEVICE__]]"}
+            ),
             "convert_device_names": True,
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "name": "val10",
@@ -2135,7 +2200,9 @@ _pf2j_processed = {
 def _pf2k(
     val1: typing.Callable,
     val2: typing.Callable[[int, float], str],
-    val3: typing.Callable[[int, float], typing.Tuple[str, str]] | typing.List[typing.Callable[[int, float], str]],
+    val3: typing.Union[
+        typing.Callable[[int, float], typing.Tuple[str, str]], typing.List[typing.Callable[[int, float], str]]
+    ],
     val4: (
         collections.abc.Callable[[int, float], typing.Tuple[str, str]]
         | list[collections.abc.Callable[[int, float], str]]
@@ -2163,7 +2230,11 @@ _pf2k_processed = {
             "name": "val2",
         },
         {
-            "annotation": {"type": "__CALLABLE__ | typing.List[__CALLABLE__]"},
+            "annotation": (
+                {"type": "__CALLABLE__ | typing.List[__CALLABLE__]"}
+                if sys.version_info >= (3, 14)
+                else {"type": "typing.Union[__CALLABLE__, typing.List[__CALLABLE__]]"}
+            ),
             "eval_expressions": True,
             "kind": {"name": "POSITIONAL_OR_KEYWORD", "value": 1},
             "name": "val3",
@@ -2224,6 +2295,7 @@ _pf2l_processed = {
     (_pf2e, _pf2e_processed),
     (_pf2f, _pf2f_processed),
     (_pf2g, _pf2g_processed),
+    (_pf2g2, _pf2g2_processed),
     (_pf2h, _pf2h_processed),
     (_pf2i, _pf2i_processed),
     (_pf2j, _pf2j_processed),

--- a/bluesky_queueserver/manager/tests/test_profile_tools.py
+++ b/bluesky_queueserver/manager/tests/test_profile_tools.py
@@ -324,7 +324,7 @@ def _configure_happi(tmp_path, monkeypatch, json_devices):
     (("det", ["motor", "2motor_$new"]), ("det", "motor"), {}, False, "may consist of lowercase letters, numbers"),
 ])
 # fmt: on
-@pytest.mark.skipif(sys.version_info[:2] == (3, 13), reason="Do not run the test for Python 3.13 (Happi)")
+@pytest.mark.skipif(sys.version_info[:2] >= (3, 13), reason="Do not run the test for Python >= 3.13 (Happi)")
 def test_load_devices_from_happi_1(tmp_path, monkeypatch, device_names, loaded_names, kw_args, success, errmsg):
     """
     Tests for ``load_devices_from_happi``.

--- a/bluesky_queueserver/profile_collection_sim/15-plans.py
+++ b/bluesky_queueserver/profile_collection_sim/15-plans.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 print(f"Loading file {__file__!r}")
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from bluesky.plans import (
     adaptive_scan,
@@ -35,6 +35,6 @@ from bluesky.plans import (
 
 
 def marked_up_count(
-    detectors: List[Any], num: int = 1, delay: Optional[float] = None, md: Optional[Dict[str, Any]] = None
+    detectors: list[Any], num: int = 1, delay: float | None = None, md: dict[str, Any] | None = None
 ):
     return (yield from count(detectors, num=num, delay=delay, md=md))

--- a/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
+++ b/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
@@ -1596,7 +1596,7 @@ existing_plans:
         value: 1
       name: backstep
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: '0.8'
       description: threshold for going backward and rescanning a region, default is
         0.8
@@ -1605,7 +1605,7 @@ existing_plans:
         value: 1
       name: threshold
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -1628,7 +1628,7 @@ existing_plans:
         value: 1
       name: detectors
     - annotation:
-        type: typing.Optional[int]
+        type: int | None
       default: '1'
       description: 'number of readings to take; default is 1
 
@@ -1639,7 +1639,7 @@ existing_plans:
         value: 1
       name: num
     - annotation:
-        type: typing.Union[float, collections.abc.Iterable[float]]
+        type: float | collections.abc.Iterable[float]
       default: '0.0'
       description: Time delay in seconds between successive readings; default is 0.
       kind:
@@ -1655,7 +1655,7 @@ existing_plans:
         value: 3
       name: per_shot
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -1786,7 +1786,7 @@ existing_plans:
         value: 1
       name: flyers
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -1813,7 +1813,7 @@ existing_plans:
         value: 2
       name: args
     - annotation:
-        type: typing.Union[collections.abc.Iterable[typing.Any], bool, NoneType]
+        type: collections.abc.Iterable[typing.Any] | bool | None
       default: None
       description: 'which axes should be snaked, either ``False`` (do not snake any
         axes),
@@ -1842,7 +1842,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -1869,7 +1869,7 @@ existing_plans:
         value: 1
       name: num
     - annotation:
-        type: typing.Union[__MOVABLE__, typing.Any]
+        type: __MOVABLE__ | typing.Any
       convert_device_names: true
       kind:
         name: VAR_POSITIONAL
@@ -1881,7 +1881,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       kind:
         name: KEYWORD_ONLY
@@ -1903,7 +1903,7 @@ existing_plans:
         value: 1
       name: detectors
     - annotation:
-        type: typing.Union[__MOVABLE__, typing.Any]
+        type: __MOVABLE__ | typing.Any
       convert_device_names: true
       description: "patterned like (``motor1, position_list1,``\n                ``motor2,\
         \ position_list2,``\n                ``motor3, position_list3,``\n       \
@@ -1945,7 +1945,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -1968,7 +1968,7 @@ existing_plans:
         value: 1
       name: detectors
     - annotation:
-        type: tuple[typing.Union[__MOVABLE__, typing.Any], list[typing.Any]]
+        type: tuple[__MOVABLE__ | typing.Any, list[typing.Any]]
       convert_device_names: true
       description: "For one dimension, ``motor, [point1, point2, ....]``.\nIn general:\n\
         \n.. code-block:: python\n\n    motor1, [point1, point2, ...],\n    motor2,\
@@ -1989,7 +1989,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -2140,7 +2140,7 @@ existing_plans:
     name: mv
     parameters:
     - annotation:
-        type: typing.Union[__MOVABLE__, typing.Any]
+        type: __MOVABLE__ | typing.Any
       convert_device_names: true
       description: device1, value1, device2, value2, ...
       kind:
@@ -2148,7 +2148,7 @@ existing_plans:
         value: 2
       name: args
     - annotation:
-        type: typing.Optional[collections.abc.Hashable]
+        type: collections.abc.Hashable | None
       default: None
       description: Used to mark these as a unit to be waited on.
       kind:
@@ -2156,7 +2156,7 @@ existing_plans:
         value: 3
       name: group
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: None
       description: Specify a maximum time that the move(s) can be waited for.
       kind:
@@ -2177,7 +2177,7 @@ existing_plans:
     name: mvr
     parameters:
     - annotation:
-        type: typing.Union[__MOVABLE__, typing.Any]
+        type: __MOVABLE__ | typing.Any
       convert_device_names: true
       description: device1, value1, device2, value2, ...
       kind:
@@ -2185,7 +2185,7 @@ existing_plans:
         value: 2
       name: args
     - annotation:
-        type: typing.Optional[collections.abc.Hashable]
+        type: collections.abc.Hashable | None
       default: None
       description: Used to mark these as a unit to be waited on.
       kind:
@@ -2193,7 +2193,7 @@ existing_plans:
         value: 3
       name: group
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: None
       description: Specify a maximum time that the move(s) can be waited for.
       kind:
@@ -2271,7 +2271,7 @@ existing_plans:
         value: 1
       name: take_pre_data
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: None
       description: 'If not None, the maximum time the ramp can run.
 
@@ -2282,7 +2282,7 @@ existing_plans:
         value: 1
       name: timeout
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: None
       description: 'If not None, take data no faster than this.  If None, take
 
@@ -2300,7 +2300,7 @@ existing_plans:
         value: 1
       name: period
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       kind:
         name: POSITIONAL_OR_KEYWORD
@@ -2380,7 +2380,7 @@ existing_plans:
         value: 1
       name: backstep
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: '0.8'
       description: threshold for going backward and rescanning a region, default is
         0.8
@@ -2389,7 +2389,7 @@ existing_plans:
         value: 1
       name: threshold
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -2412,14 +2412,14 @@ existing_plans:
         value: 1
       name: detectors
     - annotation:
-        type: typing.Union[__MOVABLE__, typing.Any]
+        type: __MOVABLE__ | typing.Any
       convert_device_names: true
       kind:
         name: VAR_POSITIONAL
         value: 2
       name: args
     - annotation:
-        type: typing.Union[collections.abc.Iterable[typing.Any], bool, NoneType]
+        type: collections.abc.Iterable[typing.Any] | bool | None
       default: None
       description: 'which axes should be snaked, either ``False`` (do not snake any
         axes),
@@ -2448,7 +2448,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -2474,7 +2474,7 @@ existing_plans:
         value: 1
       name: detectors
     - annotation:
-        type: typing.Union[__MOVABLE__, typing.Any]
+        type: __MOVABLE__ | typing.Any
       convert_device_names: true
       description: "patterned like (``motor1, position_list1,``\n                ``motor2,\
         \ position_list2,``\n                ``motor3, position_list3,``\n       \
@@ -2516,7 +2516,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -2539,7 +2539,7 @@ existing_plans:
         value: 1
       name: detectors
     - annotation:
-        type: typing.Union[__MOVABLE__, typing.Any]
+        type: __MOVABLE__ | typing.Any
       convert_device_names: true
       description: "For one dimension, ``motor, [point1, point2, ....]``.\nIn general:\n\
         \n.. code-block:: python\n\n    motor1, [point1, point2, ...],\n    motor2,\
@@ -2559,7 +2559,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -2619,7 +2619,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -2642,7 +2642,7 @@ existing_plans:
         value: 1
       name: detectors
     - annotation:
-        type: typing.Union[__MOVABLE__, typing.Any]
+        type: __MOVABLE__ | typing.Any
       convert_device_names: true
       description: "For one dimension, ``motor, start, stop``.\nIn general:\n\n..\
         \ code-block:: python\n\n    motor1, start1, stop1,\n    motor2, start2, start2,\n\
@@ -2669,7 +2669,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -2735,7 +2735,7 @@ existing_plans:
         value: 1
       name: nth
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: None
       description: 'Delta radius along the major axis of the ellipse. If None, it
 
@@ -2763,7 +2763,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -2830,7 +2830,7 @@ existing_plans:
         value: 1
       name: factor
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: None
       description: 'Delta radius along the major axis of the ellipse, if not specifed
 
@@ -2840,7 +2840,7 @@ existing_plans:
         value: 3
       name: dr_y
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: '0.0'
       description: Tilt angle in radians, default 0.0
       kind:
@@ -2858,7 +2858,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -2935,7 +2935,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -2962,7 +2962,7 @@ existing_plans:
         value: 1
       name: num
     - annotation:
-        type: typing.Union[__MOVABLE__, typing.Any]
+        type: __MOVABLE__ | typing.Any
       convert_device_names: true
       kind:
         name: VAR_POSITIONAL
@@ -2974,7 +2974,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       kind:
         name: KEYWORD_ONLY
@@ -2996,7 +2996,7 @@ existing_plans:
         value: 1
       name: detectors
     - annotation:
-        type: typing.Union[__MOVABLE__, typing.Any]
+        type: __MOVABLE__ | typing.Any
       convert_device_names: true
       description: "For one dimension, ``motor, start, stop``.\nIn general:\n\n..\
         \ code-block:: python\n\n    motor1, start1, stop1,\n    motor2, start2, stop2,\n\
@@ -3007,7 +3007,7 @@ existing_plans:
         value: 2
       name: args
     - annotation:
-        type: typing.Optional[int]
+        type: int | None
       default: None
       description: number of points
       kind:
@@ -3025,7 +3025,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -3062,7 +3062,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -3166,7 +3166,7 @@ existing_plans:
         value: 1
       name: nth
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: None
       description: 'Delta radius along the major axis of the ellipse. If None, defaults
         to
@@ -3177,7 +3177,7 @@ existing_plans:
         value: 3
       name: dr_y
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: '0.0'
       description: Tilt angle in radians, default 0.0
       kind:
@@ -3195,7 +3195,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -3276,7 +3276,7 @@ existing_plans:
         value: 1
       name: factor
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: None
       description: 'Delta radius along the major axis of the ellipse, if not specifed
 
@@ -3286,7 +3286,7 @@ existing_plans:
         value: 3
       name: dr_y
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: '0.0'
       description: Tilt angle in radians, default 0.0
       kind:
@@ -3304,7 +3304,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -3395,7 +3395,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -3481,7 +3481,7 @@ existing_plans:
         value: 1
       name: snake
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -3524,7 +3524,7 @@ existing_plans:
         value: 1
       name: step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:
@@ -3598,7 +3598,7 @@ existing_plans:
         value: 3
       name: per_step
     - annotation:
-        type: typing.Optional[dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       description: metadata
       kind:

--- a/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
+++ b/bluesky_queueserver/profile_collection_sim/existing_plans_and_devices.yaml
@@ -2061,7 +2061,7 @@ existing_plans:
     name: marked_up_count
     parameters:
     - annotation:
-        type: typing.List[typing.Any]
+        type: list[typing.Any]
       kind:
         name: POSITIONAL_OR_KEYWORD
         value: 1
@@ -2074,14 +2074,14 @@ existing_plans:
         value: 1
       name: num
     - annotation:
-        type: typing.Optional[float]
+        type: float | None
       default: None
       kind:
         name: POSITIONAL_OR_KEYWORD
         value: 1
       name: delay
     - annotation:
-        type: typing.Optional[typing.Dict[str, typing.Any]]
+        type: dict[str, typing.Any] | None
       default: None
       kind:
         name: POSITIONAL_OR_KEYWORD

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -704,4 +704,5 @@ API. By default, the API fails if called while the RE Manager is executing a pla
 
       Though a plan can be paused by sending the interrupt once (deferred pause) or twice (immediate pause),
       using :ref:`method_re_pause` API is a preferable way to pause a plan started via RE Manager or directly
-      using Jupyter Console.
+      using Jupyter Console. A short pause (0.1-0.2 s) may be needed between consecutive interrupt requests
+      in order for the kernel to process the requests and immediately pause the plan.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is a maintenance PR that includes fixes for the failing unit tests. 
Python 3.10 was removed from the test matrix.
Python 3.14 was added to the test matrix.

Minor change to the server code: after loading local modules into startup code, only the local modules themselves are removed from `sys.modules`. Other Python modules (such as `numpy`) are still left in `sys.modules`. This prevents modules from being loaded repeatedly within the same process, which is not allowed in Python 3.13 and above. The change should not affect functionality of the server.

<!--- Group the changes in the following sections: -->

### Added

Support for Python 3.14.

