### PR TITLE
Fix for leaking file descriptors in unit tests

### DIFF
--- a/src/bluesky_queueserver/manager/comms.py
+++ b/src/bluesky_queueserver/manager/comms.py
@@ -922,7 +922,6 @@ class ZMQCommSendThreads:
             self._ctx.term()
             self._ctx = None
 
-
     def _zmq_socket_restart(self):
         """
         Restart (close and open the socket). Should be called in case of communication

--- a/src/bluesky_queueserver/manager/comms.py
+++ b/src/bluesky_queueserver/manager/comms.py
@@ -694,7 +694,7 @@ class ZMQCommSendThreads:
         zmq_server_address = zmq_server_address or default_zmq_control_address
 
         # ZeroMQ communication
-        self._ctx = zmq.Context()
+        self._ctx = None
         self._zmq_socket = None
         self._zmq_server_address = zmq_server_address
 
@@ -888,6 +888,7 @@ class ZMQCommSendThreads:
         """
         Open ZMQ socket.
         """
+        self._ctx = zmq.Context()
         self._zmq_socket = self._ctx.socket(zmq.REQ)
 
         if self._server_public_key:
@@ -910,12 +911,24 @@ class ZMQCommSendThreads:
         logger.info("Connected to ZeroMQ server '%s'", self._zmq_server_address)
         logger.info("ZMQ encryption: %s", "disabled" if self._server_public_key is None else "enabled")
 
+    def _zmq_socket_close(self):
+        """
+        Close ZMQ socket.
+        """
+        if self._zmq_socket is not None:
+            self._zmq_socket.close()
+            self._zmq_socket = None
+        if self._ctx is not None:
+            self._ctx.term()
+            self._ctx = None
+
+
     def _zmq_socket_restart(self):
         """
         Restart (close and open the socket). Should be called in case of communication
         error (e.g. the server did not return the response).
         """
-        self._zmq_socket.close()
+        self._zmq_socket_close()
         self._zmq_socket_open()
 
     def _create_msg(self, *, method, params=None):
@@ -996,9 +1009,8 @@ class ZMQCommSendThreads:
         Close ZMQ socket. Call to close socket if the object is no longer needed, but may
         not be destroyed for some time.
         """
-        if self._zmq_socket is not None:
-            self._zmq_socket.close()
         self._thread_running = False
+        self._zmq_socket_close()
 
 
 class ZMQCommSendAsync:
@@ -1070,7 +1082,7 @@ class ZMQCommSendAsync:
         self._raise_exceptions = raise_exceptions
 
         # ZeroMQ communication
-        self._ctx = zmq.asyncio.Context()
+        self._ctx = None
         self._zmq_socket = None
         self._zmq_server_address = zmq_server_address
 
@@ -1127,6 +1139,7 @@ class ZMQCommSendAsync:
         return msg_in
 
     def _zmq_socket_open(self):
+        self._ctx = zmq.asyncio.Context()
         self._zmq_socket = self._ctx.socket(zmq.REQ)
 
         if self._server_public_key:
@@ -1149,8 +1162,16 @@ class ZMQCommSendAsync:
         logger.info("Connected to ZeroMQ server '%s'", self._zmq_server_address)
         logger.info("ZMQ encryption: %s", "disabled" if self._server_public_key is None else "enabled")
 
+    def _zmq_socket_close(self):
+        if self._zmq_socket is not None:
+            self._zmq_socket.close()
+            self._zmq_socket = None
+        if self._ctx is not None:
+            self._ctx.term()
+            self._ctx = None
+
     def _zmq_socket_restart(self):
-        self._zmq_socket.close()
+        self._zmq_socket_close()
         self._zmq_socket_open()
 
     def _create_msg(self, *, method, params=None):
