### PR TITLE
Support streaming RE waiting hook watcher updates over the info ZMQ topic

### DIFF
--- a/docs/source/features_and_config.rst
+++ b/docs/source/features_and_config.rst
@@ -169,6 +169,10 @@ Remote Monitoring of System Info
 --------------------------------
 
 In addition to streaming console output, RE Manager is streaming system information over the
-same 0MQ socket. Currently only RE Manager status is streamed. The convenience classes
+same 0MQ socket. RE Manager status is streamed under the ``status`` key. When a plan is running,
+device progress updates (RunEngine ``waiting_hook`` / watcher updates, such as motor position
+while moving) are also streamed on the same socket under the ``device_progress`` key. Progress
+streaming is enabled by default and can be disabled using the ``--zmq-publish-device-progress OFF``
+parameter of ``start-re-manager``. The convenience classes
 ``ReceiveSystemInfo`` and ``ReceiveSystemInfoAsync`` can be used to implement remote monitoring
 features in client applications. See :ref:`subscribing_to_system_info` for more details.

--- a/docs/source/features_and_config.rst
+++ b/docs/source/features_and_config.rst
@@ -172,7 +172,8 @@ In addition to streaming console output, RE Manager is streaming system informat
 same 0MQ socket. RE Manager status is streamed under the ``status`` key. When a plan is running,
 device progress updates (RunEngine ``waiting_hook`` / watcher updates, such as motor position
 while moving) are also streamed on the same socket under the ``device_progress`` key. Progress
-streaming is enabled by default and can be disabled using the ``--zmq-publish-device-progress OFF``
-parameter of ``start-re-manager``. The convenience classes
-``ReceiveSystemInfo`` and ``ReceiveSystemInfoAsync`` can be used to implement remote monitoring
-features in client applications. See :ref:`subscribing_to_system_info` for more details.
+streaming is disabled by default and can be enabled using the ``--zmq-stream-device-progress``
+parameter of ``start-re-manager`` or ``network/zmq_stream_device_progress`` parameter in the config
+file. The convenience classes ``ReceiveSystemInfo`` and ``ReceiveSystemInfoAsync`` can be used 
+to implement remote monitoring features in client applications. See :ref:`subscribing_to_system_info` 
+for more details.

--- a/docs/source/interacting_with_qs.rst
+++ b/docs/source/interacting_with_qs.rst
@@ -77,6 +77,17 @@ other information may be added to the stream in the future::
 
   {"time": <timestamp>, "msg": {"status": <status-info>}}
 
+While a plan is running, RE Manager also streams device progress updates (RunEngine
+``waiting_hook`` / watcher updates, e.g. the position of a moving motor) on the same socket
+under the ``device_progress`` key. Each update contains the device name, current/initial/target
+values, engineering units, precision, completion fraction, elapsed/remaining time, and a ``done``
+flag. A message with ``{"completed": true}`` is sent when the RunEngine finishes waiting::
+
+  {"time": <timestamp>, "msg": {"device_progress": <progress-info>}}
+
+Device progress streaming is enabled by default and can be disabled using the
+``--zmq-publish-device-progress OFF`` parameter of ``start-re-manager``.
+
 
 The ``ReceiveSystemInfo`` class can be used in synchronous or thread-based applications to
 receive the streamed messages:

--- a/docs/source/interacting_with_qs.rst
+++ b/docs/source/interacting_with_qs.rst
@@ -65,17 +65,34 @@ and starting and then stopping acquisition with ``start()`` and ``stop()`` metho
 Subscribing to Published System Info
 ------------------------------------
 
-In addition to streaming of console output, RE Manager is publishing status information to
-the same 0MQ PUB socket. The status information published using a different topic and can
-be easily separated from console output messages. The messages are published once per
-second or each time status is changed by RE Manager. Periodically published status can be
-used as 'heartbeat' to detect that RE Manager is running properly.
+In addition to streaming of console output, RE Manager is publishing additional information
+for system monitoring on the same 0MQ PUB socket using the topic ``QS_info``. The published
+information currently includes:
+
+- RE Manager status;
+- device progress updates.
+
+Additional information may be added to the stream in the future. Clients are responsible for 
+selecting messages using the key name. System info streaming is disabled by default and must 
+be enabled via the ``--zmq-publish-info`` CLI parameter or the ``network/zmq_publish_info`` 
+config file parameter, which enables streaming of default data such as status. 
+Streaming of optional data can be enabled independently using dedicated parameters.
+
+Status information
+++++++++++++++++++
+
+The information includes complete dictionary returned by ``status`` API. The messages are 
+published once per second or each time status is changed by RE Manager. Periodically published 
+status can be used as 'heartbeat' to detect that RE Manager is running properly.
 
 The message format used for streaming is similar to the message format for console output.
 The ``status`` key indicates that the message contains status information. Messages with
 other information may be added to the stream in the future::
 
   {"time": <timestamp>, "msg": {"status": <status-info>}}
+
+Device progress updates (optional)
+++++++++++++++++++++++++++++++++++
 
 While a plan is running, RE Manager also streams device progress updates (RunEngine
 ``waiting_hook`` / watcher updates, e.g. the position of a moving motor) on the same socket
@@ -85,8 +102,9 @@ flag. A message with ``{"completed": true}`` is sent when the RunEngine finishes
 
   {"time": <timestamp>, "msg": {"device_progress": <progress-info>}}
 
-Device progress streaming is enabled by default and can be disabled using the
-``--zmq-publish-device-progress OFF`` parameter of ``start-re-manager``.
+Device progress streaming is disabled by default and can be enabled using the
+``--zmq-stream-device-progress`` CLI parameter of ``start-re-manager`` or 
+``network/zmq_stream_device_progress`` parameter in the config file.
 
 
 The ``ReceiveSystemInfo`` class can be used in synchronous or thread-based applications to

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,9 +3,10 @@ authors = ["Dmitri Gavrilov <gavrilov.dvs@gmail.com>"]
 channels = ["conda-forge"]
 name = "bluesky-queueserver"
 platforms = ["linux-64"]
-version = "0.0.24"
+version = "0.0.25"
 
 [tasks]
+lint = "pre-commit run --all-files"
 
 [dependencies]
 python = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ ignore_missing_imports = true # Ignore missing stubs in imported modules
 # Don't collect the interactive directory which is intended for manual execution
 addopts = """
     --tb=native -vv 
-    --doctest-modules 
     --doctest-glob="*.rst" 
     --ignore src/bluesky_queueserver/profile_collection_sim
     """

--- a/src/bluesky_queueserver/__init__.py
+++ b/src/bluesky_queueserver/__init__.py
@@ -12,6 +12,8 @@ from .manager.gen_lists import gen_list_of_plans_and_devices  # noqa: E402, F401
 from .manager.output_streaming import (  # noqa: E402, F401
     ReceiveConsoleOutput,
     ReceiveConsoleOutputAsync,
+    ReceiveProgressInfo,
+    ReceiveProgressInfoAsync,
     ReceiveSystemInfo,
     ReceiveSystemInfoAsync,
 )

--- a/src/bluesky_queueserver/__init__.py
+++ b/src/bluesky_queueserver/__init__.py
@@ -12,8 +12,6 @@ from .manager.gen_lists import gen_list_of_plans_and_devices  # noqa: E402, F401
 from .manager.output_streaming import (  # noqa: E402, F401
     ReceiveConsoleOutput,
     ReceiveConsoleOutputAsync,
-    ReceiveProgressInfo,
-    ReceiveProgressInfoAsync,
     ReceiveSystemInfo,
     ReceiveSystemInfoAsync,
 )

--- a/src/bluesky_queueserver/manager/config.py
+++ b/src/bluesky_queueserver/manager/config.py
@@ -186,7 +186,7 @@ _key_mapping = {
     "zmq_encoding": "network/zmq_encoding",
     "zmq_publish_console": "network/zmq_publish_console",
     "zmq_publish_info": "network/zmq_publish_info",
-    "zmq_publish_progress": "network/zmq_publish_progress",
+    "zmq_publish_device_progress": "network/zmq_publish_device_progress",
     "redis_addr": "network/redis_addr",
     "redis_name_prefix": "network/redis_name_prefix",
     "ignore_invalid_plans": "startup/ignore_invalid_plans",
@@ -363,10 +363,10 @@ class Settings:
             value_cli=self._args_existing("zmq_publish_info"),
         )
 
