### PR TITLE
Add plan return result information to history (when serializable)

### DIFF
--- a/docs/source/manager_config.rst
+++ b/docs/source/manager_config.rst
@@ -76,6 +76,10 @@ Several parameters can be passed to RE Manager using environment variables:
   - ``QSERVER_EMERGENCY_LOCK_KEY_FOR_SERVER`` - emergency lock key used to unlock RE Manager
     if the lock key set by a user is lost. The key may also be set in the config file.
 
+  - ``QSERVER_CAPTURE_PLAN_RETURN_VALUES`` - enables or disables capture of terminal values returned
+    by plans. The default is ``false``. The value may also be set in the ``operation`` section
+    of the configuration file.
+
   - ``QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER`` - private key used to decrypt control messages sent
     by clients. **Using environment variables may be preferred way of setting the public key.**
     Alternatively, the private key may be set in the config file by referencing a different
@@ -144,6 +148,7 @@ most of the supported parameters:
       print_console_output: true
       console_logging_level: NORMAL
       update_existing_plans_and_devices: ENVIRONMENT_OPEN
+      capture_plan_return_values: false
       user_group_permissions_reload: ON_REQUEST
       emergency_lock_key: custom_lock_key
     worker:
@@ -262,6 +267,11 @@ The parameters that define run-time behavior of RE Manager:
   lists (``'NEVER'``), update the lists when the environment is opened
   (``'ENVIRONMENT_OPEN'``, default) or update the lists each the lists are changed (``'ALWAYS'``).
   The value may be set using ``--update-existing-plans-devices`` parameter.
+
+- ``capture_plan_return_values`` - enables capture of terminal values returned by completed plans and
+  stores them in plan history. The default is ``false``. If enabled, the value may be set using
+  environment variable ``QSERVER_CAPTURE_PLAN_RETURN_VALUES``. Restart RE Manager after changing
+  the setting.
 
 - ``user_group_permissions_reload`` - select when user group permissions are reloaded from disk.
   Options: ``'NEVER'`` - RE Manager never attempts to load permissions from disk file.

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -654,6 +654,9 @@ Returns       **success**: *boolean*
 
                   - **traceback** - full traceback if the plan failed, empty string otherwise.
 
+                  If ``capture_plan_return_values`` is enabled, newly finalized history items contain the
+                  following keys:
+
                   - **return_value** - JSON-normalized terminal return value of a plan with **exit_status**
                     **'completed'**. *None* is a valid plan return and is also used for plans without a completed
                     return value.
@@ -661,7 +664,8 @@ Returns       **success**: *boolean*
                   - **return_value_error** - empty string if the return value was retained; otherwise, the
                     JSON-serialization diagnostic while the plan remains completed.
 
-                  History items created before these fields were added may not contain either key.
+                  History items created while capture is disabled or before these fields were added do not contain
+                  either key.
 
               **plan_history_uid**: *str*
                   current plan history UID.

--- a/docs/source/re_manager_api.rst
+++ b/docs/source/re_manager_api.rst
@@ -654,6 +654,15 @@ Returns       **success**: *boolean*
 
                   - **traceback** - full traceback if the plan failed, empty string otherwise.
 
+                  - **return_value** - JSON-normalized terminal return value of a plan with **exit_status**
+                    **'completed'**. *None* is a valid plan return and is also used for plans without a completed
+                    return value.
+
+                  - **return_value_error** - empty string if the return value was retained; otherwise, the
+                    JSON-serialization diagnostic while the plan remains completed.
+
+                  History items created before these fields were added may not contain either key.
+
               **plan_history_uid**: *str*
                   current plan history UID.
 ------------  -----------------------------------------------------------------------------------------

--- a/docs/source/release_history.rst
+++ b/docs/source/release_history.rst
@@ -20,6 +20,9 @@ Added
   The option can be set using CLI parameter ``--permitted-re-metadata-keys`` or environment variable
   ``QSERVER_PERMITTED_RE_METADATA_KEYS``.
 
+- Optional capture of terminal plan return values in ``history_get`` records. Enable it with
+  ``operation/capture_plan_return_values`` or ``QSERVER_CAPTURE_PLAN_RETURN_VALUES``.
+
 - Support for Python 3.14
 
 Fixed

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -224,11 +224,13 @@ completion status, error message and traceback in case of failure). The plan his
 :ref:`method_history_get` API and cleared using :ref:`method_history_clear` API. Plan history is not designed
 to grow indefinitely and should be periodically cleared in order to avoid performance issues.
 
-To retrieve a plan return value, preserve the **item_uid** returned when the queue item is accepted. Monitor
-**plan_history_uid** in :ref:`method_status` until it changes, then call :ref:`method_history_get` and select the
-history item with the matching **item_uid** rather than assuming the last item belongs to the submitted plan. Read
-**result.return_value** and **result.return_value_error** from that item. The ``qserver history get`` command already
-prints the complete :ref:`method_history_get` response.
+To enable plan-return capture, set ``operation.capture_plan_return_values: true`` in the RE Manager configuration
+file or set ``QSERVER_CAPTURE_PLAN_RETURN_VALUES`` to a true boolean value before starting RE Manager. Preserve the
+**item_uid** returned when the queue item is accepted. Monitor **plan_history_uid** in :ref:`method_status` until it
+changes, then call :ref:`method_history_get` and select the history item with the matching **item_uid** rather than
+assuming the last item belongs to the submitted plan. Read **result.return_value** and
+**result.return_value_error** from that item. The ``qserver history get`` command already prints the complete
+:ref:`method_history_get` response.
 
 Controlling Execution of the Queue and the Plans
 ------------------------------------------------

--- a/docs/source/using_queue_server.rst
+++ b/docs/source/using_queue_server.rst
@@ -224,6 +224,12 @@ completion status, error message and traceback in case of failure). The plan his
 :ref:`method_history_get` API and cleared using :ref:`method_history_clear` API. Plan history is not designed
 to grow indefinitely and should be periodically cleared in order to avoid performance issues.
 
+To retrieve a plan return value, preserve the **item_uid** returned when the queue item is accepted. Monitor
+**plan_history_uid** in :ref:`method_status` until it changes, then call :ref:`method_history_get` and select the
+history item with the matching **item_uid** rather than assuming the last item belongs to the submitted plan. Read
+**result.return_value** and **result.return_value_error** from that item. The ``qserver history get`` command already
+prints the complete :ref:`method_history_get` response.
+
 Controlling Execution of the Queue and the Plans
 ------------------------------------------------
 

--- a/src/bluesky_queueserver/manager/config.py
+++ b/src/bluesky_queueserver/manager/config.py
@@ -212,6 +212,7 @@ _key_mapping = {
     "print_console_output": "operation/print_console_output",
     "console_logging_level": "operation/console_logging_level",
     "update_existing_plans_devices": "operation/update_existing_plans_and_devices",
+    "capture_plan_return_values": "operation/capture_plan_return_values",
     "user_group_permissions_reload": "operation/user_group_permissions_reload",
     "emergency_lock_key": "operation/emergency_lock_key",
 }
@@ -563,6 +564,11 @@ class Settings:
             value_default=args.update_existing_plans_devices,
             value_config=self._get_value_from_config("update_existing_plans_devices"),
             value_cli=self._args_existing("update_existing_plans_devices"),