@@ -1216,8 +1237,7 @@ class ZMQCommSendAsync:
         Close ZMQ socket. Call to close socket if the object is no longer needed, but may
         not be destroyed for some time.
         """
-        if self._zmq_socket:
-            self._zmq_socket.close()
+        self._zmq_socket_close()
 
 
 def zmq_single_request(

--- a/src/bluesky_queueserver/manager/output_streaming.py
+++ b/src/bluesky_queueserver/manager/output_streaming.py
@@ -178,11 +178,12 @@ class PublishZMQStreamOutput:
         self._zmq_topic_console = zmq_topic_console
         self._zmq_topic_info = zmq_topic_info
 
+        self._context = None
         self._socket = None
         if self._zmq_publish_on:
             try:
-                context = zmq.Context()
-                self._socket = context.socket(zmq.PUB)
+                self._context = zmq.Context()
+                self._socket = self._context.socket(zmq.PUB)
                 self._socket.bind(self._zmq_publish_addr)
             except Exception as ex:
                 logger.error(
@@ -210,6 +211,8 @@ class PublishZMQStreamOutput:
         self.stop()
         if self._socket:
             self._socket.close()
+        if self._context:
+            self._context.term()
 
     def _start_processing_thread(self):
         # The thread should not be started of Message Queue object does not exist
@@ -321,12 +324,13 @@ class _ReceiveZMQStreamOutput:
 
         self._encoding = process_zmq_encoding_name(encoding)
 
+        self._context = None
         self._socket = None
         self._socket_subscribed = False
 
         if self._zmq_subscribe_addr:
-            context = zmq.Context()
-            self._socket = context.socket(zmq.SUB)
+            self._context = zmq.Context()
+            self._socket = self._context.socket(zmq.SUB)
             self._socket.connect(self._zmq_subscribe_addr)
 
     def subscribe(self):
@@ -392,7 +396,10 @@ class _ReceiveZMQStreamOutput:
         return payload
 
     def __del__(self):
-        self._socket.close()
+        if self._socket:
+            self._socket.close()
+        if self._context:
+            self._context.term()
 
 
 class ReceiveConsoleOutput(_ReceiveZMQStreamOutput):
@@ -543,13 +550,14 @@ class _ReceiveZMQStreamOutputAsync:
 
         self._encoding = process_zmq_encoding_name(encoding)
 
+        self._context = None
         self._socket = None
         self._socket_subscribed = False
         self._unsubscribe_when_stopping = False
 
         if self._zmq_subscribe_addr:
-            context = zmq.asyncio.Context()
-            self._socket = context.socket(zmq.SUB)
+            self._context = zmq.asyncio.Context()
+            self._socket = self._context.socket(zmq.SUB)
             self._socket.connect(self._zmq_subscribe_addr)
 
     def subscribe(self):
@@ -683,6 +691,8 @@ class _ReceiveZMQStreamOutputAsync:
         self.stop()
         if self._socket:
             self._socket.close()
+        if self._context:
+            self._context.term()
 
 
 class ReceiveConsoleOutputAsync(_ReceiveZMQStreamOutputAsync):

--- a/src/bluesky_queueserver/manager/tests/conftest.py
+++ b/src/bluesky_queueserver/manager/tests/conftest.py
@@ -21,13 +21,12 @@ def close_dangling_event_loops():
     Dangling loops are mostly due to RE instances loaded as part of startup script.
     RE does not explicitly stop the running loop.
     """
-    import asyncio, gc
+    import asyncio
+    import gc
+
     yield
     gc.collect()
-    loops = [
-        obj for obj in gc.get_objects()
-        if isinstance(obj, asyncio.AbstractEventLoop) and not obj.is_closed()
-    ]
+    loops = [obj for obj in gc.get_objects() if isinstance(obj, asyncio.AbstractEventLoop) and not obj.is_closed()]
     for loop in loops:
         if loop.is_running():
             loop.call_soon_threadsafe(loop.stop)
@@ -55,5 +54,6 @@ def print_open_file_descriptors(request):
             tty.write("\n" + msg + "\n")
     except OSError:
         import sys
+
         sys.stderr.write("\n" + msg + "\n")
         sys.stderr.flush()

--- a/src/bluesky_queueserver/manager/tests/conftest.py
+++ b/src/bluesky_queueserver/manager/tests/conftest.py
@@ -6,6 +6,38 @@ import pytest
 from bluesky_queueserver.manager.profile_ops import clear_registered_items
 
 