-        self._settings["zmq_publish_progress"] = self._get_param_boolean(
-            value_default=args.zmq_publish_progress,
-            value_config=self._get_value_from_config("zmq_publish_progress"),
-            value_cli=self._args_existing("zmq_publish_progress"),
+        self._settings["zmq_publish_device_progress"] = self._get_param_boolean(
+            value_default=args.zmq_publish_device_progress,
+            value_config=self._get_value_from_config("zmq_publish_device_progress"),
+            value_cli=self._args_existing("zmq_publish_device_progress"),
         )
 
         redis_addr = self._get_param(

--- a/src/bluesky_queueserver/manager/config.py
+++ b/src/bluesky_queueserver/manager/config.py
@@ -207,6 +207,7 @@ _key_mapping = {
     "ipython_hb_port": "worker/ipython_hb_port",
     "ipython_control_port": "worker/ipython_control_port",
     "permitted_re_metadata_keys": "worker/permitted_re_metadata_keys",
+    "progress_streaming": "worker/progress_streaming",
     "print_console_output": "operation/print_console_output",
     "console_logging_level": "operation/console_logging_level",
     "update_existing_plans_devices": "operation/update_existing_plans_and_devices",
@@ -485,6 +486,12 @@ class Settings:
             value_config=self._get_value_from_config("permitted_re_metadata_keys"),
             value_ev=os.environ.get("QSERVER_PERMITTED_RE_METADATA_KEYS", "/").split(":"),
             value_cli=self._args_existing("permitted_re_metadata_keys"),
+        )
+
+        self._settings["progress_streaming"] = self._get_param_boolean(
+            value_default=args.progress_streaming,
+            value_config=self._get_value_from_config("progress_streaming"),
+            value_cli=self._args_existing("progress_streaming"),
         )
 
         existing_plans_and_devices_path = self._get_param(

--- a/src/bluesky_queueserver/manager/config.py
+++ b/src/bluesky_queueserver/manager/config.py
@@ -186,7 +186,7 @@ _key_mapping = {
     "zmq_encoding": "network/zmq_encoding",
     "zmq_publish_console": "network/zmq_publish_console",
     "zmq_publish_info": "network/zmq_publish_info",
-    "zmq_publish_device_progress": "network/zmq_publish_device_progress",
+    "zmq_stream_device_progress": "network/zmq_stream_device_progress",
     "redis_addr": "network/redis_addr",
     "redis_name_prefix": "network/redis_name_prefix",
     "ignore_invalid_plans": "startup/ignore_invalid_plans",
@@ -363,10 +363,10 @@ class Settings:
             value_cli=self._args_existing("zmq_publish_info"),
         )
 
-        self._settings["zmq_publish_device_progress"] = self._get_param_boolean(
-            value_default=args.zmq_publish_device_progress,
-            value_config=self._get_value_from_config("zmq_publish_device_progress"),
-            value_cli=self._args_existing("zmq_publish_device_progress"),
+        self._settings["zmq_stream_device_progress"] = self._get_param_boolean(
+            value_default=args.zmq_stream_device_progress,
+            value_config=self._get_value_from_config("zmq_stream_device_progress"),
+            value_cli=self._args_existing("zmq_stream_device_progress"),
         )
 
         redis_addr = self._get_param(

--- a/src/bluesky_queueserver/manager/config.py
+++ b/src/bluesky_queueserver/manager/config.py
@@ -185,6 +185,8 @@ _key_mapping = {
     "zmq_info_addr": "network/zmq_info_addr",
     "zmq_encoding": "network/zmq_encoding",
     "zmq_publish_console": "network/zmq_publish_console",
+    "zmq_publish_info": "network/zmq_publish_info",
+    "zmq_publish_progress": "network/zmq_publish_progress",
     "redis_addr": "network/redis_addr",
     "redis_name_prefix": "network/redis_name_prefix",
     "ignore_invalid_plans": "startup/ignore_invalid_plans",
@@ -207,7 +209,6 @@ _key_mapping = {
     "ipython_hb_port": "worker/ipython_hb_port",
     "ipython_control_port": "worker/ipython_control_port",
     "permitted_re_metadata_keys": "worker/permitted_re_metadata_keys",
-    "progress_streaming": "worker/progress_streaming",
     "print_console_output": "operation/print_console_output",
     "console_logging_level": "operation/console_logging_level",
     "update_existing_plans_devices": "operation/update_existing_plans_and_devices",
@@ -356,6 +357,18 @@ class Settings:
             value_cli=self._args_existing("zmq_publish_console"),
         )
 
+        self._settings["zmq_publish_info"] = self._get_param_boolean(
+            value_default=args.zmq_publish_info,
+            value_config=self._get_value_from_config("zmq_publish_info"),
+            value_cli=self._args_existing("zmq_publish_info"),
+        )
+
+        self._settings["zmq_publish_progress"] = self._get_param_boolean(
+            value_default=args.zmq_publish_progress,
+            value_config=self._get_value_from_config("zmq_publish_progress"),
+            value_cli=self._args_existing("zmq_publish_progress"),
+        )
+
         redis_addr = self._get_param(
             value_default=self._args.redis_addr,
             value_config=self._get_value_from_config("redis_addr"),
@@ -486,12 +499,6 @@ class Settings:
             value_config=self._get_value_from_config("permitted_re_metadata_keys"),
             value_ev=os.environ.get("QSERVER_PERMITTED_RE_METADATA_KEYS", "/").split(":"),
             value_cli=self._args_existing("permitted_re_metadata_keys"),
-        )
-
-        self._settings["progress_streaming"] = self._get_param_boolean(
-            value_default=args.progress_streaming,
-            value_config=self._get_value_from_config("progress_streaming"),
-            value_cli=self._args_existing("progress_streaming"),
         )
 
         existing_plans_and_devices_path = self._get_param(

--- a/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -23,7 +23,7 @@ properties:
         type: boolean
       zmq_publish_info:
         type: boolean
-      zmq_publish_progress:
+      zmq_publish_device_progress:
         type: boolean
       redis_addr:
         type: string

--- a/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -23,7 +23,7 @@ properties:
         type: boolean
       zmq_publish_info:
         type: boolean
-      zmq_publish_device_progress:
+      zmq_stream_device_progress:
         type: boolean
       redis_addr:
         type: string

--- a/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -54,6 +54,8 @@ properties:
         uniqueItems: true
         items:
           type: string
+      progress_streaming:
+        type: boolean
   startup:
     oneOf:
       - type: object

--- a/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -21,6 +21,10 @@ properties:
         type: string
       zmq_publish_console:
         type: boolean
+      zmq_publish_info:
+        type: boolean
+      zmq_publish_progress:
+        type: boolean
       redis_addr:
         type: string
       redis_name_prefix:
@@ -54,8 +58,6 @@ properties:
         uniqueItems: true
         items:
           type: string
-      progress_streaming:
-        type: boolean
   startup:
     oneOf:
       - type: object

--- a/src/bluesky_queueserver/manager/output_streaming.py
+++ b/src/bluesky_queueserver/manager/output_streaming.py
@@ -115,29 +115,8 @@ def push_info_to_msg_queue(*, key, msg, msg_queue):
     msg_queue.put(msg)
 
 
-def push_progress_to_msg_queue(*, msg, msg_queue):
-    """
-    Format a progress message and put it into the message queue. The message is published
-    to the ``progress`` channel on the ``QS_Progress`` 0MQ topic.
-
-    Parameters
-    ----------
-    msg : dict
-        The progress payload dictionary.
-    msg_queue : multiprocessing.Queue
-        Reference to the queue used for collecting messages.
-
-    Returns
-    -------
-    None
-    """
-    msg = {"channel": "progress", "time": ttime.time(), "msg": msg}
-    msg_queue.put(msg)
-
-
 _default_zmq_console_topic = "QS_Console"
 _default_zmq_info_topic = "QS_Info"
-_default_zmq_progress_topic = "QS_Progress"
 
 
 class PublishZMQStreamOutput:
@@ -160,8 +139,6 @@ class PublishZMQStreamOutput:
         Enable/disable publishing console output to 0MQ socket (``QS_Console`` topic).
     zmq_publish_info : boolean
         Enable/disable publishing info/status messages to 0MQ socket (``QS_Info`` topic).
-    zmq_publish_progress : boolean
-        Enable/disable publishing progress messages to 0MQ socket (``QS_Progress`` topic).
     zmq_publish_addr : str, None
         Address of 0MQ PUB socket for the publishing server. If ``None``, then
         the default address ``tcp://*:60625`` is used.
@@ -171,8 +148,6 @@ class PublishZMQStreamOutput:
         Name of the 0MQ topic where the console messages are published.
     zmq_topic_info : str
         Name of the 0MQ topic where the system information messages are published.
-    zmq_topic_progress : str
-        Name of the 0MQ topic where the progress messages are published.
     name : str
         Name of the thread where the messages are published.
     """
@@ -184,12 +159,10 @@ class PublishZMQStreamOutput:
         console_output_on=True,
         zmq_publish_console=True,
         zmq_publish_info=True,
-        zmq_publish_progress=True,
         zmq_publish_addr=None,
         encoding="json",
         zmq_topic_console=_default_zmq_console_topic,
         zmq_topic_info=_default_zmq_info_topic,
-        zmq_topic_progress=_default_zmq_progress_topic,
         name="RE Console Output Publisher",
     ):
         self._thread_running = False  # Set True to exit the thread
@@ -200,7 +173,6 @@ class PublishZMQStreamOutput:
         self._console_output_on = console_output_on
         self._zmq_publish_console = zmq_publish_console
         self._zmq_publish_info = zmq_publish_info
-        self._zmq_publish_progress = zmq_publish_progress
 
         self._encoding = process_zmq_encoding_name(encoding)
 
@@ -209,7 +181,6 @@ class PublishZMQStreamOutput:
         self._zmq_publish_addr = zmq_publish_addr
         self._zmq_topic_console = zmq_topic_console
         self._zmq_topic_info = zmq_topic_info
-        self._zmq_topic_progress = zmq_topic_progress
 
         zmq_publish_on = zmq_publish_console or zmq_publish_info or zmq_publish_progress
 
@@ -281,8 +252,6 @@ class PublishZMQStreamOutput:
                 topic = self._zmq_topic_console
             elif channel == "info" and self._zmq_publish_info:
                 topic = self._zmq_topic_info
-            elif channel == "progress" and self._zmq_publish_progress:
-                topic = self._zmq_topic_progress
             else:
                 return
             payload = {k: payload[k] for k in ("time", "msg")}
@@ -472,26 +441,8 @@ class ReceiveSystemInfo(_ReceiveZMQStreamOutput):
         )
 
 
-class ReceiveProgressInfo(_ReceiveZMQStreamOutput):
-    """
-    The class defaults are set to receive 0MQ messages with progress information
-    (RunEngine waiting/watcher updates).
-    """
-
-    def __init__(
-        self, *, zmq_subscribe_addr=None, encoding="json", zmq_topic=_default_zmq_progress_topic, timeout=1000
-    ):
-        super().__init__(
-            zmq_subscribe_addr=zmq_subscribe_addr,
-            encoding=encoding,
-            zmq_topic=zmq_topic,
-            timeout=timeout,
-        )
-
-
 ReceiveConsoleOutput.__doc__ += _ReceiveZMQStreamOutput.__doc__
 ReceiveSystemInfo.__doc__ += _ReceiveZMQStreamOutput.__doc__
-ReceiveProgressInfo.__doc__ += _ReceiveZMQStreamOutput.__doc__
 
 
 class _ReceiveZMQStreamOutputAsync:
@@ -783,26 +734,8 @@ class ReceiveSystemInfoAsync(_ReceiveZMQStreamOutputAsync):
         )
 
 
-class ReceiveProgressInfoAsync(_ReceiveZMQStreamOutputAsync):
-    """
-    The class defaults are set to receive 0MQ messages with progress information
-    (RunEngine waiting/watcher updates).
-    """
-
-    def __init__(
-        self, *, zmq_subscribe_addr=None, encoding="json", zmq_topic=_default_zmq_progress_topic, timeout=1000
-    ):
-        super().__init__(
-            zmq_subscribe_addr=zmq_subscribe_addr,
-            encoding=encoding,
-            zmq_topic=zmq_topic,
-            timeout=timeout,
-        )
-
-
 ReceiveConsoleOutputAsync.__doc__ += _ReceiveZMQStreamOutputAsync.__doc__
 ReceiveSystemInfoAsync.__doc__ += _ReceiveZMQStreamOutputAsync.__doc__
-ReceiveProgressInfoAsync.__doc__ += _ReceiveZMQStreamOutputAsync.__doc__
 
 
 def qserver_console_monitor_cli():

--- a/src/bluesky_queueserver/manager/output_streaming.py
+++ b/src/bluesky_queueserver/manager/output_streaming.py
@@ -828,9 +828,10 @@ def qserver_console_monitor_cli():
         dest="zmq_info_addr",
         type=str,
         default=None,
-        help="The address of RE Manager socket used for publishing console output. The parameter overrides "
-        "the address set using QSERVER_ZMQ_INFO_ADDRESS environment variable. The default value is used "
-        "if the address is not set using the parameter or the environment variable. Address format: "
+        help="The address of RE Manager socket used for publishing console output, status info, and "
+        "progress updates. The parameter overrides the address set using QSERVER_ZMQ_INFO_ADDRESS "
+        "environment variable. The default value is used if the address is not set using the parameter "
+        "or the environment variable. Address format: "
         f"'tcp://127.0.0.1:60625' (default: {default_zmq_info_address}).",
     )
 

--- a/src/bluesky_queueserver/manager/output_streaming.py
+++ b/src/bluesky_queueserver/manager/output_streaming.py
@@ -156,8 +156,12 @@ class PublishZMQStreamOutput:
         The messages added to the queue will be automatically published to 0MQ socket.
     console_output_on : boolean
         Enable/disable printing console output to the terminal
-    zmq_publish_on : boolean
-        Enable/disable publishing console output to 0MQ socket
+    zmq_publish_console : boolean
+        Enable/disable publishing console output to 0MQ socket (``QS_Console`` topic).
+    zmq_publish_info : boolean
+        Enable/disable publishing info/status messages to 0MQ socket (``QS_Info`` topic).
+    zmq_publish_progress : boolean
+        Enable/disable publishing progress messages to 0MQ socket (``QS_Progress`` topic).
     zmq_publish_addr : str, None
         Address of 0MQ PUB socket for the publishing server. If ``None``, then
         the default address ``tcp://*:60625`` is used.
@@ -167,6 +171,8 @@ class PublishZMQStreamOutput:
         Name of the 0MQ topic where the console messages are published.
     zmq_topic_info : str
         Name of the 0MQ topic where the system information messages are published.
+    zmq_topic_progress : str
+        Name of the 0MQ topic where the progress messages are published.
     name : str
         Name of the thread where the messages are published.
     """
@@ -176,7 +182,9 @@ class PublishZMQStreamOutput:
         *,
         msg_queue,
         console_output_on=True,
-        zmq_publish_on=True,
+        zmq_publish_console=True,
+        zmq_publish_info=True,
+        zmq_publish_progress=True,
         zmq_publish_addr=None,
         encoding="json",
         zmq_topic_console=_default_zmq_console_topic,
@@ -190,7 +198,9 @@ class PublishZMQStreamOutput:
         self._polling_timeout = 0.1  # in sec.
 
         self._console_output_on = console_output_on
-        self._zmq_publish_on = zmq_publish_on
+        self._zmq_publish_console = zmq_publish_console
+        self._zmq_publish_info = zmq_publish_info
+        self._zmq_publish_progress = zmq_publish_progress
 
         self._encoding = process_zmq_encoding_name(encoding)
 
@@ -201,22 +211,25 @@ class PublishZMQStreamOutput:
         self._zmq_topic_info = zmq_topic_info
         self._zmq_topic_progress = zmq_topic_progress
 
+        zmq_publish_on = zmq_publish_console or zmq_publish_info or zmq_publish_progress
+
         self._context = None
         self._socket = None
-        if self._zmq_publish_on:
+
+        if zmq_publish_on:
             try:
                 self._context = zmq.Context()
                 self._socket = self._context.socket(zmq.PUB)
                 self._socket.bind(self._zmq_publish_addr)
             except Exception as ex:
                 logger.error(
-                    "Failed to create 0MQ socket at %s. Console output will not be published. Exception: %s",
+                    "Failed to create 0MQ socket at %s. Output will not be published. Exception: %s",
                     self._zmq_publish_addr,
                     ex,
                 )
 
-        if self._socket and self._zmq_publish_on:
-            logging.info("Publishing console output to 0MQ socket at %s", zmq_publish_addr)
+        if self._socket and zmq_publish_on:
+            logging.info("Publishing output to 0MQ socket at %s", zmq_publish_addr)
 
     def start(self):
         """
@@ -263,15 +276,14 @@ class PublishZMQStreamOutput:
             sys.__stdout__.write(payload["msg"])
             sys.__stdout__.flush()
 
-        if self._zmq_publish_on and self._socket:
-            if channel == "console":
+        if self._socket:
+            if channel == "console" and self._zmq_publish_console:
                 topic = self._zmq_topic_console
-            elif channel == "info":
+            elif channel == "info" and self._zmq_publish_info:
                 topic = self._zmq_topic_info
-            elif channel == "progress":
+            elif channel == "progress" and self._zmq_publish_progress:
                 topic = self._zmq_topic_progress
             else:
-                logger.error("Failed to publish the message: unsupported 0MQ channel %s.", channel)
                 return
             payload = {k: payload[k] for k in ("time", "msg")}
             if self._encoding == ZMQEncoding.JSON:

--- a/src/bluesky_queueserver/manager/output_streaming.py
+++ b/src/bluesky_queueserver/manager/output_streaming.py
@@ -115,8 +115,29 @@ def push_info_to_msg_queue(*, key, msg, msg_queue):
     msg_queue.put(msg)
 
 
+def push_progress_to_msg_queue(*, msg, msg_queue):
+    """
+    Format a progress message and put it into the message queue. The message is published
+    to the ``progress`` channel on the ``QS_Progress`` 0MQ topic.
+
+    Parameters
+    ----------
+    msg : dict
+        The progress payload dictionary.
+    msg_queue : multiprocessing.Queue
+        Reference to the queue used for collecting messages.
+
+    Returns
+    -------
+    None
+    """
+    msg = {"channel": "progress", "time": ttime.time(), "msg": msg}
+    msg_queue.put(msg)
+
+
 _default_zmq_console_topic = "QS_Console"
 _default_zmq_info_topic = "QS_Info"
+_default_zmq_progress_topic = "QS_Progress"
 
 
 class PublishZMQStreamOutput:
@@ -160,6 +181,7 @@ class PublishZMQStreamOutput:
         encoding="json",
         zmq_topic_console=_default_zmq_console_topic,
         zmq_topic_info=_default_zmq_info_topic,
+        zmq_topic_progress=_default_zmq_progress_topic,
         name="RE Console Output Publisher",
     ):
         self._thread_running = False  # Set True to exit the thread
@@ -177,6 +199,7 @@ class PublishZMQStreamOutput:
         self._zmq_publish_addr = zmq_publish_addr
         self._zmq_topic_console = zmq_topic_console
         self._zmq_topic_info = zmq_topic_info
+        self._zmq_topic_progress = zmq_topic_progress
 
         self._context = None
         self._socket = None
@@ -245,8 +268,11 @@ class PublishZMQStreamOutput:
                 topic = self._zmq_topic_console
             elif channel == "info":
                 topic = self._zmq_topic_info
+            elif channel == "progress":
+                topic = self._zmq_topic_progress
             else:
-                logger.error("Failed to publish the message: unsupported 0MQ channel %s.")
+                logger.error("Failed to publish the message: unsupported 0MQ channel %s.", channel)
+                return
             payload = {k: payload[k] for k in ("time", "msg")}
             if self._encoding == ZMQEncoding.JSON:
                 payload_json = json.dumps(payload)
@@ -434,8 +460,26 @@ class ReceiveSystemInfo(_ReceiveZMQStreamOutput):
         )
 
 
+class ReceiveProgressInfo(_ReceiveZMQStreamOutput):
+    """
+    The class defaults are set to receive 0MQ messages with progress information
+    (RunEngine waiting/watcher updates).
+    """
+
+    def __init__(
+        self, *, zmq_subscribe_addr=None, encoding="json", zmq_topic=_default_zmq_progress_topic, timeout=1000
+    ):
+        super().__init__(
+            zmq_subscribe_addr=zmq_subscribe_addr,
+            encoding=encoding,
+            zmq_topic=zmq_topic,
+            timeout=timeout,
+        )
+
+
 ReceiveConsoleOutput.__doc__ += _ReceiveZMQStreamOutput.__doc__
 ReceiveSystemInfo.__doc__ += _ReceiveZMQStreamOutput.__doc__
+ReceiveProgressInfo.__doc__ += _ReceiveZMQStreamOutput.__doc__
 
 
 class _ReceiveZMQStreamOutputAsync:
@@ -727,8 +771,26 @@ class ReceiveSystemInfoAsync(_ReceiveZMQStreamOutputAsync):
         )
 
 
+class ReceiveProgressInfoAsync(_ReceiveZMQStreamOutputAsync):
+    """
+    The class defaults are set to receive 0MQ messages with progress information
+    (RunEngine waiting/watcher updates).
+    """
+
+    def __init__(
+        self, *, zmq_subscribe_addr=None, encoding="json", zmq_topic=_default_zmq_progress_topic, timeout=1000
+    ):
+        super().__init__(
+            zmq_subscribe_addr=zmq_subscribe_addr,
+            encoding=encoding,
+            zmq_topic=zmq_topic,
+            timeout=timeout,
+        )
+
+
 ReceiveConsoleOutputAsync.__doc__ += _ReceiveZMQStreamOutputAsync.__doc__
 ReceiveSystemInfoAsync.__doc__ += _ReceiveZMQStreamOutputAsync.__doc__
+ReceiveProgressInfoAsync.__doc__ += _ReceiveZMQStreamOutputAsync.__doc__
 
 
 def qserver_console_monitor_cli():

--- a/src/bluesky_queueserver/manager/output_streaming.py
+++ b/src/bluesky_queueserver/manager/output_streaming.py
@@ -182,7 +182,7 @@ class PublishZMQStreamOutput:
         self._zmq_topic_console = zmq_topic_console
         self._zmq_topic_info = zmq_topic_info
 
-        zmq_publish_on = zmq_publish_console or zmq_publish_info or zmq_publish_progress
+        zmq_publish_on = zmq_publish_console or zmq_publish_info
 
         self._context = None
         self._socket = None

--- a/src/bluesky_queueserver/manager/plan_monitoring.py
+++ b/src/bluesky_queueserver/manager/plan_monitoring.py
@@ -1,8 +1,11 @@
 import copy
 import logging
 import threading
+import time as ttime
 
 from bluesky.callbacks.core import CallbackBase
+
+from .output_streaming import push_progress_to_msg_queue
 
 logger = logging.getLogger(__name__)
 
@@ -205,3 +208,140 @@ class CallbackRegisterRun(CallbackBase):
             logger.info("Run was closed: %r", uid)
         except Exception as ex:
             logger.exception("RE Manager: Failed to label run as closed: %s", ex)
+
+
+def _to_json_safe(value):
+    """
+    Coerce a value to a JSON-serializable type. Returns ``None`` for values
+    that cannot be represented as a number or string.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float, bool)):
+        return value
+    if isinstance(value, str):
+        return value
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+class WatcherStreamManager:
+    """
+    RunEngine ``waiting_hook``-compatible class. Instead of rendering progress bars,
+    it serializes watcher updates and pushes them to ``msg_queue`` on the ``"progress"``
+    channel (``QS_Progress`` 0MQ topic) so they are published to 0MQ / websocket subscribers.
+
+    The RunEngine calls instances of this class with a set of Status objects each time
+    it enters a wait, and with ``None`` when the wait completes. For each status object
+    that supports ``watch()``, a callback is registered that streams position/progress
+    updates.
+
+    Parameters
+    ----------
+    msg_queue : multiprocessing.Queue
+        Reference to the shared message queue used for publishing messages.
+    min_update_period : float
+        Minimum interval in seconds between published updates for a single status
+        object. The final update (when the status is done) is always sent regardless
+        of throttling. Default: ``0.2``.
+    """
+
+    def __init__(self, *, msg_queue, min_update_period=0.2):
+        self._msg_queue = msg_queue
+        self._min_update_period = min_update_period
+        # Track status objects we have already subscribed to, keyed by id(status)
+        self._watched = set()
+        self._last_sent = {}  # id(status) -> timestamp of last sent update
+        self._status_counter = 0  # Counter for generating labels when name is None
+
+    def __call__(self, status_objs_or_none):
+        """
+        Called by the RunEngine with a set of Status objects or ``None``.
+        """
+        if status_objs_or_none is None:
+            # Waiting is complete — send a completion message and reset state
+            self._send_completed()
+            self._watched.clear()
+            self._last_sent.clear()
+            self._status_counter = 0
+            return
+
+        for st in status_objs_or_none:
+            st_id = id(st)
+            if st_id in self._watched:
+                continue
+            self._watched.add(st_id)
+            if not hasattr(st, "watch") or getattr(st, "done", False):
+                continue
+            try:
+                self._status_counter += 1
+                label = self._status_counter
+                st.watch(self._make_callback(st, label))
+            except Exception:
+                logger.debug("Status object does not support watch(): %r", st, exc_info=True)
+
+    def _make_callback(self, status_obj, label):
+        """
+        Create a watch callback bound to a specific status object.
+        """
+        st_id = id(status_obj)
+
+        def _cb(
+            *,
+            name=None,
+            current=None,
+            initial=None,
+            target=None,
+            unit=None,
+            precision=None,
+            fraction=None,
+            time_elapsed=None,
+            time_remaining=None,
+            **kwargs,
+        ):
+            now = ttime.time()
+            done = getattr(status_obj, "done", False)
+
+            # Throttle: skip non-final updates that arrive too quickly
+            last = self._last_sent.get(st_id, 0)
+            if not done and (now - last) < self._min_update_period:
+                return
+            self._last_sent[st_id] = now
+
+            if done:
+                # Clean up tracking for this status
+                self._last_sent.pop(st_id, None)
+
+            display_name = name if name is not None else f"Status {label}"
+
+            payload = {
+                "name": display_name,
+                "current": _to_json_safe(current),
+                "initial": _to_json_safe(initial),
+                "target": _to_json_safe(target),
+                "unit": unit,
+                "precision": precision,
+                "fraction": fraction,
+                "time_elapsed": time_elapsed,
+                "time_remaining": time_remaining,
+                "done": bool(done),
+            }
+
+            try:
+                push_progress_to_msg_queue(msg=payload, msg_queue=self._msg_queue)
+            except Exception:
+                logger.debug("Failed to push progress update to msg_queue", exc_info=True)
+
+        return _cb
+
+    def _send_completed(self):
+        """
+        Send a message indicating that the waiting period is complete (all statuses done).
+        """
+        payload = {"completed": True}
+        try:
+            push_progress_to_msg_queue(msg=payload, msg_queue=self._msg_queue)
+        except Exception:
+            logger.debug("Failed to push progress completion to msg_queue", exc_info=True)

--- a/src/bluesky_queueserver/manager/plan_monitoring.py
+++ b/src/bluesky_queueserver/manager/plan_monitoring.py
@@ -5,9 +5,11 @@ import time as ttime
 
 from bluesky.callbacks.core import CallbackBase
 
-from .output_streaming import push_progress_to_msg_queue
+from .output_streaming import push_info_to_msg_queue
 
 logger = logging.getLogger(__name__)
+
+_device_progress_key = "device_progress"
 
 
 class RunList:
@@ -230,8 +232,9 @@ def _to_json_safe(value):
 class WatcherStreamManager:
     """
     RunEngine ``waiting_hook``-compatible class. Instead of rendering progress bars,
-    it serializes watcher updates and pushes them to ``msg_queue`` on the ``"progress"``
-    channel (``QS_Progress`` 0MQ topic) so they are published to 0MQ / websocket subscribers.
+    it serializes watcher updates and pushes them to ``msg_queue`` on the ``"info"``
+    channel (``QS_Info`` 0MQ topic) under the ``"device_progress"`` key so they are
+    published to 0MQ / websocket subscribers.
 
     The RunEngine calls instances of this class with a set of Status objects each time
     it enters a wait, and with ``None`` when the wait completes. For each status object
@@ -340,7 +343,7 @@ class WatcherStreamManager:
             }
 
             try:
-                push_progress_to_msg_queue(msg=payload, msg_queue=self._msg_queue)
+                push_info_to_msg_queue(key=_device_progress_key, msg=payload, msg_queue=self._msg_queue)
             except Exception:
                 logger.debug("Failed to push progress update to msg_queue", exc_info=True)
 
@@ -352,6 +355,6 @@ class WatcherStreamManager:
         """
         payload = {"completed": True}
         try:
-            push_progress_to_msg_queue(msg=payload, msg_queue=self._msg_queue)
+            push_info_to_msg_queue(key=_device_progress_key, msg=payload, msg_queue=self._msg_queue)
         except Exception:
             logger.debug("Failed to push progress completion to msg_queue", exc_info=True)

--- a/src/bluesky_queueserver/manager/plan_monitoring.py
+++ b/src/bluesky_queueserver/manager/plan_monitoring.py
@@ -304,13 +304,23 @@ class WatcherStreamManager:
             now = ttime.time()
             done = getattr(status_obj, "done", False)
 
+            # The final update (the status reached its target) must never be throttled,
+            # otherwise progress bars may freeze just short of 100%. ophyd status objects
+            # emit their last watcher update with ``current == target`` *before* ``done``
+            # is set (watchers are cleared once the status settles), and ophyd reports
+            # ``fraction`` as the fraction *remaining* (0 when the target is reached).
+            at_target = (fraction is not None and fraction <= 0) or (
+                current is not None and target is not None and current == target
+            )
+            is_final = bool(done) or at_target
+
             # Throttle: skip non-final updates that arrive too quickly
             last = self._last_sent.get(st_id, 0)
-            if not done and (now - last) < self._min_update_period:
+            if not is_final and (now - last) < self._min_update_period:
                 return
             self._last_sent[st_id] = now
 
-            if done:
+            if is_final:
                 # Clean up tracking for this status
                 self._last_sent.pop(st_id, None)
 
@@ -326,7 +336,7 @@ class WatcherStreamManager:
                 "fraction": fraction,
                 "time_elapsed": time_elapsed,
                 "time_remaining": time_remaining,
-                "done": bool(done),
+                "done": is_final,
             }
 
             try:

--- a/src/bluesky_queueserver/manager/plan_monitoring.py
+++ b/src/bluesky_queueserver/manager/plan_monitoring.py
@@ -259,6 +259,19 @@ class WatcherStreamManager:
         self._last_sent = {}  # id(status) -> timestamp of last sent update
         self._status_counter = 0  # Counter for generating labels when name is None
 
+        # Reference to the callback that was already set at the Run Engine, (e.x.
+        # the callback that prints the progress bar in the terminal). The existing
+        # callback is replaced by the reference of WatcherStreamManager class.
+        self._waiting_hook = None
+
+    @property
+    def waiting_hook(self):
+        return self._waiting_hook
+
+    @waiting_hook.setter
+    def waiting_hook(self, v):
+        self._waiting_hook = v or None
+
     def __call__(self, status_objs_or_none):
         """
         Called by the RunEngine with a set of Status objects or ``None``.
@@ -269,21 +282,24 @@ class WatcherStreamManager:
             self._watched.clear()
             self._last_sent.clear()
             self._status_counter = 0
-            return
 
-        for st in status_objs_or_none:
-            st_id = id(st)
-            if st_id in self._watched:
-                continue
-            self._watched.add(st_id)
-            if not hasattr(st, "watch") or getattr(st, "done", False):
-                continue
-            try:
-                self._status_counter += 1
-                label = self._status_counter
-                st.watch(self._make_callback(st, label))
-            except Exception:
-                logger.debug("Status object does not support watch(): %r", st, exc_info=True)
+        else:
+            for st in status_objs_or_none:
+                st_id = id(st)
+                if st_id in self._watched:
+                    continue
+                self._watched.add(st_id)
+                if not hasattr(st, "watch") or getattr(st, "done", False):
+                    continue
+                try:
+                    self._status_counter += 1
+                    label = self._status_counter
+                    st.watch(self._make_callback(st, label))
+                except Exception:
+                    logger.debug("Status object does not support watch(): %r", st, exc_info=True)
+
+        if self.waiting_hook:
+            self.waiting_hook(status_objs_or_none)
 
     def _make_callback(self, status_obj, label):
         """

--- a/src/bluesky_queueserver/manager/start_manager.py
+++ b/src/bluesky_queueserver/manager/start_manager.py
@@ -633,13 +633,13 @@ def start_manager():
     )
 
     group_console_output.add_argument(
-        "--zmq-publish-progress",
-        dest="zmq_publish_progress",
+        "--zmq-publish-device-progress",
+        dest="zmq_publish_device_progress",
         type=str,
         choices=["ON", "OFF"],
         default="ON",
-        help="Enable (ON) or disable (OFF) publishing of RunEngine waiting/progress updates "
-        "to 0MQ (default: %(default)s).",
+        help="Enable (ON) or disable (OFF) publishing of RunEngine device progress updates "
+        "(waiting/watcher updates, e.g. motor position while moving) to 0MQ (default: %(default)s).",
     )
 
     group_console_output.add_argument(
@@ -698,12 +698,11 @@ def start_manager():
         console_output_on=settings.print_console_output,
         zmq_publish_console=settings.zmq_publish_console,
         zmq_publish_info=settings.zmq_publish_info,
-        zmq_publish_progress=settings.zmq_publish_progress,
         zmq_publish_addr=settings.zmq_info_addr,
         encoding=settings.zmq_encoding,
     )
 
-    zmq_publish_on = settings.zmq_publish_console or settings.zmq_publish_info or settings.zmq_publish_progress
+    zmq_publish_on = settings.zmq_publish_console or settings.zmq_publish_info
     if zmq_publish_on:
         # Wait for a short period to allow monitoring applications to connect.
         ttime.sleep(1)
@@ -800,7 +799,7 @@ def start_manager():
     config_worker["ipython_control_port"] = settings.ipython_control_port
     config_worker["ignore_invalid_plans"] = settings.ignore_invalid_plans
     config_worker["permitted_re_metadata_keys"] = settings.permitted_re_metadata_keys
-    config_worker["zmq_publish_progress"] = settings.zmq_publish_progress
+    config_worker["zmq_publish_device_progress"] = settings.zmq_publish_device_progress
 
     existing_pd_path = settings.existing_plans_and_devices_path
     if not existing_pd_path:

--- a/src/bluesky_queueserver/manager/start_manager.py
+++ b/src/bluesky_queueserver/manager/start_manager.py
@@ -607,9 +607,8 @@ def start_manager():
         dest="zmq_info_addr",
         type=str,
         default=None,
-        help="The address of ZMQ server socket used for publishing information on the state of RE Manager "
-        "and currently running processes. Currently only the captured STDOUT and STDERR published "
-        "in 'QS_Console' topic. The parameter overrides the address defined by the environment variable "
+        help="The address of ZMQ PUB socket used for publishing console output, status info, and "
+        "progress updates. The parameter overrides the address defined by the environment variable "
         "'QSERVER_ZMQ_INFO_ADDRESS_FOR_SERVER'. The default address is used if the parameter or the environment "
         " variable is not defined. Address format: 'tcp://*:60625' "
         f"(default: {default_zmq_info_address_for_server}).",

--- a/src/bluesky_queueserver/manager/start_manager.py
+++ b/src/bluesky_queueserver/manager/start_manager.py
@@ -628,18 +628,19 @@ def start_manager():
         dest="zmq_publish_info",
         type=str,
         choices=["ON", "OFF"],
-        default="ON",
+        default="OFF",
         help="Enable (ON) or disable (OFF) publishing of info/status updates to 0MQ (default: %(default)s).",
     )
 
     group_console_output.add_argument(
-        "--zmq-publish-device-progress",
-        dest="zmq_publish_device_progress",
+        "--zmq-stream-device-progress",
+        dest="zmq_stream_device_progress",
         type=str,
         choices=["ON", "OFF"],
-        default="ON",
-        help="Enable (ON) or disable (OFF) publishing of RunEngine device progress updates "
-        "(waiting/watcher updates, e.g. motor position while moving) to 0MQ (default: %(default)s).",
+        default="OFF",
+        help="Enable (ON) or disable (OFF) publishing of optional RunEngine device progress updates "
+        "(waiting/watcher updates, e.g. motor position during motion) to 0MQ. This parameter is "
+        "only effective when --zmq-publish-info=ON; it is ignored otherwise (default: %(default)s).",
     )
 
     group_console_output.add_argument(
@@ -799,7 +800,7 @@ def start_manager():
     config_worker["ipython_control_port"] = settings.ipython_control_port
     config_worker["ignore_invalid_plans"] = settings.ignore_invalid_plans
     config_worker["permitted_re_metadata_keys"] = settings.permitted_re_metadata_keys
-    config_worker["zmq_publish_device_progress"] = settings.zmq_publish_device_progress
+    config_worker["zmq_stream_device_progress"] = settings.zmq_stream_device_progress and settings.zmq_publish_info
 
     existing_pd_path = settings.existing_plans_and_devices_path
     if not existing_pd_path:

--- a/src/bluesky_queueserver/manager/start_manager.py
+++ b/src/bluesky_queueserver/manager/start_manager.py
@@ -595,16 +595,6 @@ def start_manager():
         "environment variable, where the keys are separated by colons.",
     )
 
-    parser.add_argument(
-        "--progress-streaming",
-        dest="progress_streaming",
-        type=str,
-        choices=["ON", "OFF"],
-        default="ON",
-        help="Enable (ON) or disable (OFF) streaming of RunEngine waiting/progress updates "
-        "to 0MQ info subscribers (default: %(default)s).",
-    )
-
     group_console_output = parser.add_argument_group(
         "Configure console output",
         "The arguments allow to configure printing and publishing of the console output\n"
@@ -632,6 +622,25 @@ def start_manager():
         choices=["ON", "OFF"],
         default="OFF",
         help="Enable (ON) or disable (OFF) publishing of console output to 0MQ (default: %(default)s).",
+    )
+
+    group_console_output.add_argument(
+        "--zmq-publish-info",
+        dest="zmq_publish_info",
+        type=str,
+        choices=["ON", "OFF"],
+        default="ON",
+        help="Enable (ON) or disable (OFF) publishing of info/status updates to 0MQ (default: %(default)s).",
+    )
+
+    group_console_output.add_argument(
+        "--zmq-publish-progress",
+        dest="zmq_publish_progress",
+        type=str,
+        choices=["ON", "OFF"],
+        default="ON",
+        help="Enable (ON) or disable (OFF) publishing of RunEngine waiting/progress updates "
+        "to 0MQ (default: %(default)s).",
     )
 
     group_console_output.add_argument(
@@ -688,12 +697,15 @@ def start_manager():
     stream_publisher = PublishZMQStreamOutput(
         msg_queue=msg_queue,
         console_output_on=settings.print_console_output,
-        zmq_publish_on=settings.zmq_publish_console,
+        zmq_publish_console=settings.zmq_publish_console,
+        zmq_publish_info=settings.zmq_publish_info,
+        zmq_publish_progress=settings.zmq_publish_progress,
         zmq_publish_addr=settings.zmq_info_addr,
         encoding=settings.zmq_encoding,
     )
 
-    if settings.zmq_publish_console:
+    zmq_publish_on = settings.zmq_publish_console or settings.zmq_publish_info or settings.zmq_publish_progress
+    if zmq_publish_on:
         # Wait for a short period to allow monitoring applications to connect.
         ttime.sleep(1)
 
@@ -789,7 +801,7 @@ def start_manager():
     config_worker["ipython_control_port"] = settings.ipython_control_port
     config_worker["ignore_invalid_plans"] = settings.ignore_invalid_plans
     config_worker["permitted_re_metadata_keys"] = settings.permitted_re_metadata_keys
-    config_worker["progress_streaming"] = settings.progress_streaming
+    config_worker["zmq_publish_progress"] = settings.zmq_publish_progress
 
     existing_pd_path = settings.existing_plans_and_devices_path
     if not existing_pd_path:

--- a/src/bluesky_queueserver/manager/start_manager.py
+++ b/src/bluesky_queueserver/manager/start_manager.py
@@ -595,6 +595,16 @@ def start_manager():
         "environment variable, where the keys are separated by colons.",
     )
 
+    parser.add_argument(
+        "--progress-streaming",
+        dest="progress_streaming",
+        type=str,
+        choices=["ON", "OFF"],
+        default="ON",
+        help="Enable (ON) or disable (OFF) streaming of RunEngine waiting/progress updates "
+        "to 0MQ info subscribers (default: %(default)s).",
+    )
+
     group_console_output = parser.add_argument_group(
         "Configure console output",
         "The arguments allow to configure printing and publishing of the console output\n"
@@ -779,6 +789,7 @@ def start_manager():
     config_worker["ipython_control_port"] = settings.ipython_control_port
     config_worker["ignore_invalid_plans"] = settings.ignore_invalid_plans
     config_worker["permitted_re_metadata_keys"] = settings.permitted_re_metadata_keys
+    config_worker["progress_streaming"] = settings.progress_streaming
 
     existing_pd_path = settings.existing_plans_and_devices_path
     if not existing_pd_path:

--- a/src/bluesky_queueserver/manager/tests/test_info_streaming.py
+++ b/src/bluesky_queueserver/manager/tests/test_info_streaming.py
@@ -22,6 +22,7 @@ from .common import (
     re_manager_cmd,  # noqa: F401
     use_zmq_encoding_for_tests,
     wait_for_condition,
+    wait_for_task_result,
     zmq_request,
 )
 
@@ -56,6 +57,11 @@ class ReceiveMessages(threading.Thread):
 
     def unsubscribe(self):
         self._rco.unsubscribe()
+
+    def clear(self):
+        # Clear the messages
+        self.received_msgs.clear()
+        self.n_timeouts = 0
 
     def filter_msgs(self, key):
         """
@@ -142,7 +148,26 @@ from ophyd_async.core import init_devices
 
 with init_devices():
     sim_motor = sim.SimMotor(name="sim_motor", instant=False)
+
+
+# Check waiting_hook and WatcherStreamManager state
+def unit_test_waiting_hook(device_progress_enabled):
+    from bluesky_queueserver.manager.plan_monitoring import WatcherStreamManager
+    msg = ""
+    if device_progress_enabled:
+        if not isinstance(RE.waiting_hook, WatcherStreamManager):
+            msg = "RE.waiting_hook is not pointing to WatcherStreamManager object"
+        elif isinstance(RE.waiting_hook.waiting_hook, WatcherStreamManager):
+            msg = "RE.waiting_hook.waiting_hook is pointing to WatcherStreamManager object"
+        elif RE.waiting_hook == RE.waiting_hook.waiting_hook:
+            msg = "RE.waiting_hook and RE.waiting_hook.waiting_hook are pointing to the same object"
+    else:
+        if isinstance(RE.waiting_hook, WatcherStreamManager):
+            msg = "RE.waiting_hook is pointing to WatcherStreamManager object"
+
+    return msg == "", msg
 """
+
 
 _script_enable_progress_bar = """
 
@@ -213,42 +238,73 @@ def test_zmq_info_streaming_2(
 
         re_manager_cmd(params_server)
 
-        msgs = rm_info.filter_msgs(msg_key)
-        assert len(msgs) == 0
-
         zmq_request("environment_open")
         assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
-        _plan_mv = {"name": "mv", "args": ["sim_motor", 5.0], "item_type": "plan"}
-        params = {"item": _plan_mv, "user": _user, "user_group": _user_group}
-        resp2, _ = zmq_request("queue_item_add", params)
-        assert resp2["success"] is True, f"resp={resp2}"
+        for _ntest in range(2):
+            rm_console.clear()
+            rm_info.clear()
 
-        resp3, _ = zmq_request("queue_start")
-        assert resp3["success"] is True
+            msgs = rm_info.filter_msgs(msg_key)
+            assert len(msgs) == 0
 
-        assert wait_for_condition(time=60, condition=condition_queue_processing_finished)
+            pos_start = _ntest * 5.0
+            pos_finish = pos_start + 5.0
+
+            _plan_mv = {"name": "mv", "args": ["sim_motor", pos_finish], "item_type": "plan"}
+            params = {"item": _plan_mv, "user": _user, "user_group": _user_group}
+            resp2, _ = zmq_request("queue_item_add", params)
+            assert resp2["success"] is True, f"resp={resp2}"
+
+            resp3, _ = zmq_request("queue_start")
+            assert resp3["success"] is True
+
+            assert wait_for_condition(time=60, condition=condition_queue_processing_finished)
+            ##ttime.sleep(2)
+
+            msgs = rm_info.filter_msgs(msg_key)
+            print(f"msgs = {pprint.pformat(msgs)}")
+            if stream_dev_progress_enabled is True:
+                assert len(msgs) > 3
+                assert msgs[0]["msg"]["device_progress"]["name"] == "sim_motor"
+                assert msgs[0]["msg"]["device_progress"]["current"] == pos_start
+                assert msgs[-2]["msg"]["device_progress"]["current"] == pos_finish
+                assert msgs[-1]["msg"]["device_progress"]["completed"] is True
+            else:
+                assert len(msgs) == 0
+
+            # Check that the progress bar was also sent to the console output
+            progress_console_msgs = [_ for _ in rm_console.received_msgs if re.search("sim_motor:.+%.*", _["msg"])]
+            if enable_progress_bar:
+                assert len(progress_console_msgs) > 0
+            else:
+                assert len(progress_console_msgs) == 0
+
+            # --------  Check that the waiting hook is pointing to the WatcherStreamManager object
+            func_info = {"name": "unit_test_waiting_hook",
+                         "item_type": "function",
+                         "kwargs": {"device_progress_enabled": bool(stream_dev_progress_enabled)}}
+            resp, _ = zmq_request(
+                "function_execute",
+                params={
+                    "item": func_info,
+                    "user": _user,
+                    "user_group": _user_group,
+                    "run_in_background": False,
+                },
+            )
+            assert resp["success"] is True, pprint.pformat(resp)
+            task_uid = resp["task_uid"]
+
+            assert wait_for_task_result(10, task_uid)
+
+            resp, _ = zmq_request("task_result", params={"task_uid": task_uid})
+            result = resp["result"]["return_value"]
+            assert result[0], result[1]
+            # ---------------------------------------------------------------------------------------
 
         zmq_request("environment_close")
         assert wait_for_condition(time=3, condition=condition_environment_closed)
-
-        msgs = rm_info.filter_msgs(msg_key)
-        print(f"msgs = {pprint.pformat(msgs)}")
-        if stream_dev_progress_enabled is True:
-            assert len(msgs) > 3
-            assert msgs[0]["msg"]["device_progress"]["name"] == "sim_motor"
-            assert msgs[0]["msg"]["device_progress"]["current"] == 0.0
-            assert msgs[-2]["msg"]["device_progress"]["current"] == 5.0
-            assert msgs[-1]["msg"]["device_progress"]["completed"] is True
-        else:
-            assert len(msgs) == 0
-
-        # Check that the progress bar was also sent to the console output
-        progress_console_msgs = [_ for _ in rm_console.received_msgs if re.search("sim_motor:.+%.*", _["msg"])]
-        if enable_progress_bar:
-            assert len(progress_console_msgs) > 0
-        else:
-            assert len(progress_console_msgs) == 0
 
     finally:
         rm_console.stop()

--- a/src/bluesky_queueserver/manager/tests/test_info_streaming.py
+++ b/src/bluesky_queueserver/manager/tests/test_info_streaming.py
@@ -64,6 +64,9 @@ def test_zmq_info_streaming_1(monkeypatch, re_manager_cmd, stream_enabled):  # n
     if stream_enabled is not None:
         params_server.append(f"--zmq-publish-info={'ON' if stream_enabled else 'OFF'}")
 
+    # 'zmq_publish_info' defaults to ON, so the default (None) case streams messages.
+    stream_on = stream_enabled is not False
+
     zmq_encoding = use_zmq_encoding_for_tests()
 
     rm_info = ReceiveMessages(
@@ -78,7 +81,7 @@ def test_zmq_info_streaming_1(monkeypatch, re_manager_cmd, stream_enabled):  # n
     re_manager_cmd(params_server)
 
     # Test periodic streaming of status messages (once per second)
-    if stream_enabled is True:
+    if stream_on:
         ttime.sleep(6)
         assert len(rm_info.received_msgs) > 5
 
@@ -96,19 +99,19 @@ def test_zmq_info_streaming_1(monkeypatch, re_manager_cmd, stream_enabled):  # n
 
     # The assumption is that only 'status' messages are streamed.
     # If other messages are streamed, then the test needs to be adjusted.
-    if stream_enabled is True:
+    if stream_on:
         status_1 = rm_info.received_msgs[-1]["msg"]["status"]
         assert status_1["worker_environment_exists"] is True
 
     zmq_request("environment_close")
     assert wait_for_condition(time=3, condition=condition_environment_closed)
 
-    if stream_enabled is True:
+    if stream_on:
         status_2 = rm_info.received_msgs[-1]["msg"]["status"]
         assert status_2["worker_environment_exists"] is False
         assert status_2["status_uid"] != status_1["status_uid"]
 
-    if stream_enabled is not True:
+    if not stream_on:
         assert len(rm_info.received_msgs) == 0
 
     rm_info.stop()

--- a/src/bluesky_queueserver/manager/tests/test_info_streaming.py
+++ b/src/bluesky_queueserver/manager/tests/test_info_streaming.py
@@ -64,8 +64,6 @@ def test_zmq_info_streaming_1(monkeypatch, re_manager_cmd, stream_enabled):  # n
     if stream_enabled is not None:
         params_server.append(f"--zmq-publish-info={'ON' if stream_enabled else 'OFF'}")
 
-    # 'zmq_publish_info' defaults to ON, so the default (None) case streams messages.
-    stream_on = stream_enabled is not False
 
     zmq_encoding = use_zmq_encoding_for_tests()
 
@@ -81,7 +79,7 @@ def test_zmq_info_streaming_1(monkeypatch, re_manager_cmd, stream_enabled):  # n
     re_manager_cmd(params_server)
 
     # Test periodic streaming of status messages (once per second)
-    if stream_on:
+    if stream_enabled is True:
         ttime.sleep(6)
         assert len(rm_info.received_msgs) > 5
 
@@ -99,19 +97,19 @@ def test_zmq_info_streaming_1(monkeypatch, re_manager_cmd, stream_enabled):  # n
 
     # The assumption is that only 'status' messages are streamed.
     # If other messages are streamed, then the test needs to be adjusted.
-    if stream_on:
+    if stream_enabled is True:
         status_1 = rm_info.received_msgs[-1]["msg"]["status"]
         assert status_1["worker_environment_exists"] is True
 
     zmq_request("environment_close")
     assert wait_for_condition(time=3, condition=condition_environment_closed)
 
-    if stream_on:
+    if stream_enabled is True:
         status_2 = rm_info.received_msgs[-1]["msg"]["status"]
         assert status_2["worker_environment_exists"] is False
         assert status_2["status_uid"] != status_1["status_uid"]
 
-    if not stream_on:
+    if stream_enabled is not True:
         assert len(rm_info.received_msgs) == 0
 
     rm_info.stop()

--- a/src/bluesky_queueserver/manager/tests/test_info_streaming.py
+++ b/src/bluesky_queueserver/manager/tests/test_info_streaming.py
@@ -1,10 +1,15 @@
 import pprint
+import re
 import threading
 import time as ttime
 
 import pytest
 
-from bluesky_queueserver.manager.output_streaming import ReceiveSystemInfo, _default_zmq_info_topic
+from bluesky_queueserver.manager.output_streaming import (
+    ReceiveSystemInfo,
+    _default_zmq_console_topic,
+    _default_zmq_info_topic,
+)
 
 from .common import (
     _user,
@@ -86,46 +91,48 @@ def test_zmq_info_streaming_1(monkeypatch, re_manager_cmd, stream_enabled):  # n
         encoding=zmq_encoding,
     )
 
-    rm_info.start()
+    try:
+        rm_info.start()
 
-    re_manager_cmd(params_server)
+        re_manager_cmd(params_server)
 
-    # Test periodic streaming of status messages (once per second)
-    if stream_enabled is True:
-        ttime.sleep(6)
-        assert len(rm_info.received_msgs) > 5
+        # Test periodic streaming of status messages (once per second)
+        if stream_enabled is True:
+            ttime.sleep(6)
+            assert len(rm_info.received_msgs) > 5
 
-        msg_prev = rm_info.received_msgs[-2]
-        msg_last = rm_info.received_msgs[-1]
-        assert msg_last["time"] > msg_prev["time"]
-        status_prev = msg_prev["msg"]["status"]
-        status_last = msg_last["msg"]["status"]
-        assert status_last["status_uid"] == status_prev["status_uid"]
-        assert status_last["manager_state"] == "idle"
-        assert status_last["worker_environment_exists"] is False
+            msg_prev = rm_info.received_msgs[-2]
+            msg_last = rm_info.received_msgs[-1]
+            assert msg_last["time"] > msg_prev["time"]
+            status_prev = msg_prev["msg"]["status"]
+            status_last = msg_last["msg"]["status"]
+            assert status_last["status_uid"] == status_prev["status_uid"]
+            assert status_last["manager_state"] == "idle"
+            assert status_last["worker_environment_exists"] is False
 
-    zmq_request("environment_open")
-    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+        zmq_request("environment_open")
+        assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
 
-    # The assumption is that only 'status' messages are streamed.
-    # If other messages are streamed, then the test needs to be adjusted.
-    if stream_enabled is True:
-        status_1 = rm_info.received_msgs[-1]["msg"]["status"]
-        assert status_1["worker_environment_exists"] is True
+        # The assumption is that only 'status' messages are streamed.
+        # If other messages are streamed, then the test needs to be adjusted.
+        if stream_enabled is True:
+            status_1 = rm_info.received_msgs[-1]["msg"]["status"]
+            assert status_1["worker_environment_exists"] is True
 
-    zmq_request("environment_close")
-    assert wait_for_condition(time=3, condition=condition_environment_closed)
+        zmq_request("environment_close")
+        assert wait_for_condition(time=3, condition=condition_environment_closed)
 
-    if stream_enabled is True:
-        status_2 = rm_info.received_msgs[-1]["msg"]["status"]
-        assert status_2["worker_environment_exists"] is False
-        assert status_2["status_uid"] != status_1["status_uid"]
+        if stream_enabled is True:
+            status_2 = rm_info.received_msgs[-1]["msg"]["status"]
+            assert status_2["worker_environment_exists"] is False
+            assert status_2["status_uid"] != status_1["status_uid"]
 
-    if stream_enabled is not True:
-        assert len(rm_info.received_msgs) == 0
+        if stream_enabled is not True:
+            assert len(rm_info.received_msgs) == 0
 
-    rm_info.stop()
-    rm_info.join()
+    finally:
+        rm_info.stop()
+        rm_info.join()
 
 
 _script_device_progress = """
@@ -137,11 +144,25 @@ with init_devices():
     sim_motor = sim.SimMotor(name="sim_motor", instant=False)
 """
 
+_script_enable_progress_bar = """
+
+from bluesky.utils import ProgressBarManager
+RE.waiting_hook = ProgressBarManager()
+"""
+
+_script_disable_progress_bar = """
+
+RE.waiting_hook = None
+"""
+
 
 # fmt: off
+@pytest.mark.parametrize("enable_progress_bar", [True, False])
 @pytest.mark.parametrize("stream_dev_progress_enabled", [True, False, None])
 # fmt: on
-def test_zmq_info_streaming_2(tmp_path, monkeypatch, re_manager_cmd, stream_dev_progress_enabled):  # noqa: F811
+def test_zmq_info_streaming_2(
+    tmp_path, monkeypatch, re_manager_cmd, enable_progress_bar, stream_dev_progress_enabled  # noqa: F811
+    ):
     """
     Test 0MQ streaming functionality: streaming of device progress.
     Test that streaming of device progress can be disabled.
@@ -152,15 +173,32 @@ def test_zmq_info_streaming_2(tmp_path, monkeypatch, re_manager_cmd, stream_dev_
     # Add extra plan. The original set of startup files will not contain this plan.
     append_code_to_last_startup_file(pc_path, additional_code=_script_device_progress)
 
+    if enable_progress_bar:
+        append_code_to_last_startup_file(pc_path, additional_code=_script_enable_progress_bar)
+    else:
+        append_code_to_last_startup_file(pc_path, additional_code=_script_disable_progress_bar)
+
     address_info_server = "tcp://*:60621"
     address_info_client = "tcp://localhost:60621"
 
-    params_server = [f"--zmq-info-addr={address_info_server}", "--zmq-publish-info=ON", f"--startup-dir={pc_path}"]
+    params_server = [
+        f"--zmq-info-addr={address_info_server}",
+        "--zmq-publish-console=ON",
+        "--zmq-publish-info=ON",
+        f"--startup-dir={pc_path}"
+    ]
     if stream_dev_progress_enabled is not None:
         params_server.append(f"--zmq-stream-device-progress={'ON' if stream_dev_progress_enabled else 'OFF'}")
 
     zmq_encoding = use_zmq_encoding_for_tests()
 
+    rm_console = ReceiveMessages(
+        receiver_class=ReceiveSystemInfo,
+        zmq_subscribe_addr=address_info_client,
+        zmq_topic=_default_zmq_console_topic,
+        encoding=zmq_encoding,
+
+    )
     rm_info = ReceiveMessages(
         receiver_class=ReceiveSystemInfo,
         zmq_subscribe_addr=address_info_client,
@@ -169,39 +207,51 @@ def test_zmq_info_streaming_2(tmp_path, monkeypatch, re_manager_cmd, stream_dev_
     )
     msg_key = "device_progress"
 
-    rm_info.start()
+    try:
+        rm_console.start()
+        rm_info.start()
 
-    re_manager_cmd(params_server)
+        re_manager_cmd(params_server)
 
-    msgs = rm_info.filter_msgs(msg_key)
-    assert len(msgs) == 0
-
-    zmq_request("environment_open")
-    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
-
-    _plan_mv = {"name": "mv", "args": ["sim_motor", 5.0], "item_type": "plan"}
-    params = {"item": _plan_mv, "user": _user, "user_group": _user_group}
-    resp2, _ = zmq_request("queue_item_add", params)
-    assert resp2["success"] is True, f"resp={resp2}"
-
-    resp3, _ = zmq_request("queue_start")
-    assert resp3["success"] is True
-
-    assert wait_for_condition(time=60, condition=condition_queue_processing_finished)
-
-    zmq_request("environment_close")
-    assert wait_for_condition(time=3, condition=condition_environment_closed)
-
-    msgs = rm_info.filter_msgs(msg_key)
-    print(f"msgs = {pprint.pformat(msgs)}")
-    if stream_dev_progress_enabled is True:
-        assert len(msgs) > 3
-        assert msgs[0]["msg"]["device_progress"]["name"] == "sim_motor"
-        assert msgs[0]["msg"]["device_progress"]["current"] == 0.0
-        assert msgs[-2]["msg"]["device_progress"]["current"] == 5.0
-        assert msgs[-1]["msg"]["device_progress"]["completed"] is True
-    else:
+        msgs = rm_info.filter_msgs(msg_key)
         assert len(msgs) == 0
 
-    rm_info.stop()
-    rm_info.join()
+        zmq_request("environment_open")
+        assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+        _plan_mv = {"name": "mv", "args": ["sim_motor", 5.0], "item_type": "plan"}
+        params = {"item": _plan_mv, "user": _user, "user_group": _user_group}
+        resp2, _ = zmq_request("queue_item_add", params)
+        assert resp2["success"] is True, f"resp={resp2}"
+
+        resp3, _ = zmq_request("queue_start")
+        assert resp3["success"] is True
+
+        assert wait_for_condition(time=60, condition=condition_queue_processing_finished)
+
+        zmq_request("environment_close")
+        assert wait_for_condition(time=3, condition=condition_environment_closed)
+
+        msgs = rm_info.filter_msgs(msg_key)
+        print(f"msgs = {pprint.pformat(msgs)}")
+        if stream_dev_progress_enabled is True:
+            assert len(msgs) > 3
+            assert msgs[0]["msg"]["device_progress"]["name"] == "sim_motor"
+            assert msgs[0]["msg"]["device_progress"]["current"] == 0.0
+            assert msgs[-2]["msg"]["device_progress"]["current"] == 5.0
+            assert msgs[-1]["msg"]["device_progress"]["completed"] is True
+        else:
+            assert len(msgs) == 0
+
+        # Check that the progress bar was also sent to the console output
+        progress_console_msgs = [_ for _ in rm_console.received_msgs if re.search("sim_motor:.+%.*", _["msg"])]
+        if enable_progress_bar:
+            assert len(progress_console_msgs) > 0
+        else:
+            assert len(progress_console_msgs) == 0
+
+    finally:
+        rm_console.stop()
+        rm_info.stop()
+        rm_console.join()
+        rm_info.join()

--- a/src/bluesky_queueserver/manager/tests/test_info_streaming.py
+++ b/src/bluesky_queueserver/manager/tests/test_info_streaming.py
@@ -62,7 +62,7 @@ def test_zmq_info_streaming_1(monkeypatch, re_manager_cmd, stream_enabled):  # n
 
     params_server = [f"--zmq-info-addr={address_info_server}"]
     if stream_enabled is not None:
-        params_server.append(f"--zmq-publish-console={'ON' if stream_enabled else 'OFF'}")
+        params_server.append(f"--zmq-publish-info={'ON' if stream_enabled else 'OFF'}")
 
     zmq_encoding = use_zmq_encoding_for_tests()
 

--- a/src/bluesky_queueserver/manager/tests/test_info_streaming.py
+++ b/src/bluesky_queueserver/manager/tests/test_info_streaming.py
@@ -1,3 +1,4 @@
+import pprint
 import threading
 import time as ttime
 
@@ -6,8 +7,13 @@ import pytest
 from bluesky_queueserver.manager.output_streaming import ReceiveSystemInfo, _default_zmq_info_topic
 
 from .common import (
+    _user,
+    _user_group,
+    append_code_to_last_startup_file,
     condition_environment_closed,
     condition_environment_created,
+    condition_queue_processing_finished,
+    copy_default_profile_collection,
     re_manager_cmd,  # noqa: F401
     use_zmq_encoding_for_tests,
     wait_for_condition,
@@ -45,6 +51,12 @@ class ReceiveMessages(threading.Thread):
 
     def unsubscribe(self):
         self._rco.unsubscribe()
+
+    def filter_msgs(self, key):
+        """
+        Returns a list of messages of the specific type (with matching key).
+        """
+        return [_ for _ in self.received_msgs if key in _["msg"].keys()]
 
 
 # fmt: off
@@ -111,6 +123,85 @@ def test_zmq_info_streaming_1(monkeypatch, re_manager_cmd, stream_enabled):  # n
 
     if stream_enabled is not True:
         assert len(rm_info.received_msgs) == 0
+
+    rm_info.stop()
+    rm_info.join()
+
+
+_script_device_progress = """
+
+from ophyd_async import sim
+from ophyd_async.core import init_devices
+
+with init_devices():
+    sim_motor = sim.SimMotor(name="sim_motor", instant=False)
+"""
+
+
+# fmt: off
+@pytest.mark.parametrize("stream_dev_progress_enabled", [True, False, None])
+# fmt: on
+def test_zmq_info_streaming_2(tmp_path, monkeypatch, re_manager_cmd, stream_dev_progress_enabled):  # noqa: F811
+    """
+    Test 0MQ streaming functionality: streaming of device progress.
+    Test that streaming of device progress can be disabled.
+    """
+
+    pc_path = copy_default_profile_collection(tmp_path)
+
+    # Add extra plan. The original set of startup files will not contain this plan.
+    append_code_to_last_startup_file(pc_path, additional_code=_script_device_progress)
+
+    address_info_server = "tcp://*:60621"
+    address_info_client = "tcp://localhost:60621"
+
+    params_server = [f"--zmq-info-addr={address_info_server}", "--zmq-publish-info=ON", f"--startup-dir={pc_path}"]
+    if stream_dev_progress_enabled is not None:
+        params_server.append(f"--zmq-stream-device-progress={'ON' if stream_dev_progress_enabled else 'OFF'}")
+
+    zmq_encoding = use_zmq_encoding_for_tests()
+
+    rm_info = ReceiveMessages(
+        receiver_class=ReceiveSystemInfo,
+        zmq_subscribe_addr=address_info_client,
+        zmq_topic=_default_zmq_info_topic,
+        encoding=zmq_encoding,
+    )
+    msg_key = "device_progress"
+
+    rm_info.start()
+
+    re_manager_cmd(params_server)
+
+    msgs = rm_info.filter_msgs(msg_key)
+    assert len(msgs) == 0
+
+    zmq_request("environment_open")
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    _plan_mv = {"name": "mv", "args": ["sim_motor", 5.0], "item_type": "plan"}
+    params = {"item": _plan_mv, "user": _user, "user_group": _user_group}
+    resp2, _ = zmq_request("queue_item_add", params)
+    assert resp2["success"] is True, f"resp={resp2}"
+
+    resp3, _ = zmq_request("queue_start")
+    assert resp3["success"] is True
+
+    assert wait_for_condition(time=60, condition=condition_queue_processing_finished)
+
+    zmq_request("environment_close")
+    assert wait_for_condition(time=3, condition=condition_environment_closed)
+
+    msgs = rm_info.filter_msgs(msg_key)
+    print(f"msgs = {pprint.pformat(msgs)}")
+    if stream_dev_progress_enabled is True:
+        assert len(msgs) > 3
+        assert msgs[0]["msg"]["device_progress"]["name"] == "sim_motor"
+        assert msgs[0]["msg"]["device_progress"]["current"] == 0.0
+        assert msgs[-2]["msg"]["device_progress"]["current"] == 5.0
+        assert msgs[-1]["msg"]["device_progress"]["completed"] is True
+    else:
+        assert len(msgs) == 0
 
     rm_info.stop()
     rm_info.join()

--- a/src/bluesky_queueserver/manager/tests/test_output_streaming.py
+++ b/src/bluesky_queueserver/manager/tests/test_output_streaming.py
@@ -118,7 +118,8 @@ def test_ReceiveConsoleOutput_1(
     pco = PublishZMQStreamOutput(
         msg_queue=queue,
         console_output_on=console_output_on,
-        zmq_publish_on=zmq_publish_on,
+        zmq_publish_console=zmq_publish_on,
+        zmq_publish_info=zmq_publish_on,
         zmq_publish_addr=zmq_publish_addr,
         zmq_topic_console=zmq_topic_console,
         zmq_topic_info=zmq_topic_info,
@@ -259,7 +260,8 @@ def test_ReceiveConsoleOutputAsync_1(period, cb_type, zmq_encoding, channel):
     pco = PublishZMQStreamOutput(
         msg_queue=queue,
         console_output_on=True,
-        zmq_publish_on=True,
+        zmq_publish_console=True,
+        zmq_publish_info=True,
         zmq_publish_addr=zmq_publish_addr,
         zmq_topic_console=zmq_topic_console,
         zmq_topic_info=zmq_topic_info,
@@ -418,7 +420,8 @@ def test_push_info_to_msg_queue_1(zmq_encoding):
     pco = PublishZMQStreamOutput(
         msg_queue=queue,
         console_output_on=True,
-        zmq_publish_on=True,
+        zmq_publish_console=True,
+        zmq_publish_info=True,
         zmq_publish_addr=zmq_publish_addr,
         zmq_topic_console=zmq_topic_console,
         zmq_topic_info=zmq_topic_info,

--- a/src/bluesky_queueserver/manager/tests/test_plan_monitoring.py
+++ b/src/bluesky_queueserver/manager/tests/test_plan_monitoring.py
@@ -2,8 +2,12 @@ import uuid
 
 import pytest
 
-from bluesky_queueserver.manager.plan_monitoring import CallbackRegisterRun, RunList
-
+from bluesky_queueserver.manager.plan_monitoring import CallbackRegisterRun, RunList, WatcherStreamManager
+from bluesky_queueserver.manager.profile_ops import (
+    get_default_startup_dir,
+    load_profile_collection,
+    load_script_into_existing_nspace,
+)
 
 def test_RunList_1():
     """
@@ -135,3 +139,306 @@ def test_CallbackRegisterRun_1(scan_id):
     assert run_list.get_run_list() == [{"uid": uid, "is_open": True, "exit_status": None, **param_expected}]
     cb("stop", {"run_start": uid, "exit_status": "success"})
     assert run_list.get_run_list() == [{"uid": uid, "is_open": False, "exit_status": "success", **param_expected}]
+
+
+
+class _MockQueue:
+    """A simple list-backed mock for multiprocessing.Queue."""
+
+    def __init__(self):
+        self.messages = []
+
+    def put(self, msg):
+        self.messages.append(msg)
+
+
+class _MockStatus:
+    """A mock Status object that supports watch()."""
+
+    def __init__(self, *, name="motor1", done=False, supports_watch=True):
+        self._name = name
+        self.done = done
+        self._supports_watch = supports_watch
+        self._watchers = []
+
+    def watch(self, func):
+        if not self._supports_watch:
+            raise AttributeError("watch not supported")
+        self._watchers.append(func)
+
+    def simulate_update(self, **kwargs):
+        """Simulate a watcher callback from the status object."""
+        defaults = dict(
+            name=self._name,
+            current=None,
+            initial=None,
+            target=None,
+            unit=None,
+            precision=None,
+            fraction=None,
+            time_elapsed=None,
+            time_remaining=None,
+        )
+        defaults.update(kwargs)
+        for w in self._watchers:
+            w(**defaults)
+
+
+def _get_progress_messages(mock_queue):
+    """Extract only progress payloads from the mock queue."""
+    results = []
+    for msg in mock_queue.messages:
+        if msg.get("channel") == "progress" and isinstance(msg.get("msg"), dict):
+            results.append(msg["msg"])
+    return results
+
+
+def test_WatcherStreamManager_basic():
+    """
+    WatcherStreamManager subscribes to status objects and publishes progress updates.
+    """
+    mq = _MockQueue()
+    wsm = WatcherStreamManager(msg_queue=mq, min_update_period=0)
+
+    st = _MockStatus(name="motor1")
+    wsm({st})
+
+    # Simulate an update
+    st.simulate_update(current=1.0, initial=0.0, target=5.0, unit="mm", precision=3, fraction=0.2)
+
+    msgs = _get_progress_messages(mq)
+    assert len(msgs) == 1
+    assert msgs[0]["name"] == "motor1"
+    assert msgs[0]["current"] == 1.0
+    assert msgs[0]["target"] == 5.0
+    assert msgs[0]["unit"] == "mm"
+    assert msgs[0]["done"] is False
+
+    # Simulate completion
+    st.done = True
+    st.simulate_update(current=5.0, initial=0.0, target=5.0, fraction=1.0)
+
+    msgs = _get_progress_messages(mq)
+    assert len(msgs) == 2
+    assert msgs[1]["done"] is True
+    assert msgs[1]["current"] == 5.0
+
+
+def test_WatcherStreamManager_none_clears():
+    """
+    Calling with None sends a completed message and resets state.
+    """
+    mq = _MockQueue()
+    wsm = WatcherStreamManager(msg_queue=mq, min_update_period=0)
+
+    st = _MockStatus(name="motor1")
+    wsm({st})
+    st.simulate_update(current=1.0)
+
+    # Signal end of waiting
+    wsm(None)
+
+    msgs = _get_progress_messages(mq)
+    # Last message should be the completion indicator
+    assert msgs[-1] == {"completed": True}
+
+
+def test_WatcherStreamManager_no_resubscribe():
+    """
+    Calling with the same status object multiple times does not re-subscribe.
+    """
+    mq = _MockQueue()
+    wsm = WatcherStreamManager(msg_queue=mq, min_update_period=0)
+
+    st = _MockStatus(name="motor1")
+    wsm({st})
+    wsm({st})
+    wsm({st})
+
+    # Should have exactly one watcher registered
+    assert len(st._watchers) == 1
+
+
+def test_WatcherStreamManager_throttling():
+    """
+    Updates that arrive faster than min_update_period are suppressed,
+    except for the final (done) update.
+    """
+    mq = _MockQueue()
+    # Set a very long throttle period so all non-final updates are suppressed
+    wsm = WatcherStreamManager(msg_queue=mq, min_update_period=9999)
+
+    st = _MockStatus(name="motor1")
+    wsm({st})
+
+    # First update always goes through (last_sent starts at 0)
+    st.simulate_update(current=1.0)
+    # Second update should be throttled
+    st.simulate_update(current=2.0)
+    # Third update should be throttled
+    st.simulate_update(current=3.0)
+
+    msgs = _get_progress_messages(mq)
+    assert len(msgs) == 1  # Only the first one
+
+    # Final update (done=True) must always go through
+    st.done = True
+    st.simulate_update(current=5.0)
+
+    msgs = _get_progress_messages(mq)
+    assert len(msgs) == 2
+    assert msgs[1]["done"] is True
+
+
+def test_WatcherStreamManager_no_watch_support():
+    """
+    Status objects without watch() are silently ignored.
+    """
+    mq = _MockQueue()
+    wsm = WatcherStreamManager(msg_queue=mq, min_update_period=0)
+
+    st = _MockStatus(supports_watch=False)
+    # Should not raise
+    wsm({st})
+
+    msgs = _get_progress_messages(mq)
+    assert len(msgs) == 0
+
+
+def test_WatcherStreamManager_already_done():
+    """
+    Status objects that are already done are not subscribed to.
+    """
+    mq = _MockQueue()
+    wsm = WatcherStreamManager(msg_queue=mq, min_update_period=0)
+
+    st = _MockStatus(done=True)
+    wsm({st})
+
+    assert len(st._watchers) == 0
+
+
+def test_WatcherStreamManager_no_watch_attr():
+    """
+    Objects without a watch attribute at all are ignored.
+    """
+    mq = _MockQueue()
+    wsm = WatcherStreamManager(msg_queue=mq, min_update_period=0)
+
+    class _BareStatus:
+        done = False
+
+    wsm({_BareStatus()})
+    msgs = _get_progress_messages(mq)
+    assert len(msgs) == 0
+
+
+def test_WatcherStreamManager_multiple_statuses():
+    """
+    Multiple concurrent status objects each get their own progress stream.
+    """
+    mq = _MockQueue()
+    wsm = WatcherStreamManager(msg_queue=mq, min_update_period=0)
+
+    st1 = _MockStatus(name="motor1")
+    st2 = _MockStatus(name="motor2")
+    wsm({st1, st2})
+
+    st1.simulate_update(current=1.0, target=5.0)
+    st2.simulate_update(current=10.0, target=20.0)
+
+    msgs = _get_progress_messages(mq)
+    assert len(msgs) == 2
+    names = {m["name"] for m in msgs}
+    assert names == {"motor1", "motor2"}
+
+
+def test_WatcherStreamManager_name_none():
+    """
+    If the watch callback receives name=None, a generated label is used.
+    """
+    mq = _MockQueue()
+    wsm = WatcherStreamManager(msg_queue=mq, min_update_period=0)
+
+    st = _MockStatus(name=None)
+    wsm({st})
+    st.simulate_update(name=None, current=1.0)
+
+    msgs = _get_progress_messages(mq)
+    assert len(msgs) == 1
+    assert msgs[0]["name"].startswith("Status ")
+
+
+def test_WatcherStreamManager_json_safe_coercion():
+    """
+    Non-JSON-safe values for current/initial/target are coerced.
+    """
+    import numpy as np
+
+    mq = _MockQueue()
+    wsm = WatcherStreamManager(msg_queue=mq, min_update_period=0)
+
+    st = _MockStatus(name="motor1")
+    wsm({st})
+    st.simulate_update(current=np.float64(3.14), initial=np.int32(0), target=np.float64(10.0))
+
+    msgs = _get_progress_messages(mq)
+    assert len(msgs) == 1
+    assert isinstance(msgs[0]["current"], float)
+    assert isinstance(msgs[0]["initial"], float)
+    assert isinstance(msgs[0]["target"], float)
+
+
+def test_WatcherStreamManager_sim_motor_move():
+    """
+    Integration test: load the simulated profile collection, append a script
+    that creates a slow motor, attach WatcherStreamManager to the RunEngine,
+    move the motor, and verify that progress updates were published to the queue.
+    """
+
+    # Load the simulated profile collection
+    startup_dir = get_default_startup_dir()
+    nspace = load_profile_collection(startup_dir, patch_profiles=True)
+
+    # Append a script that creates a slow motor (non-zero delay so watch fires)
+    script = """
+from ophyd.sim import SynAxis
+slow_motor = SynAxis(name="slow_motor", labels={"motors"})
+slow_motor.delay = 0.3
+"""
+    load_script_into_existing_nspace(
+        script=script,
+        nspace=nspace,
+        script_root_path=startup_dir,
+    )
+
+    RE = nspace["RE"]
+    slow_motor = nspace["slow_motor"]
+
+    # Attach WatcherStreamManager
+    mq = _MockQueue()
+    wsm = WatcherStreamManager(msg_queue=mq, min_update_period=0)
+    RE.waiting_hook = wsm
+
+    # Move the motor from 0 to 1 — this triggers waiting_hook with a MoveStatus
+    RE(nspace["mv"](slow_motor, 1))
+
+    msgs = _get_progress_messages(mq)
+
+    # We should have received at least one progress update and one completed message
+    progress_updates = [m for m in msgs if "completed" not in m]
+    completed_msgs = [m for m in msgs if m.get("completed") is True]
+
+    assert len(progress_updates) > 0, "Expected at least one progress update during motor move"
+    assert len(completed_msgs) >= 1, "Expected a 'completed' message after motor move"
+
+    # Verify the structure of a progress update
+    update = progress_updates[0]
+    assert "name" in update
+    assert "current" in update
+    assert "target" in update
+    assert update["done"] in (True, False)
+    assert update["name"] == "slow_motor"
+
+    # The target should be 1 (where we moved the motor)
+    assert update["target"] == 1

--- a/src/bluesky_queueserver/manager/tests/test_plan_monitoring.py
+++ b/src/bluesky_queueserver/manager/tests/test_plan_monitoring.py
@@ -9,6 +9,7 @@ from bluesky_queueserver.manager.profile_ops import (
     load_script_into_existing_nspace,
 )
 
+
 def test_RunList_1():
     """
     Full functionality test: ``RunList`` class.

--- a/src/bluesky_queueserver/manager/tests/test_plan_monitoring.py
+++ b/src/bluesky_queueserver/manager/tests/test_plan_monitoring.py
@@ -186,11 +186,13 @@ class _MockStatus:
 
 
 def _get_progress_messages(mock_queue):
-    """Extract only progress payloads from the mock queue."""
+    """Extract only progress payloads from the mock queue (info channel, 'device_progress' key)."""
     results = []
     for msg in mock_queue.messages:
-        if msg.get("channel") == "progress" and isinstance(msg.get("msg"), dict):
-            results.append(msg["msg"])
+        if msg.get("channel") == "info" and isinstance(msg.get("msg"), dict):
+            payload = msg["msg"].get("device_progress")
+            if isinstance(payload, dict):
+                results.append(payload)
     return results
 
 

--- a/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -514,7 +514,7 @@ def _get_expected_settings_default_1(_1, _2):
         "zmq_private_key": None,
         "zmq_publish_console": False,
         "zmq_publish_info": True,
-        "zmq_publish_device_progress": True,
+        "zmq_stream_device_progress": True,
     }
 
 
@@ -619,7 +619,7 @@ def _get_expected_settings_config_2(file_dir, ip_con_dir):
         "zmq_private_key": "Ue=.po0aQ9.}<Xvrny+f{V04XMc6JZ9ufKf5aeFy",
         "zmq_publish_console": True,
         "zmq_publish_info": True,
-        "zmq_publish_device_progress": True,
+        "zmq_stream_device_progress": True,
     }
 
 
@@ -715,7 +715,7 @@ def _get_expected_settings_params_3(file_dir, _):
         "zmq_private_key": "Ue=.po0aQ9.}<Xvrny+f{V04XMc6JZ9ufKf5aeFy",
         "zmq_publish_console": False,
         "zmq_publish_info": True,
-        "zmq_publish_device_progress": True,
+        "zmq_stream_device_progress": True,
     }
 
 

--- a/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -513,6 +513,8 @@ def _get_expected_settings_default_1(_1, _2):
         "zmq_info_addr": "tcp://*:60625",
         "zmq_private_key": None,
         "zmq_publish_console": False,
+        "zmq_publish_info": True,
+        "zmq_publish_progress": True,
     }
 
 
@@ -616,6 +618,8 @@ def _get_expected_settings_config_2(file_dir, ip_con_dir):
         "zmq_info_addr": "tcp://*:60627",
         "zmq_private_key": "Ue=.po0aQ9.}<Xvrny+f{V04XMc6JZ9ufKf5aeFy",
         "zmq_publish_console": True,
+        "zmq_publish_info": True,
+        "zmq_publish_progress": True,
     }
 
 
@@ -710,6 +714,8 @@ def _get_expected_settings_params_3(file_dir, _):
         "zmq_info_addr": "tcp://*:60629",
         "zmq_private_key": "Ue=.po0aQ9.}<Xvrny+f{V04XMc6JZ9ufKf5aeFy",
         "zmq_publish_console": False,
+        "zmq_publish_info": True,
+        "zmq_publish_progress": True,
     }
 
 

--- a/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -513,8 +513,8 @@ def _get_expected_settings_default_1(_1, _2):
         "zmq_info_addr": "tcp://*:60625",
         "zmq_private_key": None,
         "zmq_publish_console": False,
-        "zmq_publish_info": True,
-        "zmq_stream_device_progress": True,
+        "zmq_publish_info": False,
+        "zmq_stream_device_progress": False,
     }
 
 
@@ -530,6 +530,8 @@ network:
   zmq_private_key: {0}
   zmq_info_addr: tcp://*:60627
   zmq_publish_console: true
+  zmq_publish_info: true
+  zmq_stream_device_progress: true
   redis_addr: localhost:6379
   redis_name_prefix: qs_unit_tests2
 worker:
@@ -658,6 +660,8 @@ def _get_cli_params_3(file_dir):
         "/d/",
         "--zmq-info-addr=tcp://*:60629",
         "--zmq-publish-console=OFF",
+        "--zmq-publish-info=OFF",
+        "--zmq-stream-device-progress=OFF",
         "--console-output=OFF",
     ]
 
@@ -714,8 +718,8 @@ def _get_expected_settings_params_3(file_dir, _):
         "zmq_info_addr": "tcp://*:60629",
         "zmq_private_key": "Ue=.po0aQ9.}<Xvrny+f{V04XMc6JZ9ufKf5aeFy",
         "zmq_publish_console": False,
-        "zmq_publish_info": True,
-        "zmq_stream_device_progress": True,
+        "zmq_publish_info": False,
+        "zmq_stream_device_progress": False,
     }
 
 

--- a/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -514,7 +514,7 @@ def _get_expected_settings_default_1(_1, _2):
         "zmq_private_key": None,
         "zmq_publish_console": False,
         "zmq_publish_info": True,
-        "zmq_publish_progress": True,
+        "zmq_publish_device_progress": True,
     }
 
 