+        )
+        self._settings["capture_plan_return_values"] = self._get_param_boolean(
+            value_default=False,
+            value_ev=os.environ.get("QSERVER_CAPTURE_PLAN_RETURN_VALUES", None),
+            value_config=self._get_value_from_config("capture_plan_return_values"),
         )
 
         self._settings["user_group_permissions_reload"] = self._get_param(

--- a/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
+++ b/src/bluesky_queueserver/manager/config_schemas/config_schema.yml
@@ -325,6 +325,8 @@ properties:
       update_existing_plans_and_devices:
         type: string
         pattern: "^(NEVER)|(ENVIRONMENT_OPEN)|(ALWAYS)$"
+      capture_plan_return_values:
+        type: boolean
       user_group_permissions_reload:
         type: string
         pattern: "^(NEVER)|(ON_REQUEST)|(ON_STARTUP)"

--- a/src/bluesky_queueserver/manager/manager.py
+++ b/src/bluesky_queueserver/manager/manager.py
@@ -813,20 +813,15 @@ class RunEngineManager(Process):
         else:
             plan_state = plan_report["plan_state"]
             success = plan_report["success"]
-            result = plan_report["result"]
+            return_value = plan_report["return_value"]
+            return_value_error = plan_report["return_value_error"]
             uids = plan_report["uids"]
             scan_ids = plan_report["scan_ids"]
             err_msg = plan_report["err_msg"]
             err_tb = plan_report["traceback"]
             stop_queue = plan_report["stop_queue"]  # Worker tells the manager to stop the queue
 
-            msg_display = result if result else err_msg
-            logger.debug(
-                "Report received from RE Worker:\nplan_state=%s\nsuccess=%s\n%s\n)",
-                plan_state,
-                success,
-                msg_display,
-            )
+            logger.debug("Report received from RE Worker: plan_state=%s, success=%s", plan_state, success)
 
             ignore_failures = self._plan_queue.plan_queue_mode["ignore_failures"]
             continue_failed = (plan_state == "failed") and ignore_failures
@@ -841,13 +836,25 @@ class RunEngineManager(Process):
                 # execution of the queue is stopped. It can be restarted later (failed or
                 # interrupted plan will still be in the queue.
                 await self._plan_queue.set_processed_item_as_completed(
-                    exit_status=plan_state, run_uids=uids, scan_ids=scan_ids, err_msg=err_msg, err_tb=err_tb
+                    exit_status=plan_state,
+                    run_uids=uids,
+                    scan_ids=scan_ids,
+                    err_msg=err_msg,
+                    err_tb=err_tb,
+                    return_value=return_value,
+                    return_value_error=return_value_error,
                 )
                 await self._start_plan_task(stop_queue=stop_queue or bool(immediate_execution))
             elif plan_state in ("failed", "stopped", "aborted", "halted"):
                 # Paused plan was stopped/aborted/halted
                 await self._plan_queue.set_processed_item_as_stopped(
-                    exit_status=plan_state, run_uids=uids, scan_ids=scan_ids, err_msg=err_msg, err_tb=err_tb
+                    exit_status=plan_state,
+                    run_uids=uids,
+                    scan_ids=scan_ids,
+                    err_msg=err_msg,
+                    err_tb=err_tb,
+                    return_value=return_value,
+                    return_value_error=return_value_error,
                 )
                 self._loop.create_task(self._set_manager_state(MState.IDLE, autostart_disable=True))
             elif plan_state == "paused":

--- a/src/bluesky_queueserver/manager/manager.py
+++ b/src/bluesky_queueserver/manager/manager.py
@@ -813,8 +813,12 @@ class RunEngineManager(Process):
         else:
             plan_state = plan_report["plan_state"]
             success = plan_report["success"]
-            return_value = plan_report["return_value"]
-            return_value_error = plan_report["return_value_error"]
+            return_value_kwargs = {}
+            if self._config_dict["capture_plan_return_values"]:
+                return_value_kwargs = {
+                    "return_value": plan_report["return_value"],
+                    "return_value_error": plan_report["return_value_error"],
+                }
             uids = plan_report["uids"]
             scan_ids = plan_report["scan_ids"]
             err_msg = plan_report["err_msg"]
@@ -841,8 +845,7 @@ class RunEngineManager(Process):
                     scan_ids=scan_ids,
                     err_msg=err_msg,
                     err_tb=err_tb,
-                    return_value=return_value,
-                    return_value_error=return_value_error,
+                    **return_value_kwargs,
                 )
                 await self._start_plan_task(stop_queue=stop_queue or bool(immediate_execution))
             elif plan_state in ("failed", "stopped", "aborted", "halted"):
@@ -853,8 +856,7 @@ class RunEngineManager(Process):
                     scan_ids=scan_ids,
                     err_msg=err_msg,
                     err_tb=err_tb,
-                    return_value=return_value,
-                    return_value_error=return_value_error,
+                    **return_value_kwargs,
                 )
                 self._loop.create_task(self._set_manager_state(MState.IDLE, autostart_disable=True))
             elif plan_state == "paused":

--- a/src/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/src/bluesky_queueserver/manager/plan_queue_ops.py
@@ -1744,7 +1744,9 @@ class PlanQueueOperations:
         async with self._lock:
             return await self._set_next_item_as_running(item=item)
 
-    async def _set_processed_item_as_completed(self, *, exit_status, run_uids, scan_ids, err_msg, err_tb):
+    async def _set_processed_item_as_completed(
+        self, *, exit_status, run_uids, scan_ids, err_msg, err_tb, return_value=None, return_value_error=""
+    ):
         """
         See ``self.set_processed_item_as_completed`` method.
         """
@@ -1772,6 +1774,8 @@ class PlanQueueOperations:
             item_cleaned["result"]["time_stop"] = ttime.time()
             item_cleaned["result"]["msg"] = err_msg
             item_cleaned["result"]["traceback"] = err_tb
+            item_cleaned["result"]["return_value"] = return_value
+            item_cleaned["result"]["return_value_error"] = return_value_error
             await self._clear_running_item_info()
             if not loop_mode and not immediate_execution:
                 self._uid_dict_remove(item["item_uid"])
@@ -1786,7 +1790,9 @@ class PlanQueueOperations:
 
         return item_cleaned
 
-    async def set_processed_item_as_completed(self, *, exit_status, run_uids, scan_ids, err_msg, err_tb):
+    async def set_processed_item_as_completed(
+        self, *, exit_status, run_uids, scan_ids, err_msg, err_tb, return_value=None, return_value_error=""
+    ):
         """
         Moves currently executed item (plan) to history and sets ``exit_status`` key.
         UID is removed from ``self._uid_dict``, so a copy of the item with
@@ -1808,6 +1814,10 @@ class PlanQueueOperations:
             Error message in case of failure.
         err_tb: str
             Traceback in case of failure.
+        return_value: JSON-compatible value
+            Terminal return value of a completed plan.
+        return_value_error: str
+            JSON serialization diagnostic for the plan return value.
 
         Returns
         -------
@@ -1817,10 +1827,18 @@ class PlanQueueOperations:
         """
         async with self._lock:
             return await self._set_processed_item_as_completed(
-                exit_status=exit_status, run_uids=run_uids, scan_ids=scan_ids, err_msg=err_msg, err_tb=err_tb
+                exit_status=exit_status,
+                run_uids=run_uids,
+                scan_ids=scan_ids,
+                err_msg=err_msg,
+                err_tb=err_tb,
+                return_value=return_value,
+                return_value_error=return_value_error,
             )
 