+@pytest.fixture(autouse=True)
+def setup_and_teardown_for_every_test():
+    print("Clearing registered items ...")
+    clear_registered_items()
+    yield
+    print("Clearing registered items ...")
+    clear_registered_items()
+
+
+@pytest.fixture(autouse=True)
+def close_dangling_event_loops():
+    """
+    Dangling loops are mostly due to RE instances loaded as part of startup script.
+    RE does not explicitly stop the running loop.
+    """
+    import asyncio, gc
+    yield
+    gc.collect()
+    loops = [
+        obj for obj in gc.get_objects()
+        if isinstance(obj, asyncio.AbstractEventLoop) and not obj.is_closed()
+    ]
+    for loop in loops:
+        if loop.is_running():
+            loop.call_soon_threadsafe(loop.stop)
+    if loops:
+        ttime.sleep(0.1)  # allow running loops to stop before closing
+    for loop in loops:
+        if not loop.is_closed() and not loop.is_running():
+            loop.close()
+
+
 @pytest.fixture(scope="session", autouse=True)
 def print_open_file_descriptors():
     yield
@@ -23,12 +55,3 @@ def print_open_file_descriptors():
 
         sys.stderr.write(msg)
         sys.stderr.flush()
-
-
-@pytest.fixture(autouse=True)
-def setup_and_teardown_for_every_test():
-    print("Clearing registered items ...")
-    clear_registered_items()
-    yield
-    print("Clearing registered items ...")
-    clear_registered_items()

--- a/src/bluesky_queueserver/manager/tests/conftest.py
+++ b/src/bluesky_queueserver/manager/tests/conftest.py
@@ -39,19 +39,21 @@ def close_dangling_event_loops():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def print_open_file_descriptors():
+def print_open_file_descriptors(request):
     yield
     ttime.sleep(1)
     pid = os.getpid()
     fd_dir = f"/proc/{pid}/fd"
     fd_entries = sorted(os.listdir(fd_dir), key=int)
-    msg = f"\n+++ PID={pid} OPEN FILE DESCRIPTORS = {len(fd_entries)}\n"
-    # /dev/tty bypasses all pytest capture layers
+    msg = f"+++ PID={pid} OPEN FILE DESCRIPTORS = {len(fd_entries)}"
+    # terminalreporter works on CI (it is supposed to work locally, but it doesn't)
+    reporter = request.config.pluginmanager.get_plugin("terminalreporter")
+    reporter.write_line(msg)
+    # /dev/tty bypasses all pytest capture layers (local use only)
     try:
         with open("/dev/tty", "w") as tty:
-            tty.write(msg)
+            tty.write("\n" + msg + "\n")
     except OSError:
         import sys
-
-        sys.stderr.write(msg)
+        sys.stderr.write("\n" + msg + "\n")
         sys.stderr.flush()

--- a/src/bluesky_queueserver/manager/tests/conftest.py
+++ b/src/bluesky_queueserver/manager/tests/conftest.py
@@ -1,6 +1,28 @@
+import os
+import time as ttime
+
 import pytest
 
 from bluesky_queueserver.manager.profile_ops import clear_registered_items
+
+
+@pytest.fixture(scope="session", autouse=True)
+def print_open_file_descriptors():
+    yield
+    ttime.sleep(1)
+    pid = os.getpid()
+    fd_dir = f"/proc/{pid}/fd"
+    fd_entries = sorted(os.listdir(fd_dir), key=int)
+    msg = f"\n+++ PID={pid} OPEN FILE DESCRIPTORS = {len(fd_entries)}\n"
+    # /dev/tty bypasses all pytest capture layers
+    try:
+        with open("/dev/tty", "w") as tty:
+            tty.write(msg)
+    except OSError:
+        import sys
+
+        sys.stderr.write(msg)
+        sys.stderr.flush()
 
 
 @pytest.fixture(autouse=True)

--- a/src/bluesky_queueserver/manager/tests/test_comms.py
+++ b/src/bluesky_queueserver/manager/tests/test_comms.py
@@ -952,6 +952,7 @@ def _zmq_server_1msg(*, private_key=None, encoding="json"):
     _zmq_send(msg_out, zmq_socket, encoding=encoding)
 
     zmq_socket.close(linger=10)
+    ctx.term()
 
 
 # fmt: off
@@ -999,6 +1000,7 @@ def test_ZMQCommSendThreads_1(is_blocking, encryption_enabled, encoding):
     assert msg_recv_err == ""
 
     thread.join()
+    zmq_comm.close()
 
 
 def _zmq_server_2msg(*, private_key=None, encoding="json"):
@@ -1025,6 +1027,7 @@ def _zmq_server_2msg(*, private_key=None, encoding="json"):
     _zmq_send(msg_out, zmq_socket, encoding=encoding)
 
     zmq_socket.close(linger=10)
