### PR TITLE
Remove several deprecated CLI flags, and any associated references

### DIFF
--- a/src/bluesky_queueserver/manager/config.py
+++ b/src/bluesky_queueserver/manager/config.py
@@ -187,7 +187,6 @@ _key_mapping = {
     "zmq_publish_console": "network/zmq_publish_console",
     "redis_addr": "network/redis_addr",
     "redis_name_prefix": "network/redis_name_prefix",
-    "keep_re": "startup/keep_re",
     "ignore_invalid_plans": "startup/ignore_invalid_plans",
     "existing_plans_and_devices_path": "startup/existing_plans_and_devices_path",
     "user_group_permissions_path": "startup/user_group_permissions_path",
@@ -334,7 +333,7 @@ class Settings:
             value_default=default_zmq_info_address_for_server,
             value_ev=os.environ.get("QSERVER_ZMQ_INFO_ADDRESS_FOR_SERVER", None),
             value_config=self._get_value_from_config("zmq_info_addr"),
-            value_cli=self._args_existing("zmq_info_addr") or self._args_existing("zmq_publish_console_addr"),
+            value_cli=self._args_existing("zmq_info_addr"),
         )
 
         zmq_encoding = self._get_param(
@@ -371,12 +370,6 @@ class Settings:
         if not isinstance(redis_name_prefix, str):
             raise ConfigError(f"Redis name prefix must be a string: {redis_name_prefix!r}")
         self._settings["redis_name_prefix"] = redis_name_prefix
-
-        # Print warnings if deprecated parameter is used
-        if self._args_existing("keep_re"):
-            logger.warning("The CLI parameter '--keep-re' is deprecated and will be removed in future releases.")
-        if self._get_value_from_config("keep_re") is not None:
-            logger.warning("The config parameter 'keep_re' is deprecated and will be removed in future releases.")
 
         device_max_depth = self._get_param(
             value_default=self._args.device_max_depth,
@@ -855,12 +848,7 @@ class Settings:
         Returns 0MQ control address (string).
         """
         zmq_control_addr_cli = self._args.zmq_control_addr
-        if self._args.zmq_addr is not None:
-            logger.warning(
-                "Parameter --zmq-addr is deprecated and will be removed in future releases. "
-                "Use --zmq-control-addr instead."
-            )
-        zmq_control_addr_cli = zmq_control_addr_cli or self._args.zmq_addr
+        zmq_control_addr_cli = zmq_control_addr_cli
 
         zmq_control_addr = self._get_param(
             value_default=default_zmq_control_address_for_server,

--- a/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -59,8 +59,6 @@ properties:
       - type: object
         additionalProperties: false
         properties:
-          keep_re:
-            type: boolean
           device_max_depth:
             type: integer
           ignore_invalid_plans:
@@ -83,8 +81,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -96,8 +92,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -114,8 +108,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -132,8 +124,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -153,8 +143,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -171,8 +159,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -189,8 +175,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -207,8 +191,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -228,8 +210,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -249,8 +229,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -273,8 +251,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -294,8 +270,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:
@@ -315,8 +289,6 @@ properties:
           - type: object
             additionalProperties: false
             properties:
-              keep_re:
-                type: boolean
               device_max_depth:
                 type: integer
               ignore_invalid_plans:

--- a/src/bluesky_queueserver/manager/output_streaming.py
+++ b/src/bluesky_queueserver/manager/output_streaming.py
@@ -749,13 +749,6 @@ def qserver_console_monitor_cli():
         "if the address is not set using the parameter or the environment variable. Address format: "
         f"'tcp://127.0.0.1:60625' (default: {default_zmq_info_address}).",
     )
-    parser.add_argument(
-        "--zmq-subscribe-addr",
-        dest="zmq_subscribe_addr",
-        type=str,
-        default=None,
-        help="The parameter is deprecated and will be removed. Use --zmq-info-addr instead.",
-    )
 
     parser.add_argument(
         "--zmq-encoding",
@@ -770,11 +763,6 @@ def qserver_console_monitor_cli():
     args = parser.parse_args()
 
     zmq_info_addr = args.zmq_info_addr
-    if args.zmq_subscribe_addr is not None:
-        logger.warning(
-            "The parameter --zmq-subscribe-addr is deprecated and will be removed. Use --zmq-info-addr instead."
-        )
-    zmq_info_addr = zmq_info_addr or args.zmq_subscribe_addr
     zmq_info_addr = zmq_info_addr or os.environ.get("QSERVER_ZMQ_INFO_ADDRESS", None)
     zmq_info_addr = zmq_info_addr or default_zmq_info_address
 

--- a/src/bluesky_queueserver/manager/start_manager.py
+++ b/src/bluesky_queueserver/manager/start_manager.py
@@ -307,6 +307,7 @@ def start_manager():
         "must point to an existing file or directory (may be empty), otherwise the manager can not "
         "be started.",
     )
+
     parser.add_argument(
         "--zmq-control-addr",
         dest="zmq_control_addr",
@@ -317,13 +318,7 @@ def start_manager():
         "the parameter or the environment variable is not defined. Address format: 'tcp://*:60615' "
         f"(default: {default_zmq_control_address_for_server!r}).",
     )
-    parser.add_argument(
-        "--zmq-addr",
-        dest="zmq_addr",
-        type=str,
-        default=None,
-        help="The parameter is deprecated and will be removed in future releases. Use --zmq-control-addr instead.",
-    )
+
     parser.add_argument(
         "--zmq-encoding",
         dest="zmq_encoding",
@@ -464,15 +459,6 @@ def start_manager():
         type=str,
         default="qs_default",
         help="The prefix for the names of Redis keys used by RE Manager (default: %(default)s). ",
-    )
-
-    parser.add_argument(
-        "--keep-re",
-        dest="keep_re",
-        action="store_true",
-        help="The parameter is deprecated. The value is ignored by the Queue Server. Run Engine instance\n"
-        "must always be defined and configured in the startup code. The parameter will be removed\n"
-        "in future releases.",
     )
 
     group_ip_kernel = parser.add_argument_group(
@@ -630,14 +616,6 @@ def start_manager():
     )
 
     group_console_output.add_argument(
-        "--zmq-publish-console-addr",
-        dest="zmq_publish_console_addr",
-        type=str,
-        default=None,
-        help="The parameter is deprecated and will be removed in future releases. Use --zmq-info-addr instead.",
-    )
-
-    group_console_output.add_argument(
         "--zmq-publish-console",
         dest="zmq_publish_console",
         type=str,
@@ -686,12 +664,6 @@ def start_manager():
     args = parser.parse_args()
 
     settings = Settings(parser=parser, args=args)
-
-    if args.zmq_publish_console_addr is not None:
-        logger.warning(
-            "Parameter --zmq-publish-console-addr is deprecated and will be removed in future releases. "
-            "Use --zmq-info-addr instead."
-        )
 
     msg_queue = Queue()
     setup_console_output_redirection(msg_queue)

--- a/src/bluesky_queueserver/manager/tests/test_config.py
+++ b/src/bluesky_queueserver/manager/tests/test_config.py
@@ -166,7 +166,6 @@ network:
   redis_addr: localhost:6379
   redis_name_prefix: qs_test
 startup:
-  keep_re: true
   startup_dir: ~/.ipython/profile_collection/startup
   existing_plans_and_devices_path: ~/.ipython/profile_collection/startup
   user_group_permissions_path: ~/.ipython/profile_collection/startup
@@ -206,7 +205,6 @@ network:
 
 config_01b_success = """
 startup:
-  keep_re: true
   startup_dir: ~/.ipython/profile_collection/startup
   existing_plans_and_devices_path: ~/.ipython/profile_collection/startup
   user_group_permissions_path: ~/.ipython/profile_collection/startup
@@ -250,7 +248,6 @@ config_01_dict = {
         "redis_name_prefix": "qs_test",
     },
     "startup": {
-        "keep_re": True,
         "startup_dir": "~/.ipython/profile_collection/startup",
         "existing_plans_and_devices_path": "~/.ipython/profile_collection/startup",
         "user_group_permissions_path": "~/.ipython/profile_collection/startup",
@@ -280,10 +277,10 @@ config_01_dict = {
 
 config_02_success = """
 startup:
-  keep_re: true
+  device_max_depth: 0
 """
 
-config_02_dict = {"startup": {"keep_re": True}}
+config_02_dict = {"startup": {"device_max_depth": 0}}
 
 # 'startup_dir' and 'startup_script' are mutually exclusive
 config_03_fail = """

--- a/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -546,7 +546,6 @@ worker:
     - /c
     - /d/
 startup:
-  keep_re: false
   device_max_depth: 2
   ignore_invalid_plans: true
   startup_dir: {1}
@@ -635,7 +634,6 @@ def _get_cli_params_3(file_dir):
         "--user-group-permissions-reload=NEVER",
         "--redis-addr=localhost:6379",
         "--redis-name-prefix=qs_unit_tests3",
-        "--keep-re",
         "--device-max-depth=5",
         "--ignore-invalid-plans=ON",
         f"--use-ipython-kernel={use_ip_kernel}",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The CLI flags in question have been deprecated for at least several releases, and thus should be safe to remove

## Description
<!--- Describe your changes in detail -->
Removes deprecated CLI flags for keep-re and the zmq-info address port

## Motivation and Context
Cleaning up deprecated features reduces the size of the codebase and removes unnecessary conditionals and warning messages

## Summary of Changes for Release Notes
<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

### Removed
Deprecated CLI flags for setting the ZMQ info address and for keeping the RE.

## How Has This Been Tested?
Unit/Integration tests