-    async def _set_processed_item_as_stopped(self, *, exit_status, run_uids, scan_ids, err_msg, err_tb):
+    async def _set_processed_item_as_stopped(
+        self, *, exit_status, run_uids, scan_ids, err_msg, err_tb, return_value=None, return_value_error=""
+    ):
         """
         See ``self.set_processed_item_as_stopped()`` method.
         """
@@ -1829,7 +1847,13 @@ class PlanQueueOperations:
             # Stopped item is considered successful, so it is not pushed back to the beginning
             #   of the queue, and it is added to the back of the queue in LOOP mode.
             item_cleaned = await self._set_processed_item_as_completed(
-                exit_status=exit_status, run_uids=run_uids, scan_ids=scan_ids, err_msg=err_msg, err_tb=err_tb
+                exit_status=exit_status,
+                run_uids=run_uids,
+                scan_ids=scan_ids,
+                err_msg=err_msg,
+                err_tb=err_tb,
+                return_value=return_value,
+                return_value_error=return_value_error,
             )
         elif await self._is_item_running():
             item = await self._get_running_item_info()
@@ -1845,6 +1869,8 @@ class PlanQueueOperations:
             item_cleaned["result"]["time_stop"] = ttime.time()
             item_cleaned["result"]["msg"] = err_msg
             item_cleaned["result"]["traceback"] = err_tb
+            item_cleaned["result"]["return_value"] = return_value
+            item_cleaned["result"]["return_value_error"] = return_value_error
 
             await self._add_to_history(item_cleaned)
             await self._clear_running_item_info()
@@ -1866,7 +1892,9 @@ class PlanQueueOperations:
 
         return item_cleaned
 
-    async def set_processed_item_as_stopped(self, *, exit_status, run_uids, scan_ids, err_msg, err_tb):
+    async def set_processed_item_as_stopped(
+        self, *, exit_status, run_uids, scan_ids, err_msg, err_tb, return_value=None, return_value_error=""
+    ):
         """
         A stopped plan is considered successfully completed (if ``exit_status=="stopped"``) or
         failed (otherwise). All items are added to history with respective ``exit_status``.
@@ -1887,6 +1915,10 @@ class PlanQueueOperations:
             Error message in case of failure.
         err_tb: str
             Traceback in case of failure.
+        return_value: JSON-compatible value
+            Terminal return value of a completed plan.
+        return_value_error: str
+            JSON serialization diagnostic for the plan return value.
 
         Returns
         -------
@@ -1897,7 +1929,13 @@ class PlanQueueOperations:
         """
         async with self._lock:
             return await self._set_processed_item_as_stopped(
-                exit_status=exit_status, run_uids=run_uids, scan_ids=scan_ids, err_msg=err_msg, err_tb=err_tb
+                exit_status=exit_status,
+                run_uids=run_uids,
+                scan_ids=scan_ids,
+                err_msg=err_msg,
+                err_tb=err_tb,
+                return_value=return_value,
+                return_value_error=return_value_error,
             )
 
     # =============================================================================================

--- a/src/bluesky_queueserver/manager/plan_queue_ops.py
+++ b/src/bluesky_queueserver/manager/plan_queue_ops.py
@@ -8,6 +8,7 @@ import uuid
 import redis.asyncio
 
 logger = logging.getLogger(__name__)
+_RETURN_VALUE_UNSET = object()
 
 
 class PlanQueueOperations:
@@ -1745,7 +1746,15 @@ class PlanQueueOperations:
             return await self._set_next_item_as_running(item=item)
 
     async def _set_processed_item_as_completed(
-        self, *, exit_status, run_uids, scan_ids, err_msg, err_tb, return_value=None, return_value_error=""
+        self,
+        *,
+        exit_status,
+        run_uids,
+        scan_ids,
+        err_msg,
+        err_tb,
+        return_value=_RETURN_VALUE_UNSET,
+        return_value_error="",
     ):
         """
         See ``self.set_processed_item_as_completed`` method.
@@ -1760,13 +1769,17 @@ class PlanQueueOperations:
             item_time_start = item["properties"]["time_start"]
             item_cleaned = self._clean_item_properties(item)
 
+            item_cleaned.setdefault("result", {})
+            if return_value is _RETURN_VALUE_UNSET:
+                item_cleaned["result"].pop("return_value", None)
+                item_cleaned["result"].pop("return_value_error", None)
             if loop_mode and not immediate_execution:
                 item_to_add = item_cleaned.copy()
+                item_to_add.pop("result", None)
                 item_to_add = self.set_new_item_uuid(item_to_add)
                 await self._r_pool.rpush(self._name_plan_queue, json.dumps(item_to_add))
                 self._uid_dict_remove(item["item_uid"])
                 self._uid_dict_add(item_to_add)
-            item_cleaned.setdefault("result", {})
             item_cleaned["result"]["exit_status"] = exit_status
             item_cleaned["result"]["run_uids"] = run_uids
             item_cleaned["result"]["scan_ids"] = scan_ids
@@ -1774,8 +1787,9 @@ class PlanQueueOperations:
             item_cleaned["result"]["time_stop"] = ttime.time()
             item_cleaned["result"]["msg"] = err_msg
             item_cleaned["result"]["traceback"] = err_tb
-            item_cleaned["result"]["return_value"] = return_value
-            item_cleaned["result"]["return_value_error"] = return_value_error
+            if return_value is not _RETURN_VALUE_UNSET:
+                item_cleaned["result"]["return_value"] = return_value
+                item_cleaned["result"]["return_value_error"] = return_value_error
             await self._clear_running_item_info()
             if not loop_mode and not immediate_execution:
                 self._uid_dict_remove(item["item_uid"])
@@ -1791,7 +1805,15 @@ class PlanQueueOperations:
         return item_cleaned
 
     async def set_processed_item_as_completed(
-        self, *, exit_status, run_uids, scan_ids, err_msg, err_tb, return_value=None, return_value_error=""
+        self,
+        *,
+        exit_status,
+        run_uids,
+        scan_ids,
+        err_msg,
+        err_tb,
+        return_value=_RETURN_VALUE_UNSET,
+        return_value_error="",
     ):
         """
         Moves currently executed item (plan) to history and sets ``exit_status`` key.
@@ -1814,9 +1836,10 @@ class PlanQueueOperations:
             Error message in case of failure.
         err_tb: str
             Traceback in case of failure.
-        return_value: JSON-compatible value
-            Terminal return value of a completed plan.
-        return_value_error: str
+        return_value: JSON-compatible value, optional
+            Terminal return value of a completed plan. Omit the parameter to leave return value fields
+            out of the history item.
+        return_value_error: str, optional
             JSON serialization diagnostic for the plan return value.
 
         Returns