+    ctx.term()
 
 
 # fmt: off
@@ -1073,6 +1076,7 @@ def test_ZMQCommSendThreads_2(is_blocking, encryption_enabled, encoding):
         assert msg_recv_err == ""
 
     thread.join()
+    zmq_comm.close()
 
 
 def _zmq_server_2msg_delay1(*, private_key=None, encoding="json"):
@@ -1100,6 +1104,7 @@ def _zmq_server_2msg_delay1(*, private_key=None, encoding="json"):
     _zmq_send(msg_out, zmq_socket, encoding=encoding)
 
     zmq_socket.close(linger=10)
+    ctx.term()
 
 
 # fmt: off
@@ -1169,6 +1174,7 @@ def test_ZMQCommSendThreads_3(is_blocking, encryption_enabled, encoding):
         assert msg_recv_err[n] == ""
 
     thread.join()
+    zmq_comm.close()
 
 
 def _zmq_server_delay2(*, private_key=None, encoding="json"):
@@ -1196,6 +1202,7 @@ def _zmq_server_delay2(*, private_key=None, encoding="json"):
     _zmq_send(msg_out, zmq_socket, encoding=encoding)
 
     zmq_socket.close(linger=10)
+    ctx.term()
 
 
 # fmt: off
@@ -1272,6 +1279,7 @@ def test_ZMQCommSendThreads_4(is_blocking, raise_exception, delay_between_reads,
             assert msg_recv_err == ""
 
     thread.join()
+    zmq_comm.close()
 
 
 def _zmq_server_delay3(delay, encoding="json"):
@@ -1289,6 +1297,7 @@ def _zmq_server_delay3(delay, encoding="json"):
     _zmq_send(msg_out, zmq_socket, encoding=encoding)
 
     zmq_socket.close(linger=10)
+    ctx.term()
 
 
 # fmt: off
@@ -1317,6 +1326,7 @@ def test_ZMQCommSendThreads_5(timeout, encoding):
         assert msg_recv["success"] is True, pprint.pformat(msg_recv)
 
     thread.join()
+    zmq_comm.close()
 
 
 def test_ZMQCommSendThreads_6_fail():
@@ -1364,6 +1374,8 @@ def test_ZMQCommSendAsync_1(encryption_enabled, encoding):
         assert msg_recv["some_data"] == 10, str(msg_recv)
         assert msg_recv["msg_in"] == {"method": method, "params": params}, str(msg_recv)
 
+        zmq_comm.close()
+
     asyncio.run(testing())
 
     thread.join()
@@ -1397,6 +1409,8 @@ def test_ZMQCommSendAsync_2(encryption_enabled, encoding):
             assert msg_recv["success"] is True, str(msg_recv)
             assert msg_recv["some_data"] == val, str(msg_recv)
             assert msg_recv["msg_in"] == {"method": method, "params": params}, str(msg_recv)
+
+        zmq_comm.close()
 
     asyncio.run(testing())
 
@@ -1444,6 +1458,8 @@ def test_ZMQCommSendAsync_3(encryption_enabled, encoding):
             assert res["success"] is True, str(res)
             assert res["some_data"] == val, str(res)
             assert res["msg_in"] == {"method": method, "params": params}, str(res)
+
+        zmq_comm.close()
 
     asyncio.run(testing())
 
@@ -1508,6 +1524,8 @@ def test_ZMQCommSendAsync_4(raise_exception, delay_between_reads, encryption_ena
                 assert msg_recv["msg_in"] == {"method": method, "params": params}, str(msg_recv)
                 assert msg_recv_err == ""
 
+        zmq_comm.close()
+
     asyncio.run(testing())
 
     thread.join()
@@ -1542,6 +1560,8 @@ def test_ZMQCommSendAsync_5(timeout, encoding):
                 method=method, params=params, timeout=timeout, raise_exceptions=True
             )
             assert msg_recv["success"] is True, pprint.pformat(msg_recv)
+
+        zmq_comm.close()
 
     asyncio.run(testing())
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This is a maintenance PR, which fixes a number of small issues that caused large number of leaked file descriptors while running the unit tests. The changes are not expected to have any noticeable effect on the users.

A session scope fixture was added that prints the number of open file descriptors after completion of the test suite. The number can be periodically check to make sure tests are not leaking large number of descriptors.