@@ -619,7 +619,7 @@ def _get_expected_settings_config_2(file_dir, ip_con_dir):
         "zmq_private_key": "Ue=.po0aQ9.}<Xvrny+f{V04XMc6JZ9ufKf5aeFy",
         "zmq_publish_console": True,
         "zmq_publish_info": True,
-        "zmq_publish_progress": True,
+        "zmq_publish_device_progress": True,
     }
 
 
@@ -715,7 +715,7 @@ def _get_expected_settings_params_3(file_dir, _):
         "zmq_private_key": "Ue=.po0aQ9.}<Xvrny+f{V04XMc6JZ9ufKf5aeFy",
         "zmq_publish_console": False,
         "zmq_publish_info": True,
-        "zmq_publish_progress": True,
+        "zmq_publish_device_progress": True,
     }
 
 

--- a/src/bluesky_queueserver/manager/worker.py
+++ b/src/bluesky_queueserver/manager/worker.py
@@ -246,7 +246,7 @@ class RunEngineWorker(Process):
         """
         if self._RE is None or self._msg_queue is None:
             return
-        if not self._config_dict.get("zmq_publish_device_progress", True):
+        if not self._config_dict.get("zmq_stream_device_progress", True):
             return
         try:
             from .plan_monitoring import WatcherStreamManager

--- a/src/bluesky_queueserver/manager/worker.py
+++ b/src/bluesky_queueserver/manager/worker.py
@@ -152,6 +152,9 @@ class RunEngineWorker(Process):
         # Class that supports communication over the pipe
         self._comm_to_manager = None
 
+        # The reference for device progress update stream
+        self._device_progress_stream = None
+
         # Note: 'self._config' is a private attribute of 'multiprocessing.Process'. Overriding
         #   this variable may lead to unpredictable and hard to debug issues.
         self._config_dict = config or {}
@@ -251,9 +254,14 @@ class RunEngineWorker(Process):
         try:
             from .plan_monitoring import WatcherStreamManager
 
-            self._watcher_stream = WatcherStreamManager(msg_queue=self._msg_queue)
-            self._RE.waiting_hook = self._watcher_stream
-            logger.info("Progress streaming is enabled (RE.waiting_hook is set).")
+            if not isinstance(self._device_progress_stream, WatcherStreamManager):
+                if not self._device_progress_stream:
+                    self._device_progress_stream = WatcherStreamManager(msg_queue=self._msg_queue)
+                    self._device_progress_stream.waiting_hook = self._RE.waiting_hook
+                else:
+                    self._device_progress_stream.waiting_hook = self._RE.waiting_hook
+                self._RE.waiting_hook = self._device_progress_stream
+                logger.info("Progress streaming is enabled (RE.waiting_hook is set).")
         except Exception as ex:
             logger.warning("Failed to set up progress streaming: %s", ex)
 
@@ -263,6 +271,7 @@ class RunEngineWorker(Process):
         is used exclusively to pass data between threads and may contain at most 1 element.
         This is not a plan queue. The function is expected to run in the main thread.
         """