@@ -1837,7 +1860,15 @@ class PlanQueueOperations:
             )
 
     async def _set_processed_item_as_stopped(
-        self, *, exit_status, run_uids, scan_ids, err_msg, err_tb, return_value=None, return_value_error=""
+        self,
+        *,
+        exit_status,
+        run_uids,
+        scan_ids,
+        err_msg,
+        err_tb,
+        return_value=_RETURN_VALUE_UNSET,
+        return_value_error="",
     ):
         """
         See ``self.set_processed_item_as_stopped()`` method.
@@ -1862,6 +1893,9 @@ class PlanQueueOperations:
             item_cleaned = self._clean_item_properties(item)
 
             item_cleaned.setdefault("result", {})
+            if return_value is _RETURN_VALUE_UNSET:
+                item_cleaned["result"].pop("return_value", None)
+                item_cleaned["result"].pop("return_value_error", None)
             item_cleaned["result"]["exit_status"] = exit_status
             item_cleaned["result"]["run_uids"] = run_uids
             item_cleaned["result"]["scan_ids"] = scan_ids
@@ -1869,8 +1903,9 @@ class PlanQueueOperations:
             item_cleaned["result"]["time_stop"] = ttime.time()
             item_cleaned["result"]["msg"] = err_msg
             item_cleaned["result"]["traceback"] = err_tb
-            item_cleaned["result"]["return_value"] = return_value
-            item_cleaned["result"]["return_value_error"] = return_value_error
+            if return_value is not _RETURN_VALUE_UNSET:
+                item_cleaned["result"]["return_value"] = return_value
+                item_cleaned["result"]["return_value_error"] = return_value_error
 
             await self._add_to_history(item_cleaned)
             await self._clear_running_item_info()
@@ -1893,7 +1928,15 @@ class PlanQueueOperations:
         return item_cleaned
 
     async def set_processed_item_as_stopped(
-        self, *, exit_status, run_uids, scan_ids, err_msg, err_tb, return_value=None, return_value_error=""
+        self,
+        *,
+        exit_status,
+        run_uids,
+        scan_ids,
+        err_msg,
+        err_tb,
+        return_value=_RETURN_VALUE_UNSET,
+        return_value_error="",
     ):
         """
         A stopped plan is considered successfully completed (if ``exit_status=="stopped"``) or
@@ -1915,9 +1958,10 @@ class PlanQueueOperations:
             Error message in case of failure.
         err_tb: str
             Traceback in case of failure.
-        return_value: JSON-compatible value
-            Terminal return value of a completed plan.
-        return_value_error: str
+        return_value: JSON-compatible value, optional
+            Terminal return value of a completed plan. Omit the parameter to leave return value fields
+            out of the history item.
+        return_value_error: str, optional
             JSON serialization diagnostic for the plan return value.
 
         Returns

--- a/src/bluesky_queueserver/manager/start_manager.py
+++ b/src/bluesky_queueserver/manager/start_manager.py
@@ -801,6 +801,7 @@ def start_manager():
     config_worker["ignore_invalid_plans"] = settings.ignore_invalid_plans
     config_worker["permitted_re_metadata_keys"] = settings.permitted_re_metadata_keys
     config_worker["zmq_stream_device_progress"] = settings.zmq_stream_device_progress and settings.zmq_publish_info
+    config_worker["capture_plan_return_values"] = settings.capture_plan_return_values
 
     existing_pd_path = settings.existing_plans_and_devices_path
     if not existing_pd_path:
@@ -840,6 +841,7 @@ def start_manager():
 
     config_worker["update_existing_plans_devices"] = settings.update_existing_plans_devices
     config_manager["user_group_permissions_reload"] = settings.user_group_permissions_reload
+    config_manager["capture_plan_return_values"] = settings.capture_plan_return_values
 
     config_manager["zmq_addr"] = settings.zmq_control_addr
     config_manager["zmq_private_key"] = settings.zmq_private_key

--- a/src/bluesky_queueserver/manager/tests/test_config.py
+++ b/src/bluesky_queueserver/manager/tests/test_config.py
@@ -174,6 +174,7 @@ operation:
   print_console_output: true
   console_logging_level: NORMAL
   update_existing_plans_and_devices: ENVIRONMENT_OPEN
+  capture_plan_return_values: true
   user_group_permissions_reload: ON_REQUEST
   emergency_lock_key: some_lock_key
 worker:
@@ -217,6 +218,7 @@ operation:
   console_logging_level: NORMAL
   update_existing_plans_and_devices: ENVIRONMENT_OPEN
   user_group_permissions_reload: ON_REQUEST
