### PR TITLE
Prevent standard packages from being recognized as local imports

### DIFF
--- a/src/bluesky_queueserver/manager/profile_ops.py
+++ b/src/bluesky_queueserver/manager/profile_ops.py
@@ -456,7 +456,10 @@ def load_startup_script(script_path, *, enable_local_imports=True, nspace=None):
                     # Make sure the module is local before deleting it.
                     # Do not delete common library modules.
                     fl = getattr(sys.modules[key], "__file__", None)
-                    if fl and fl.startswith(p):
+                    # In case 'venv' or '.pixi' directories are in the startup directory, then
+                    #   standard packages can also be recognized as 'local' and removed, which leads
+                    #   to annoying issues. Thus skip the packages with 'site-packages' in the path.
+                    if fl and fl.startswith(p) and "site-packages" not in fl:
                         # print(f"Deleting the key '{key}'")
                         del sys.modules[key]
 
@@ -660,7 +663,10 @@ def load_script_into_existing_nspace(
                     # Make sure the module is local before deleting it.
                     # Do not delete common library modules.
                     fl = getattr(sys.modules[key], "__file__", None)
-                    if fl and fl.startswith(script_root_path):
+                    # In case 'venv' or '.pixi' directories are in the startup directory, then
+                    #   standard packages can also be recognized as 'local' and removed, which leads
+                    #   to annoying issues. Thus skip the packages with 'site-packages' in the path.
+                    if fl and fl.startswith(script_root_path) and "site-packages" not in fl:
                         # print(f"Deleting the key '{key}'")
                         del sys.modules[key]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

If a virtual environment (`venv`, `.pixi`) resides inside the startup script or startup directory, and local imports are enabled, standard packages imported by the startup code (e.g. `numpy`) may be incorrectly removed from `sys.modules` during cleanup. Any subsequent attempt to re-import such packages fails in Python 3.13 due to restrictions on reloading C extensions. This PR fixes the issue by skipping modules whose path contains site-packages during the local module cleanup step.

In general it is recommended that in production environments the startup code is placed in dedicated directory instead of the root `/` directory of the container. This may help avoid such issues.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Addresses the issue https://github.com/bluesky/bluesky-queueserver/issues/347

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- Prevent standard packages from being recognized as local imports.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