+        self._setup_waiting_hook()
         if exec_option == ExecOption.TASK:
             self._execute_task(parameters, exec_option)
         else:
@@ -836,7 +845,6 @@ class RunEngineWorker(Process):
         if update_re:
             if ("RE" in self._re_namespace) and (self._RE != self._re_namespace["RE"]):
                 self._RE = self._re_namespace["RE"]
-                self._setup_waiting_hook()
                 logger.info("Run Engine instance ('RE') was replaced.")
 
         if update_lists:
@@ -1485,7 +1493,6 @@ class RunEngineWorker(Process):
 
                 # Copy reference to Run Engine from the namespace. Set to None if RE does not exist.
                 self._RE = self._re_namespace.get("RE", None)
-                self._setup_waiting_hook()
 
                 self._execution_queue = queue.Queue()
 

--- a/src/bluesky_queueserver/manager/worker.py
+++ b/src/bluesky_queueserver/manager/worker.py
@@ -246,7 +246,7 @@ class RunEngineWorker(Process):
         """
         if self._RE is None or self._msg_queue is None:
             return
-        if not self._config_dict.get("zmq_publish_progress", True):
+        if not self._config_dict.get("zmq_publish_device_progress", True):
             return
         try:
             from .plan_monitoring import WatcherStreamManager

--- a/src/bluesky_queueserver/manager/worker.py
+++ b/src/bluesky_queueserver/manager/worker.py
@@ -239,6 +239,24 @@ class RunEngineWorker(Process):
 
         return value
 
+    def _setup_waiting_hook(self):
+        """
+        Set up the ``WatcherStreamManager`` as the RunEngine's ``waiting_hook`` if progress
+        streaming is enabled and the RunEngine and message queue are available.
+        """
+        if self._RE is None or self._msg_queue is None:
+            return
+        if not self._config_dict.get("progress_streaming", True):
+            return
+        try:
+            from .plan_monitoring import WatcherStreamManager
+
+            self._watcher_stream = WatcherStreamManager(msg_queue=self._msg_queue)
+            self._RE.waiting_hook = self._watcher_stream
+            logger.info("Progress streaming is enabled (RE.waiting_hook is set).")
+        except Exception as ex:
+            logger.warning("Failed to set up progress streaming: %s", ex)
+
     def _execute_plan_or_task(self, parameters, exec_option):
         """
         Execute a plan or a task pulled from ``self._execution_queue``. Note, that the queue