+  capture_plan_return_values: true
   emergency_lock_key: some_lock_key
 """
 
@@ -258,6 +260,7 @@ config_01_dict = {
         "console_logging_level": "NORMAL",
         "update_existing_plans_and_devices": "ENVIRONMENT_OPEN",
         "user_group_permissions_reload": "ON_REQUEST",
+        "capture_plan_return_values": True,
         "emergency_lock_key": "some_lock_key",
     },
     "worker": {

--- a/src/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/src/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -2151,6 +2151,8 @@ def test_set_processed_item_as_completed_1():
             plan_history_expected = add_msg_to_plan_history(
                 plan_history_expected, [plan_uids[0]], "Test message", "Traceback"
             )
+            plan_history_expected[0]["result"]["return_value"] = {"value": 1}
+            plan_history_expected[0]["result"]["return_value_error"] = ""
             check_plan_history(plan_history, plan_history_expected)
 
     asyncio.run(testing())
@@ -2411,6 +2413,8 @@ def test_set_processed_item_as_stopped_1():
             plan_history_expected = add_msg_to_plan_history(
                 plan_history_expected, [running_uid2], "Plan stopped", "Traceback 2"
             )
+            plan_history_expected[0]["result"]["return_value"] = None
+            plan_history_expected[0]["result"]["return_value_error"] = "Test return value error"
             check_plan_history(plan_history, plan_history_expected)
 
             # Verify that `_uid_dict` still has correct size. `_uid_dict` should never be accessed directly.

--- a/src/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/src/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -2047,8 +2047,6 @@ def test_set_processed_item_as_completed_1():
             plan["result"]["scan_ids"] = scan_id
             plan["result"]["msg"] = ""
             plan["result"]["traceback"] = ""
-            plan["result"]["return_value"] = None
-            plan["result"]["return_value_error"] = ""
             plans_modified.append(plan)
         return plans_modified
 
@@ -2122,6 +2120,7 @@ def test_set_processed_item_as_completed_1():
                 plan_history_expected, [plan_uids[0]], "Test message", "Traceback"
             )
             plan_history_expected[0]["result"]["return_value"] = {"value": 1}
+            plan_history_expected[0]["result"]["return_value_error"] = ""
             print(plan_history)
             print(plan_history_expected)
             check_plan_history(plan_history, plan_history_expected)
@@ -2142,8 +2141,8 @@ def test_set_processed_item_as_completed_1():
             assert plan["result"]["exit_status"] == "completed"
             assert plan["result"]["run_uids"] == plans_run_uids[1]
             assert plan["result"]["scan_ids"] == plans_scan_ids[1]
-            assert plan["result"]["return_value"] is None
-            assert plan["result"]["return_value_error"] == ""
+            assert "return_value" not in plan["result"]
+            assert "return_value_error" not in plan["result"]
 
             plan_history, _ = await pq.get_history()
             plan_history_expected = add_status_to_plans(
@@ -2222,8 +2221,8 @@ def test_set_processed_item_as_completed_2():
             assert plan["result"]["msg"] == ""
             assert plan["result"]["traceback"] == ""
             assert plan["result"]["time_stop"] > plan["result"]["time_start"]
-            assert plan["result"]["return_value"] is None
-            assert plan["result"]["return_value_error"] == ""
+            assert "return_value" not in plan["result"]
+            assert "return_value_error" not in plan["result"]
 
             # Execute the second plan
             await pq.set_next_item_as_running()
@@ -2247,8 +2246,8 @@ def test_set_processed_item_as_completed_2():
             assert plan["result"]["msg"] == "Unknown exit status"
             assert plan["result"]["traceback"] == "Some traceback"
             assert plan["result"]["time_stop"] > plan["result"]["time_start"]
-            assert plan["result"]["return_value"] is None
-            assert plan["result"]["return_value_error"] == ""
+            assert "return_value" not in plan["result"]
+            assert "return_value_error" not in plan["result"]
 
     asyncio.run(testing())
 
@@ -2287,8 +2286,6 @@ def test_set_processed_item_as_stopped_1():
             plan["result"]["scan_ids"] = scan_id
             plan["result"]["msg"] = ""
             plan["result"]["traceback"] = ""
-            plan["result"]["return_value"] = None
-            plan["result"]["return_value_error"] = ""
             plans_modified.append(plan)
         return plans_modified
 
@@ -2372,6 +2369,7 @@ def test_set_processed_item_as_stopped_1():
             plan_history_expected = add_msg_to_plan_history(
                 plan_history_expected, [running_uid1], "Plan failed", "Traceback"
             )
+            plan_history_expected[0]["result"]["return_value"] = None
             plan_history_expected[0]["result"]["return_value_error"] = "Test return value error"
             check_plan_history(plan_history, plan_history_expected)
 
@@ -2395,8 +2393,8 @@ def test_set_processed_item_as_stopped_1():
             assert plan["result"]["msg"] == "Plan stopped"
             assert plan["result"]["traceback"] == "Traceback 2"
             assert plan["result"]["time_stop"] > plan["result"]["time_start"]
-            assert plan["result"]["return_value"] is None
-            assert plan["result"]["return_value_error"] == ""
+            assert "return_value" not in plan["result"]
+            assert "return_value_error" not in plan["result"]
 
             plan_history, _ = await pq.get_history()
             plan_history_expected = add_status_to_plans(
@@ -2504,8 +2502,8 @@ def test_set_processed_item_as_stopped_2(loop_mode, func, immediate_execution):
                 assert p["result"]["scan_ids"] == plan4_scan_ids
                 assert p["result"]["msg"] == err_msg
                 assert p["result"]["traceback"] == err_tb
-                assert p["result"]["return_value"] is None
-                assert p["result"]["return_value_error"] == ""
+                assert "return_value" not in p["result"]
+                assert "return_value_error" not in p["result"]
                 assert plan["result"]["time_stop"] > plan["result"]["time_start"]
 
             check_plan(plan)
@@ -2559,8 +2557,8 @@ def test_set_processed_item_as_stopped_3(loop_mode, func):
             # assert False, plan1
             assert plan1["name"] == plan["name"]
             assert "properties" not in plan1
-            assert plan1["result"]["return_value"] is None
-            assert plan1["result"]["return_value_error"] == ""
+            assert "return_value" not in plan1["result"]
+            assert "return_value_error" not in plan1["result"]
 
             assert pq.get_queue_size() == 0
             assert pq.get_history_size() == 1

--- a/src/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
+++ b/src/bluesky_queueserver/manager/tests/test_plan_queue_ops.py
@@ -2047,6 +2047,8 @@ def test_set_processed_item_as_completed_1():
             plan["result"]["scan_ids"] = scan_id
             plan["result"]["msg"] = ""
             plan["result"]["traceback"] = ""
+            plan["result"]["return_value"] = None
+            plan["result"]["return_value_error"] = ""
             plans_modified.append(plan)
         return plans_modified
 
@@ -2097,6 +2099,8 @@ def test_set_processed_item_as_completed_1():
                 scan_ids=plans_scan_ids[0],
                 err_msg="Test message",
                 err_tb="Traceback",
+                return_value={"value": 1},
+                return_value_error="",
             )
             assert pq.plan_queue_uid != pq_uid
             assert pq.plan_history_uid != ph_uid
@@ -2107,6 +2111,8 @@ def test_set_processed_item_as_completed_1():
             assert plan["result"]["exit_status"] == "completed"
             assert plan["result"]["run_uids"] == plans_run_uids[0]
             assert plan["result"]["scan_ids"] == plans_scan_ids[0]
+            assert plan["result"]["return_value"] == {"value": 1}
+            assert plan["result"]["return_value_error"] == ""
 
             plan_history, _ = await pq.get_history()
             plan_history_expected = add_status_to_plans(
@@ -2115,6 +2121,7 @@ def test_set_processed_item_as_completed_1():
             plan_history_expected = add_msg_to_plan_history(
                 plan_history_expected, [plan_uids[0]], "Test message", "Traceback"
             )
+            plan_history_expected[0]["result"]["return_value"] = {"value": 1}
             print(plan_history)
             print(plan_history_expected)
             check_plan_history(plan_history, plan_history_expected)
@@ -2135,6 +2142,8 @@ def test_set_processed_item_as_completed_1():
             assert plan["result"]["exit_status"] == "completed"
             assert plan["result"]["run_uids"] == plans_run_uids[1]
             assert plan["result"]["scan_ids"] == plans_scan_ids[1]
+            assert plan["result"]["return_value"] is None
+            assert plan["result"]["return_value_error"] == ""
 
             plan_history, _ = await pq.get_history()
             plan_history_expected = add_status_to_plans(
@@ -2213,6 +2222,8 @@ def test_set_processed_item_as_completed_2():
             assert plan["result"]["msg"] == ""
             assert plan["result"]["traceback"] == ""
             assert plan["result"]["time_stop"] > plan["result"]["time_start"]
+            assert plan["result"]["return_value"] is None
+            assert plan["result"]["return_value_error"] == ""
 
             # Execute the second plan
             await pq.set_next_item_as_running()
@@ -2236,6 +2247,8 @@ def test_set_processed_item_as_completed_2():
             assert plan["result"]["msg"] == "Unknown exit status"
             assert plan["result"]["traceback"] == "Some traceback"
             assert plan["result"]["time_stop"] > plan["result"]["time_start"]
+            assert plan["result"]["return_value"] is None
+            assert plan["result"]["return_value_error"] == ""
 
     asyncio.run(testing())
 
@@ -2274,6 +2287,8 @@ def test_set_processed_item_as_stopped_1():
             plan["result"]["scan_ids"] = scan_id
             plan["result"]["msg"] = ""
             plan["result"]["traceback"] = ""
+            plan["result"]["return_value"] = None
+            plan["result"]["return_value_error"] = ""
             plans_modified.append(plan)
         return plans_modified
 
@@ -2325,6 +2340,8 @@ def test_set_processed_item_as_stopped_1():
                 scan_ids=plans_scan_ids[0],
                 err_msg="Plan failed",
                 err_tb="Traceback",
+                return_value=None,
+                return_value_error="Test return value error",
             )
             assert pq.plan_queue_uid != pq_uid
             assert pq.plan_history_uid != ph_uid
@@ -2338,6 +2355,8 @@ def test_set_processed_item_as_stopped_1():
             assert plan["result"]["msg"] == "Plan failed"
             assert plan["result"]["traceback"] == "Traceback"
             assert plan["result"]["time_stop"] > plan["result"]["time_start"]
+            assert plan["result"]["return_value"] is None
+            assert plan["result"]["return_value_error"] == "Test return value error"
             assert plan["item_uid"] == plans[0]["item_uid"]
 
             # New plan UID is generated when the plan is pushed back into the queue
@@ -2353,6 +2372,7 @@ def test_set_processed_item_as_stopped_1():
             plan_history_expected = add_msg_to_plan_history(
                 plan_history_expected, [running_uid1], "Plan failed", "Traceback"
             )
+            plan_history_expected[0]["result"]["return_value_error"] = "Test return value error"
             check_plan_history(plan_history, plan_history_expected)
 
             # Execute the second plan
@@ -2375,6 +2395,8 @@ def test_set_processed_item_as_stopped_1():
             assert plan["result"]["msg"] == "Plan stopped"
             assert plan["result"]["traceback"] == "Traceback 2"
             assert plan["result"]["time_stop"] > plan["result"]["time_start"]
+            assert plan["result"]["return_value"] is None
+            assert plan["result"]["return_value_error"] == ""
 
             plan_history, _ = await pq.get_history()
             plan_history_expected = add_status_to_plans(
@@ -2482,6 +2504,8 @@ def test_set_processed_item_as_stopped_2(loop_mode, func, immediate_execution):
                 assert p["result"]["scan_ids"] == plan4_scan_ids
                 assert p["result"]["msg"] == err_msg
                 assert p["result"]["traceback"] == err_tb
+                assert p["result"]["return_value"] is None
+                assert p["result"]["return_value_error"] == ""
                 assert plan["result"]["time_stop"] > plan["result"]["time_start"]
 
             check_plan(plan)
@@ -2535,6 +2559,8 @@ def test_set_processed_item_as_stopped_3(loop_mode, func):
             # assert False, plan1
             assert plan1["name"] == plan["name"]
             assert "properties" not in plan1
+            assert plan1["result"]["return_value"] is None
+            assert plan1["result"]["return_value_error"] == ""
 
             assert pq.get_queue_size() == 0
             assert pq.get_history_size() == 1

--- a/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
+++ b/src/bluesky_queueserver/manager/tests/test_start_re_manager_cli.py
@@ -506,6 +506,7 @@ def _get_expected_settings_default_1(_1, _2):
         "startup_profile": startup_profile,
         "startup_script": None,
         "update_existing_plans_devices": "ENVIRONMENT_OPEN",
+        "capture_plan_return_values": False,
         "user_group_permissions_path": user_group_permissions_path,
         "user_group_permissions_reload": "ON_STARTUP",
         "zmq_control_addr": "tcp://*:60615",
@@ -559,6 +560,7 @@ operation:
   print_console_output: true
   console_logging_level: VERBOSE
   update_existing_plans_and_devices: ALWAYS
+  capture_plan_return_values: true
   user_group_permissions_reload: ON_REQUEST
   emergency_lock_key: different_lock_key
 """