@@ -818,6 +836,7 @@ class RunEngineWorker(Process):
         if update_re:
             if ("RE" in self._re_namespace) and (self._RE != self._re_namespace["RE"]):
                 self._RE = self._re_namespace["RE"]
+                self._setup_waiting_hook()
                 logger.info("Run Engine instance ('RE') was replaced.")
 
         if update_lists:
@@ -1466,6 +1485,7 @@ class RunEngineWorker(Process):
 
                 # Copy reference to Run Engine from the namespace. Set to None if RE does not exist.
                 self._RE = self._re_namespace.get("RE", None)
+                self._setup_waiting_hook()
 
                 self._execution_queue = queue.Queue()
 

--- a/src/bluesky_queueserver/manager/worker.py
+++ b/src/bluesky_queueserver/manager/worker.py
@@ -254,14 +254,14 @@ class RunEngineWorker(Process):
         try:
             from .plan_monitoring import WatcherStreamManager
 
-            if not isinstance(self._device_progress_stream, WatcherStreamManager):
-                if not self._device_progress_stream:
-                    self._device_progress_stream = WatcherStreamManager(msg_queue=self._msg_queue)
-                    self._device_progress_stream.waiting_hook = self._RE.waiting_hook
-                else:
-                    self._device_progress_stream.waiting_hook = self._RE.waiting_hook
+            if not self._device_progress_stream:
+                self._device_progress_stream = WatcherStreamManager(msg_queue=self._msg_queue)
+
+            if self._RE.waiting_hook != self._device_progress_stream:
+                self._device_progress_stream.waiting_hook = self._RE.waiting_hook
                 self._RE.waiting_hook = self._device_progress_stream
                 logger.info("Progress streaming is enabled (RE.waiting_hook is set).")