@@ -613,6 +615,7 @@ def _get_expected_settings_config_2(file_dir, ip_con_dir):
         "startup_profile": startup_profile,
         "startup_script": None,
         "update_existing_plans_devices": "ALWAYS",
+        "capture_plan_return_values": True,
         "user_group_permissions_path": user_group_permissions_path,
         "user_group_permissions_reload": "ON_REQUEST",
         "zmq_control_addr": "tcp://*:60617",
@@ -711,6 +714,7 @@ def _get_expected_settings_params_3(file_dir, _):
         "startup_profile": startup_profile,
         "startup_script": None,
         "update_existing_plans_devices": "NEVER",
+        "capture_plan_return_values": True,
         "user_group_permissions_path": user_group_permissions_path,
         "user_group_permissions_reload": "NEVER",
         "zmq_control_addr": "tcp://*:60619",

--- a/src/bluesky_queueserver/manager/tests/test_zmq_api_base.py
+++ b/src/bluesky_queueserver/manager/tests/test_zmq_api_base.py
@@ -1302,6 +1302,8 @@ def test_zmq_api_queue_item_execute_1(re_manager):  # noqa: F811
     assert h_items[0]["name"] == _plan3["name"]
     assert h_items[1]["name"] == _plan1["name"]
 
+    assert "return_value" not in h_items[0]["result"]
+    assert "return_value_error" not in h_items[0]["result"]
     # Close the environment
     resp6, _ = zmq_request("environment_close")
     assert resp6["success"] is True, f"resp={resp6}"
@@ -1323,15 +1325,17 @@ def plan_return_rd():
 """
 
 
-def test_zmq_api_plan_return_values_1(re_manager_pc_copy):  # noqa: F811
+def test_zmq_api_plan_return_values_1(tmp_path, monkeypatch, re_manager_cmd):  # noqa: F811
     """
     Verify completed plan return values are persisted without blocking queue progression.
     """
-    _, pc_path = re_manager_pc_copy
+    pc_path = copy_default_profile_collection(tmp_path)
     re_config = "from bluesky import RunEngine\nRE = RunEngine({})\n"
     if "call_returns_result" in inspect.signature(RunEngine).parameters:
         re_config = "from bluesky import RunEngine\nRE = RunEngine({}, call_returns_result=True)\n"
     append_code_to_last_startup_file(pc_path, additional_code=re_config)
+    monkeypatch.setenv("QSERVER_CAPTURE_PLAN_RETURN_VALUES", "ON")
+    re_manager_cmd(["--startup-dir", pc_path])
 
     resp, _ = zmq_request("environment_open")
     assert resp["success"] is True, pprint.pformat(resp)
@@ -1392,10 +1396,13 @@ def plan_return_resume():
 """
 
 
-def test_zmq_api_plan_return_values_2_resume(re_manager):  # noqa: F811
+def test_zmq_api_plan_return_values_2_resume(monkeypatch, re_manager_cmd):  # noqa: F811
     """
     Verify a resumed plan retains its terminal return value.
     """
+    monkeypatch.setenv("QSERVER_CAPTURE_PLAN_RETURN_VALUES", "ON")
+    re_manager_cmd()
+
     resp, _ = zmq_request("environment_open")
     assert resp["success"] is True, pprint.pformat(resp)
     assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)

--- a/src/bluesky_queueserver/manager/tests/test_zmq_api_base.py
+++ b/src/bluesky_queueserver/manager/tests/test_zmq_api_base.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import glob
+import inspect
 import json
 import os
 import pprint
@@ -14,6 +15,7 @@ import numpy as np
 import pytest
 import yaml
 import zmq
+from bluesky import RunEngine
 
 import bluesky_queueserver
 from bluesky_queueserver import gen_list_of_plans_and_devices
@@ -1303,6 +1305,142 @@ def test_zmq_api_queue_item_execute_1(re_manager):  # noqa: F811
     # Close the environment
     resp6, _ = zmq_request("environment_close")
     assert resp6["success"] is True, f"resp={resp6}"