+
         except Exception as ex:
             logger.warning("Failed to set up progress streaming: %s", ex)
 
@@ -271,10 +271,10 @@ class RunEngineWorker(Process):
         is used exclusively to pass data between threads and may contain at most 1 element.
         This is not a plan queue. The function is expected to run in the main thread.
         """
-        self._setup_waiting_hook()
         if exec_option == ExecOption.TASK:
             self._execute_task(parameters, exec_option)
         else:
+            self._setup_waiting_hook()
             self._execute_plan(parameters, exec_option)
 
     def _execute_plan(self, parameters, exec_option):
@@ -845,6 +845,7 @@ class RunEngineWorker(Process):
         if update_re:
             if ("RE" in self._re_namespace) and (self._RE != self._re_namespace["RE"]):
                 self._RE = self._re_namespace["RE"]
+                self._setup_waiting_hook()
                 logger.info("Run Engine instance ('RE') was replaced.")
 
         if update_lists:
@@ -1493,6 +1494,7 @@ class RunEngineWorker(Process):
 
                 # Copy reference to Run Engine from the namespace. Set to None if RE does not exist.
                 self._RE = self._re_namespace.get("RE", None)
+                self._setup_waiting_hook()
 
                 self._execution_queue = queue.Queue()
 

--- a/src/bluesky_queueserver/manager/worker.py
+++ b/src/bluesky_queueserver/manager/worker.py
@@ -246,7 +246,7 @@ class RunEngineWorker(Process):
         """
         if self._RE is None or self._msg_queue is None:
             return