+    assert wait_for_condition(time=5, condition=condition_environment_closed)
+
+
+_script_plan_return_values_1 = """
+from bluesky import plan_stubs as bps
+
+
+def plan_return_object():
+    yield from bps.null()
+    return object()
+
+
+def plan_return_rd():
+    yield from bps.mv(motor, 5)
+    return (yield from bps.rd(motor))
+"""
+
+
+def test_zmq_api_plan_return_values_1(re_manager_pc_copy):  # noqa: F811
+    """
+    Verify completed plan return values are persisted without blocking queue progression.
+    """
+    _, pc_path = re_manager_pc_copy
+    re_config = "from bluesky import RunEngine\nRE = RunEngine({})\n"
+    if "call_returns_result" in inspect.signature(RunEngine).parameters:
+        re_config = "from bluesky import RunEngine\nRE = RunEngine({}, call_returns_result=True)\n"
+    append_code_to_last_startup_file(pc_path, additional_code=re_config)
+
+    resp, _ = zmq_request("environment_open")
+    assert resp["success"] is True, pprint.pformat(resp)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    resp, _ = zmq_request("script_upload", params={"script": _script_plan_return_values_1, "update_lists": True})
+    assert resp["success"] is True, pprint.pformat(resp)
+    script_result = wait_for_task_result(10, resp["task_uid"])
+    assert script_result["success"] is True, pprint.pformat(script_result)
+    assert wait_for_condition(time=5, condition=condition_manager_idle)
+
+    item_uids = []
+    for plan_name in ("plan_return_object", "plan_return_rd"):
+        resp, _ = zmq_request(
+            "queue_item_add",
+            params={"item": {"item_type": "plan", "name": plan_name}, "user": _user, "user_group": _user_group},
+        )
+        assert resp["success"] is True, pprint.pformat(resp)
+        item_uids.append(resp["item"]["item_uid"])
+    item_uid_object, item_uid_rd = item_uids
+
+    status_before, _ = zmq_request("status")
+    plan_history_uid = status_before["plan_history_uid"]
+    resp, _ = zmq_request("queue_start")
+    assert resp["success"] is True, pprint.pformat(resp)
+    assert wait_for_condition(time=20, condition=condition_manager_idle)
+
+    status, _ = zmq_request("status")
+    assert status["items_in_queue"] == 0
+    assert status["items_in_history"] == 2
+    assert status["plan_history_uid"] != plan_history_uid
+
+    history, _ = zmq_request("history_get")
+    assert history["success"] is True, pprint.pformat(history)
+    history_by_uid = {item["item_uid"]: item for item in history["items"]}
+    object_result = history_by_uid[item_uid_object]["result"]
+    rd_result = history_by_uid[item_uid_rd]["result"]
+
+    assert object_result["exit_status"] == "completed"
+    assert object_result["return_value"] is None
+    assert object_result["return_value_error"].startswith("Plan return value can not be serialized as JSON:")
+    assert rd_result["exit_status"] == "completed"
+    assert rd_result["return_value"] == 5
+    assert rd_result["return_value_error"] == ""
+
+    resp, _ = zmq_request("environment_close")
+    assert resp["success"] is True, pprint.pformat(resp)
+    assert wait_for_condition(time=5, condition=condition_environment_closed)
+
+
+_script_plan_return_values_2 = """
+from bluesky.plans import count
+
+
+def plan_return_resume():
+    yield from count([det1], num=3, delay=2)
+    return "resumed"
+"""
+
+
+def test_zmq_api_plan_return_values_2_resume(re_manager):  # noqa: F811
+    """
+    Verify a resumed plan retains its terminal return value.
+    """
+    resp, _ = zmq_request("environment_open")
+    assert resp["success"] is True, pprint.pformat(resp)
+    assert wait_for_condition(time=timeout_env_open, condition=condition_environment_created)
+
+    resp, _ = zmq_request("script_upload", params={"script": _script_plan_return_values_2, "update_lists": True})
+    assert resp["success"] is True, pprint.pformat(resp)
+    script_result = wait_for_task_result(10, resp["task_uid"])
+    assert script_result["success"] is True, pprint.pformat(script_result)
+    assert wait_for_condition(time=5, condition=condition_manager_idle)
+
+    params = {
+        "item": {"item_type": "plan", "name": "plan_return_resume"},
+        "user": _user,
+        "user_group": _user_group,
+    }
+    resp, _ = zmq_request("queue_item_add", params=params)
+    assert resp["success"] is True, pprint.pformat(resp)
+    item_uid = resp["item"]["item_uid"]
+
+    resp, _ = zmq_request("queue_start")
+    assert resp["success"] is True, pprint.pformat(resp)
+    ttime.sleep(3)
+
+    resp, _ = zmq_request("re_pause")
+    assert resp["success"] is True, pprint.pformat(resp)
+    assert wait_for_condition(time=20, condition=condition_manager_paused)
+
+    resp, _ = zmq_request("re_resume")
+    assert resp["success"] is True, pprint.pformat(resp)
+    assert wait_for_condition(time=30, condition=condition_manager_idle)
+
+    status, _ = zmq_request("status")
+    assert status["items_in_queue"] == 0
+    assert status["items_in_history"] == 1
+
+    history, _ = zmq_request("history_get")
+    assert history["success"] is True, pprint.pformat(history)
+    history_by_uid = {item["item_uid"]: item for item in history["items"]}
+    result = history_by_uid[item_uid]["result"]
+    assert result["exit_status"] == "completed"
+    assert result["return_value"] == "resumed"
+    assert result["return_value_error"] == ""
+
+    resp, _ = zmq_request("environment_close")
+    assert resp["success"] is True, pprint.pformat(resp)
     assert wait_for_condition(time=5, condition=condition_environment_closed)
 
 

--- a/src/bluesky_queueserver/manager/worker.py
+++ b/src/bluesky_queueserver/manager/worker.py
@@ -135,6 +135,8 @@ class RunEngineWorker(Process):
 
         # Reference to Bluesky Run Engine
         self._RE = None
+        # Terminal value returned by the currently executing top-level plan.
+        self._plan_return_value = None
 
         # The following variable determine the state of RE Worker
         self._env_state = EState.CLOSED
@@ -322,15 +324,24 @@ class RunEngineWorker(Process):
             th.start()
             # -------------------------------------------------------------------------------------------
 
-            result = func()
+            func()
 
             uids, scan_ids = self._active_run_list.get_uids(), self._active_run_list.get_scan_ids()
+
+            return_value = None
+            return_value_error = ""
+            if exec_option in (ExecOption.NEW, ExecOption.RESUME):
+                try:
+                    return_value = json.loads(json.dumps(self._plan_return_value))
+                except Exception as ex:
+                    return_value_error = f"Plan return value can not be serialized as JSON: {ex}"
 
             with self._re_report_lock:
                 self._re_report = {
                     "action": "plan_exit",
                     "success": True,
-                    "result": result,
+                    "return_value": return_value,
+                    "return_value_error": return_value_error,
                     "uids": uids,
                     "scan_ids": scan_ids,
                     "err_msg": "",
@@ -362,7 +373,8 @@ class RunEngineWorker(Process):
                     "action": "plan_exit",
                     "uids": uids,
                     "scan_ids": scan_ids,
-                    "result": "",
+                    "return_value": None,
+                    "return_value_error": "",
                     "traceback": traceback.format_exc(),
                     "stop_queue": False,  # True - request manager not to start the next plan
                 }
@@ -419,7 +431,8 @@ class RunEngineWorker(Process):
                 "action": "plan_exit",
                 "success": plan_state == "success",
                 "plan_state": plan_state,
-                "result": tuple(uids),  # List of UIDs
+                "return_value": None,
+                "return_value_error": "",
                 "uids": uids,
                 "scan_ids": scan_ids,
                 "err_msg": "The plan is completed outside RE Manager",  # List of UIDs
@@ -483,6 +496,7 @@ class RunEngineWorker(Process):
         Generate the function that starts execution of a plan based on plan parameters.
         """
         plan_info = parameters
+        self._plan_return_value = None
 
         try:
             with self._allowed_items_lock:
@@ -512,7 +526,10 @@ class RunEngineWorker(Process):
 
             def get_start_plan_func(plan_func, plan_args, plan_kwargs, plan_meta):
                 def start_plan_func():
-                    return self._RE(plan_func(*plan_args, **plan_kwargs), {"all": [self._run_reg_cb]}, **plan_meta)
+                    def plan_with_return_value():
+                        self._plan_return_value = yield from plan_func(*plan_args, **plan_kwargs)
+
+                    return self._RE(plan_with_return_value(), {"all": [self._run_reg_cb]}, **plan_meta)
 
                 return start_plan_func
 

--- a/src/bluesky_queueserver/manager/worker.py
+++ b/src/bluesky_queueserver/manager/worker.py
@@ -160,6 +160,7 @@ class RunEngineWorker(Process):
         # Note: 'self._config' is a private attribute of 'multiprocessing.Process'. Overriding
         #   this variable may lead to unpredictable and hard to debug issues.
         self._config_dict = config or {}
+        self._capture_plan_return_values = self._config_dict["capture_plan_return_values"]
         self._existing_plans_and_devices_changed = False
         self._existing_plans, self._existing_devices = {}, {}
         self._allowed_plans, self._allowed_devices = {}, {}
@@ -330,7 +331,7 @@ class RunEngineWorker(Process):
 
             return_value = None
             return_value_error = ""
-            if exec_option in (ExecOption.NEW, ExecOption.RESUME):
+            if self._capture_plan_return_values and exec_option in (ExecOption.NEW, ExecOption.RESUME):
                 try:
                     return_value = json.loads(json.dumps(self._plan_return_value))
                 except Exception as ex:
@@ -340,14 +341,15 @@ class RunEngineWorker(Process):
                 self._re_report = {
                     "action": "plan_exit",
                     "success": True,
-                    "return_value": return_value,
-                    "return_value_error": return_value_error,
                     "uids": uids,
                     "scan_ids": scan_ids,
                     "err_msg": "",
                     "traceback": "",
                     "stop_queue": False,  # True - request manager not to start the next plan
                 }
+                if self._capture_plan_return_values:
+                    self._re_report["return_value"] = return_value
+                    self._re_report["return_value_error"] = return_value_error
                 if exec_option in (ExecOption.NEW, ExecOption.RESUME):
                     self._re_report["plan_state"] = "completed"
                     self._running_plan_exec_state = PlanExecState.COMPLETED
@@ -373,11 +375,12 @@ class RunEngineWorker(Process):
                     "action": "plan_exit",
                     "uids": uids,
                     "scan_ids": scan_ids,
-                    "return_value": None,
-                    "return_value_error": "",
                     "traceback": traceback.format_exc(),
                     "stop_queue": False,  # True - request manager not to start the next plan
                 }
+                if self._capture_plan_return_values:
+                    self._re_report["return_value"] = None
+                    self._re_report["return_value_error"] = ""
 
                 if self.re_state == "paused":
                     # Run Engine was paused
@@ -431,8 +434,6 @@ class RunEngineWorker(Process):
                 "action": "plan_exit",
                 "success": plan_state == "success",
                 "plan_state": plan_state,
-                "return_value": None,
-                "return_value_error": "",
                 "uids": uids,
                 "scan_ids": scan_ids,
                 "err_msg": "The plan is completed outside RE Manager",  # List of UIDs
@@ -440,6 +441,9 @@ class RunEngineWorker(Process):
                 "stop_queue": True,  # True - request manager not to start the next plan
                 "re_state": self.re_state,
             }
+            if self._capture_plan_return_values:
+                self._re_report["return_value"] = None
+                self._re_report["return_value_error"] = ""
 
         self._running_plan_exec_state = PlanExecState.COMPLETED
         self._active_run_list.clear()
@@ -526,10 +530,15 @@ class RunEngineWorker(Process):
 
             def get_start_plan_func(plan_func, plan_args, plan_kwargs, plan_meta):
                 def start_plan_func():
-                    def plan_with_return_value():
-                        self._plan_return_value = yield from plan_func(*plan_args, **plan_kwargs)
+                    if self._capture_plan_return_values:
 
-                    return self._RE(plan_with_return_value(), {"all": [self._run_reg_cb]}, **plan_meta)
+                        def plan_with_return_value():
+                            self._plan_return_value = yield from plan_func(*plan_args, **plan_kwargs)
+
+                        plan = plan_with_return_value()
+                    else:
+                        plan = plan_func(*plan_args, **plan_kwargs)
+                    return self._RE(plan, {"all": [self._run_reg_cb]}, **plan_meta)
 
                 return start_plan_func
 

--- a/src/bluesky_queueserver/manager/worker.py
+++ b/src/bluesky_queueserver/manager/worker.py
@@ -160,7 +160,6 @@ class RunEngineWorker(Process):
         # Note: 'self._config' is a private attribute of 'multiprocessing.Process'. Overriding
         #   this variable may lead to unpredictable and hard to debug issues.
         self._config_dict = config or {}
-        self._capture_plan_return_values = self._config_dict["capture_plan_return_values"]
         self._existing_plans_and_devices_changed = False
         self._existing_plans, self._existing_devices = {}, {}
         self._allowed_plans, self._allowed_devices = {}, {}
@@ -331,7 +330,10 @@ class RunEngineWorker(Process):
 
             return_value = None
             return_value_error = ""
-            if self._capture_plan_return_values and exec_option in (ExecOption.NEW, ExecOption.RESUME):
+            if self._config_dict["capture_plan_return_values"] and exec_option in (
+                ExecOption.NEW,
+                ExecOption.RESUME,
+            ):
                 try:
                     return_value = json.loads(json.dumps(self._plan_return_value))
                 except Exception as ex:
@@ -347,7 +349,7 @@ class RunEngineWorker(Process):
                     "traceback": "",
                     "stop_queue": False,  # True - request manager not to start the next plan
                 }
-                if self._capture_plan_return_values:
+                if self._config_dict["capture_plan_return_values"]:
                     self._re_report["return_value"] = return_value
                     self._re_report["return_value_error"] = return_value_error
                 if exec_option in (ExecOption.NEW, ExecOption.RESUME):
@@ -378,7 +380,7 @@ class RunEngineWorker(Process):
                     "traceback": traceback.format_exc(),
                     "stop_queue": False,  # True - request manager not to start the next plan
                 }
-                if self._capture_plan_return_values:
+                if self._config_dict["capture_plan_return_values"]:
                     self._re_report["return_value"] = None
                     self._re_report["return_value_error"] = ""
 
@@ -441,7 +443,7 @@ class RunEngineWorker(Process):
                 "stop_queue": True,  # True - request manager not to start the next plan
                 "re_state": self.re_state,
             }
-            if self._capture_plan_return_values:
+            if self._config_dict["capture_plan_return_values"]:
                 self._re_report["return_value"] = None
                 self._re_report["return_value_error"] = ""
 
@@ -530,7 +532,7 @@ class RunEngineWorker(Process):
 
             def get_start_plan_func(plan_func, plan_args, plan_kwargs, plan_meta):
                 def start_plan_func():
-                    if self._capture_plan_return_values:
+                    if self._config_dict["capture_plan_return_values"]:
 
                         def plan_with_return_value():
                             self._plan_return_value = yield from plan_func(*plan_args, **plan_kwargs)


### PR DESCRIPTION
Assisted-by: oh-my-pi:gpt-5.6-terra

<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds functionality to capture the plan return and attempt to attach it to the queue item's result. If the return value is not JSON serializable, then we replace it with none and give an error instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Related to #300, not sure if it closes it.

I would like there to be a simple way to put a plan like `bps.rd` in the queue and inspect its result without having to use `bp.count` instead. Often I just want to know the current state of a signal without the overhead of opening a run -> staging -> reading -> saving -> unstaging -> closing a run and all of the callbacks involved with that.

Capturing the real return value of the plan and storing it in the queue item solves this problem.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Return value of plans are captured and put in the queue item, queryable from the queue history.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added checks to existing unit tests and wrote new ones using the zmq api.

<!--
## Screenshots (if appropriate):
-->