-        if not self._config_dict.get("progress_streaming", True):
+        if not self._config_dict.get("zmq_publish_progress", True):
             return
         try:
             from .plan_monitoring import WatcherStreamManager

--- a/src/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/src/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -43,6 +43,7 @@ user_groups:
     allowed_functions:
       - ":element$"
       - ":elements$"
+      - ":^unit_test"
       - "function_sleep"
       - "clear_buffer"
     forbidden_functions:

--- a/src/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/src/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -24,6 +24,7 @@ user_groups:
     allowed_functions:
       - "function_sleep"  # Explicitly listed name
       - ":^func_for_test"
+      - ":^unit_test"      
   test_user:  # Another group used for unit tests.
     allowed_plans:
       - ":^count"  # Use regular expression patterns
@@ -44,6 +45,5 @@ user_groups:
       - ":elements$"
       - "function_sleep"
       - "clear_buffer"
-      - ":^unit_test.*$"
     forbidden_functions:
       - ":^_"  # All functions with names starting with '_'

--- a/src/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
+++ b/src/bluesky_queueserver/profile_collection_sim/user_group_permissions.yaml
@@ -28,6 +28,7 @@ user_groups:
     allowed_plans:
       - ":^count"  # Use regular expression patterns
       - ":scan$"
+      - "mv"  # Use full plan name
     forbidden_plans:
       - ":^adaptive_scan$" # Use regular expression patterns
       - ":^inner_product"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Resolves #353. Adds an additional keyed stream to the info zmq topic for streaming RE waiting hook progress updates. Adds additional CLI/config options to enable the feature + a waiting hook compatible class that posts the updates from the RE to zmq. Clients can then use these updates to construct progress bars and the like.

## Motivation and Context
Currently, a common piece of feedback from BL staff that use queueserver is that there isn't enough feedback on the state of a scan as it is taking place. Being able to re-create something similar to the bluesky `ProgressBarManager` by using streamed RE updates should ameliorate this issue.

## Summary of Changes for Release Notes
### Fixed

### Added
- Implementation for streaming of device progress data.
- Additional CLI parameter of `start-re-manager`: `--zmq-stream-device-progress` and `network/zmq_stream_device_progress` config file equivalent.

### Changed
- Separate CLI parameter for controlling Info message publishing: `--zmq_publish_info` (`network/zmq_publish_info` config file parameter).

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
Added unit tests, and explicit local integration test
